### PR TITLE
fix: P0 빌드 타입 에러 + matchMedia 테스트 mock (#1, #2)

### DIFF
--- a/src/stores/eventTagStore.ts
+++ b/src/stores/eventTagStore.ts
@@ -44,7 +44,7 @@ export const useEventTagStore = create<EventTagState>((set, get) => ({
     if (!existing) throw new Error('Tag not found')
     const tag = await eventTagApi.updateTag(id, {
       name: updates.name ?? existing.name,
-      color_hex: updates.color_hex ?? existing.color_hex,
+      color_hex: updates.color_hex ?? existing.color_hex ?? undefined,
     })
     set(s => { const tags = new Map(s.tags); tags.set(tag.uuid, tag); return { tags } })
     return tag

--- a/tests/components/AuthGuard.test.tsx
+++ b/tests/components/AuthGuard.test.tsx
@@ -5,6 +5,8 @@ import { AuthGuard } from '../../src/components/AuthGuard'
 import { useAuthStore } from '../../src/stores/authStore'
 import { useToastStore } from '../../src/stores/toastStore'
 
+vi.mock('../../src/firebase', () => ({ auth: {} }))
+
 vi.mock('../../src/stores/authStore', () => ({
   useAuthStore: vi.fn(),
 }))

--- a/tests/pages/SettingsPage.test.tsx
+++ b/tests/pages/SettingsPage.test.tsx
@@ -8,6 +8,8 @@ import { accountApi } from '../../src/api/accountApi'
 import { useAuthStore } from '../../src/stores/authStore'
 import { useToastStore } from '../../src/stores/toastStore'
 
+vi.mock('../../src/firebase', () => ({ auth: {} }))
+
 vi.mock('../../src/api/settingApi', () => ({
   settingApi: {
     getDefaultTagColors: vi.fn(),

--- a/tests/pages/TagManagementPage.test.tsx
+++ b/tests/pages/TagManagementPage.test.tsx
@@ -5,6 +5,8 @@ import { MemoryRouter } from 'react-router-dom'
 import { TagManagementPage } from '../../src/pages/TagManagementPage'
 import { useToastStore } from '../../src/stores/toastStore'
 
+vi.mock('../../src/firebase', () => ({ auth: {} }))
+
 vi.mock('../../src/api/eventTagApi', () => ({
   eventTagApi: {
     getAllTags: vi.fn().mockResolvedValue([]),

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,2 +1,16 @@
 import '@testing-library/jest-dom'
 import '../src/i18n'
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})

--- a/tests/stores/eventTagStore.test.ts
+++ b/tests/stores/eventTagStore.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useEventTagStore } from '../../src/stores/eventTagStore'
 
+vi.mock('../../src/firebase', () => ({ auth: {} }))
+
 vi.mock('../../src/api/eventTagApi', () => ({
   eventTagApi: {
     getAllTags: vi.fn(),


### PR DESCRIPTION
## Summary

- closes #1: `eventTagStore.ts` line 47에서 `color_hex` 타입 불일치 수정 — `null | undefined` → `?? undefined`로 `string | undefined`로 좁힘
- closes #2: `tests/setup.ts`에 `window.matchMedia` 전역 mock 추가 — jsdom 환경에서 `themeStore.ts` 임포트 시 발생하던 `TypeError` 해결
- 추가: 4개 테스트 파일에 `vi.mock('../../src/firebase', ...)` 추가 — `.env.local` 없는 환경에서 `auth/invalid-api-key` 오류로 실패하던 5번째 파일 포함

## Test plan

- [ ] `npm run build` — TypeScript 컴파일 오류 없음 확인
- [ ] `npm test` — 40개 파일 / 254개 테스트 전부 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)