### PR TITLE
test(e2e): P1 나머지 + P2/P3 E2E 스펙 추가

### DIFF
--- a/e2e/specs/p1-event-detail.spec.ts
+++ b/e2e/specs/p1-event-detail.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test'
+import { setupAuthContext } from '../helpers/auth'
+
+test.beforeEach(async ({ context }) => {
+  await setupAuthContext(context)
+})
+
+const TODO_FIXTURE = {
+  uuid: 'test-id',
+  name: 'E2E 테스트 할 일',
+  is_current: true,
+  event_time: { time_type: 'at', timestamp: 1744290000 },
+}
+
+const SCHEDULE_FIXTURE = {
+  uuid: 'test-id',
+  name: 'E2E 테스트 일정',
+  event_time: { time_type: 'at', timestamp: 1744290000 },
+}
+
+function mockTodoApi(page: Parameters<Parameters<typeof test>[1]>[0]) {
+  return page.route('**/v1/todos/todo/test-id', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(TODO_FIXTURE),
+    })
+  })
+}
+
+function mockScheduleApi(page: Parameters<Parameters<typeof test>[1]>[0]) {
+  return page.route('**/v1/schedules/schedule/test-id', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(SCHEDULE_FIXTURE),
+    })
+  })
+}
+
+test('Todo 이벤트 상세 페이지에 이벤트 이름이 표시된다', async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+  await mockTodoApi(page)
+
+  // when
+  await page.goto('/events/test-id?type=todo')
+  await expect(page.getByRole('heading', { name: 'E2E 테스트 할 일' })).toBeVisible()
+})
+
+test('Todo 이벤트 상세 페이지에 편집 버튼이 표시된다', async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+  await mockTodoApi(page)
+
+  // when
+  await page.goto('/events/test-id?type=todo')
+  await expect(page.getByRole('heading', { name: 'E2E 테스트 할 일' })).toBeVisible()
+
+  // then
+  await expect(page.getByRole('button', { name: '편집' }).first()).toBeVisible()
+})
+
+test('Todo 이벤트 상세 페이지에 핀/언핀 버튼이 표시된다', async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+  await mockTodoApi(page)
+
+  // when
+  await page.goto('/events/test-id?type=todo')
+  await expect(page.getByRole('heading', { name: 'E2E 테스트 할 일' })).toBeVisible()
+
+  // then — "고정 설정" 또는 "고정 해제" 버튼이 표시된다
+  const pinButton = page.getByRole('button', { name: /고정/ })
+  await expect(pinButton).toBeVisible()
+})
+
+test('뒤로 버튼을 누르면 이전 페이지로 돌아간다', async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+  await mockTodoApi(page)
+  await page.goto('/events/test-id?type=todo')
+  await expect(page.getByRole('heading', { name: 'E2E 테스트 할 일' })).toBeVisible()
+
+  // when
+  await page.getByRole('button', { name: /← 뒤로/ }).click()
+
+  // then
+  await expect(page).not.toHaveURL(/\/events\/test-id/)
+})
+
+test('Schedule 이벤트 상세 페이지에 이벤트 이름이 표시된다', async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+  await mockScheduleApi(page)
+
+  // when
+  await page.goto('/events/test-id?type=schedule')
+
+  // then
+  await expect(page.getByRole('heading', { name: 'E2E 테스트 일정' })).toBeVisible()
+})
+
+test('Schedule 이벤트 상세 페이지에 편집 버튼이 표시된다', async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+  await mockScheduleApi(page)
+
+  // when
+  await page.goto('/events/test-id?type=schedule')
+  await expect(page.getByRole('heading', { name: 'E2E 테스트 일정' })).toBeVisible()
+
+  // then
+  await expect(page.getByRole('button', { name: '편집' }).first()).toBeVisible()
+})

--- a/e2e/specs/p1-schedule-crud.spec.ts
+++ b/e2e/specs/p1-schedule-crud.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test'
+import { setupAuthContext } from '../helpers/auth'
+
+test.beforeEach(async ({ context }) => {
+  await setupAuthContext(context)
+})
+
+test('/schedules/new 진입 시 "새 Schedule" 제목이 표시된다', async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // when
+  await page.goto('/schedules/new')
+
+  // then
+  await expect(page.getByRole('heading', { name: '새 Schedule' })).toBeVisible()
+})
+
+test('새 Schedule 폼에 이름 입력, 저장/취소 버튼이 표시된다', async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // when
+  await page.goto('/schedules/new')
+
+  // then
+  await expect(page.getByLabel('이름')).toBeVisible()
+  await expect(page.getByRole('button', { name: '저장' })).toBeVisible()
+  await expect(page.getByRole('button', { name: '취소' })).toBeVisible()
+})
+
+test('새 Schedule 폼에 EventTimePicker(시간 선택)가 표시된다', async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // when
+  await page.goto('/schedules/new')
+
+  // then — Schedule은 required=true이므로 "시간 없음" 옵션 없이 "특정 시각" 라디오가 기본 선택됨
+  await expect(page.getByText('특정 시각')).toBeVisible()
+  // 날짜/시각 datetime-local 입력 필드가 존재한다
+  await expect(page.getByRole('textbox', { name: '시각' })).toBeVisible()
+})
+
+test('이름을 입력하고 저장하면 이전 페이지로 돌아간다', async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  await page.route('**/v1/schedules/schedule', async route => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          uuid: 'new-schedule-id',
+          name: 'E2E 테스트 일정',
+          event_time: { time_type: 'at', timestamp: Math.floor(Date.now() / 1000) },
+        }),
+      })
+    } else {
+      await route.continue()
+    }
+  })
+
+  await page.goto('/schedules/new')
+  await expect(page.getByLabel('이름')).toBeVisible()
+
+  // when
+  await page.getByLabel('이름').fill('E2E 테스트 일정')
+  await page.getByRole('button', { name: '저장' }).click()
+
+  // then — 저장 후 폼 페이지를 벗어난다
+  await expect(page).not.toHaveURL('/schedules/new')
+})
+
+test('이름 없이 저장하면 폼이 그대로 유지된다', async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+  await page.goto('/schedules/new')
+
+  // when — 이름을 입력하지 않고 저장
+  await page.getByRole('button', { name: '저장' }).click()
+
+  // then — 폼이 떠있어야 한다
+  await expect(page).toHaveURL(/\/schedules\/new/)
+  await expect(page.getByRole('heading', { name: '새 Schedule' })).toBeVisible()
+})
+
+test('취소 버튼을 누르면 이전 페이지로 돌아간다', async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+  await page.goto('/schedules/new')
+
+  // when
+  await page.getByRole('button', { name: '취소' }).click()
+
+  // then
+  await expect(page).not.toHaveURL('/schedules/new')
+})

--- a/e2e/specs/p2-keyboard.spec.ts
+++ b/e2e/specs/p2-keyboard.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test'
+import { setupAuthContext } from '../helpers/auth'
+
+test.beforeEach(async ({ context }) => {
+  await setupAuthContext(context)
+})
+
+test("메인 페이지에서 'n' 키를 누르면 새 Todo 폼 오버레이가 열린다", async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // when — body에 포커스 후 'n' 키 입력
+  await page.locator('body').press('n')
+
+  // then — URL이 /todos/new로 변경되고 오버레이가 열린다
+  await expect(page).toHaveURL(/\/todos\/new/)
+  await expect(page.getByRole('heading', { name: '새 Todo' })).toBeVisible()
+})
+
+test("새 Todo 오버레이가 열린 상태에서 취소 버튼을 누르면 메인 페이지로 돌아간다", async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+  await page.locator('body').press('n')
+  await expect(page).toHaveURL(/\/todos\/new/)
+  await expect(page.getByRole('heading', { name: '새 Todo' })).toBeVisible()
+
+  // when — 취소 버튼 클릭
+  await page.getByRole('button', { name: '취소' }).click()
+
+  // then — 오버레이가 닫히고 이전 페이지로 돌아간다
+  await expect(page).not.toHaveURL(/\/todos\/new/)
+})
+
+test("입력 필드에 포커스 시 'n' 키는 폼 열기를 트리거하지 않는다", async ({ page }) => {
+  // given — 새 Todo 폼 오버레이를 직접 열어서 이름 입력 필드에 포커스
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+  await page.goto('/todos/new')
+  await expect(page.getByLabel('이름')).toBeVisible()
+
+  // when — 이름 입력 필드에 'n' 키 입력
+  await page.getByLabel('이름').press('n')
+
+  // then — 여전히 /todos/new 상태 (중첩 폼이 열리지 않는다)
+  await expect(page).toHaveURL(/\/todos\/new/)
+  await expect(page.getByRole('heading', { name: '새 Todo' })).toBeVisible()
+})

--- a/e2e/specs/p2-overlay.spec.ts
+++ b/e2e/specs/p2-overlay.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test'
+import { setupAuthContext } from '../helpers/auth'
+
+test.beforeEach(async ({ context }) => {
+  await setupAuthContext(context)
+})
+
+test("'n' 키로 /todos/new 오버레이를 열면 배경에 메인 페이지 캘린더가 유지된다", async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // when — 키보드로 오버레이 열기 (background state 포함)
+  await page.locator('body').press('n')
+  await expect(page).toHaveURL(/\/todos\/new/)
+
+  // then — 오버레이 폼이 표시된다
+  await expect(page.getByRole('heading', { name: '새 Todo' })).toBeVisible()
+  // 배경 메인 페이지의 캘린더가 여전히 보인다
+  await expect(page.getByTestId('day-cell').first()).toBeVisible()
+})
+
+test("FAB 클릭 후 Todo 선택 시 배경에 메인 페이지 캘린더가 유지된다", async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // when — FAB 클릭 후 Todo 선택
+  await page.getByRole('button', { name: '새 이벤트 추가' }).click()
+  await expect(page.getByRole('button', { name: 'Todo' })).toBeVisible()
+  await page.getByRole('button', { name: 'Todo' }).click()
+
+  // then — /todos/new 오버레이가 열린다
+  await expect(page).toHaveURL(/\/todos\/new/)
+  await expect(page.getByRole('heading', { name: '새 Todo' })).toBeVisible()
+  // 배경에 캘린더가 여전히 렌더되어 있다
+  await expect(page.getByTestId('day-cell').first()).toBeVisible()
+})
+
+test("FAB 클릭 후 Schedule 선택 시 배경에 메인 페이지 캘린더가 유지된다", async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // when — FAB 클릭 후 Schedule 선택
+  await page.getByRole('button', { name: '새 이벤트 추가' }).click()
+  await expect(page.getByRole('button', { name: 'Schedule' })).toBeVisible()
+  await page.getByRole('button', { name: 'Schedule' }).click()
+
+  // then — /schedules/new 오버레이가 열린다
+  await expect(page).toHaveURL(/\/schedules\/new/)
+  await expect(page.getByRole('heading', { name: '새 Schedule' })).toBeVisible()
+  // 배경에 캘린더가 여전히 렌더되어 있다
+  await expect(page.getByTestId('day-cell').first()).toBeVisible()
+})

--- a/e2e/specs/p3-404.spec.ts
+++ b/e2e/specs/p3-404.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test'
+import { setupAuthContext } from '../helpers/auth'
+
+test.beforeEach(async ({ context }) => {
+  await setupAuthContext(context)
+})
+
+test('존재하지 않는 경로로 이동 시 404 텍스트가 표시된다', async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // when
+  await page.goto('/nonexistent-page')
+
+  // then
+  await expect(page.getByRole('heading', { name: '404' })).toBeVisible()
+})
+
+test('404 페이지에서 홈으로 가기 링크가 표시된다', async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // when
+  await page.goto('/nonexistent-page')
+  await expect(page.getByRole('heading', { name: '404' })).toBeVisible()
+
+  // then — "홈으로 돌아가기" 링크가 표시된다
+  await expect(page.getByRole('link', { name: '홈으로 돌아가기' })).toBeVisible()
+})
+
+test('홈으로 가기 링크 클릭 시 루트 경로로 이동한다', async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+  await page.goto('/nonexistent-page')
+  await expect(page.getByRole('heading', { name: '404' })).toBeVisible()
+
+  // when
+  await page.getByRole('link', { name: '홈으로 돌아가기' }).click()
+
+  // then
+  await expect(page).toHaveURL('/')
+})
+
+test('404 페이지에서 "페이지를 찾을 수 없습니다" 메시지가 표시된다', async ({ page }) => {
+  // given
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // when
+  await page.goto('/nonexistent-page')
+
+  // then
+  await expect(page.getByText('페이지를 찾을 수 없습니다')).toBeVisible()
+})

--- a/e2e/specs/p3-i18n-gaps.spec.ts
+++ b/e2e/specs/p3-i18n-gaps.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * P3 i18n gaps spec
+ *
+ * 이 스펙은 영어 모드에서 한국어가 여전히 노출되는 알려진 i18n 미적용 구간을 검증한다.
+ * TodoFormPage, ScheduleFormPage, EventTimePicker 컴포넌트의 레이블/버튼이
+ * i18n 키 대신 하드코딩된 한국어 문자열을 사용하고 있어 FAIL이 예상된다.
+ */
+import { test, expect } from '@playwright/test'
+import { setupAuthContext } from '../helpers/auth'
+
+test.beforeEach(async ({ context }) => {
+  await setupAuthContext(context)
+})
+
+async function setEnglishLanguage(page: Parameters<Parameters<typeof test>[1]>[0]) {
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+  // i18n은 localStorage의 'language' 키로 언어를 결정한다
+  await page.evaluate(() => localStorage.setItem('language', 'en'))
+}
+
+// --- TodoFormPage i18n gaps ---
+
+test('[KNOWN FAIL] 영어 모드에서 /todos/new에 한국어 "이름" 레이블이 남아있다', async ({ page }) => {
+  // given — 영어 모드 설정
+  await setEnglishLanguage(page)
+
+  // when
+  await page.goto('/todos/new')
+  await page.waitForLoadState('networkidle')
+
+  // then — 한국어 "이름"이 보이지 않아야 한다 (현재는 보임 → FAIL)
+  await expect(page.getByText('이름')).not.toBeVisible()
+})
+
+test('[KNOWN FAIL] 영어 모드에서 /todos/new에 한국어 "저장" 버튼이 남아있다', async ({ page }) => {
+  // given
+  await setEnglishLanguage(page)
+
+  // when
+  await page.goto('/todos/new')
+  await page.waitForLoadState('networkidle')
+
+  // then — 한국어 "저장"이 보이지 않아야 한다 (현재는 보임 → FAIL)
+  await expect(page.getByRole('button', { name: '저장' })).not.toBeVisible()
+})
+
+test('[KNOWN FAIL] 영어 모드에서 /todos/new에 한국어 "취소" 버튼이 남아있다', async ({ page }) => {
+  // given
+  await setEnglishLanguage(page)
+
+  // when
+  await page.goto('/todos/new')
+  await page.waitForLoadState('networkidle')
+
+  // then — 한국어 "취소"가 보이지 않아야 한다 (현재는 보임 → FAIL)
+  await expect(page.getByRole('button', { name: '취소' })).not.toBeVisible()
+})
+
+// --- EventTimePicker i18n gaps ---
+
+test('[KNOWN FAIL] 영어 모드에서 EventTimePicker에 한국어 "시간 없음" 옵션이 남아있다', async ({ page }) => {
+  // given
+  await setEnglishLanguage(page)
+
+  // when
+  await page.goto('/todos/new')
+  await page.waitForLoadState('networkidle')
+
+  // then — 한국어 "시간 없음"이 보이지 않아야 한다 (현재는 보임 → FAIL)
+  await expect(page.getByText('시간 없음')).not.toBeVisible()
+})
+
+test('[KNOWN FAIL] 영어 모드에서 EventTimePicker에 한국어 "특정 시각" 옵션이 남아있다', async ({ page }) => {
+  // given
+  await setEnglishLanguage(page)
+
+  // when
+  await page.goto('/todos/new')
+  await page.waitForLoadState('networkidle')
+
+  // then — 한국어 "특정 시각"이 보이지 않아야 한다 (현재는 보임 → FAIL)
+  await expect(page.getByText('특정 시각')).not.toBeVisible()
+})
+
+// --- ScheduleFormPage i18n gaps ---
+
+test('[KNOWN FAIL] 영어 모드에서 /schedules/new에 한국어 "이름" 레이블이 남아있다', async ({ page }) => {
+  // given
+  await setEnglishLanguage(page)
+
+  // when
+  await page.goto('/schedules/new')
+  await page.waitForLoadState('networkidle')
+
+  // then — 한국어 "이름"이 보이지 않아야 한다 (현재는 보임 → FAIL)
+  await expect(page.getByText('이름')).not.toBeVisible()
+})


### PR DESCRIPTION
## Summary

- **P1**: Schedule CRUD 스펙 (`p1-schedule-crud.spec.ts`) — 새 폼 렌더, 이름/저장/취소 버튼, EventTimePicker 필수, 저장/취소 동작
- **P1**: EventDetail 스펙 (`p1-event-detail.spec.ts`) — Todo/Schedule 이벤트 이름, 편집 버튼, 핀/언핀 버튼, 뒤로가기
- **P2**: 키보드 단축키 스펙 (`p2-keyboard.spec.ts`) — `n` 키로 새 Todo 오버레이 열기, 취소 버튼으로 닫기, 입력 필드 포커스 시 단축키 무시
- **P2**: 오버레이 배경 유지 스펙 (`p2-overlay.spec.ts`) — FAB + Todo/Schedule 선택 시, `n` 키 사용 시 배경 캘린더 유지
- **P3**: i18n 미적용 갭 스펙 (`p3-i18n-gaps.spec.ts`) — 영어 모드에서도 TodoFormPage/ScheduleFormPage/EventTimePicker에 한국어 텍스트가 남아있는 알려진 갭 6건 (KNOWN FAIL)
- **P3**: 404 스펙 (`p3-404.spec.ts`) — 존재하지 않는 경로, 404 텍스트, 홈으로 가기 링크

## Test Results

| 구분 | 수 | 상태 |
|------|-----|------|
| P1 schedule-crud | 6 | ✅ pass |
| P1 event-detail | 6 | ✅ pass |
| P2 keyboard | 3 | ✅ pass |
| P2 overlay | 3 | ✅ pass |
| P3 404 | 4 | ✅ pass |
| P3 i18n-gaps | 6 | ❌ KNOWN FAIL (i18n 미적용 갭 문서화) |
| **전체 신규** | **28** | **22 pass / 6 known fail** |
| **전체 (기존 포함)** | **87** | **81 pass / 6 known fail** |

i18n-gaps 스펙은 TodoFormPage/ScheduleFormPage의 레이블·버튼(`이름`, `저장`, `취소`)과 EventTimePicker의 라디오 레이블(`시간 없음`, `특정 시각`)이 i18n 키 없이 하드코딩된 한국어를 사용하는 알려진 갭을 의도적으로 FAIL로 문서화합니다.

## Test plan

- [x] Dev server (localhost:5175) + Firebase Auth emulator (localhost:9099) 환경에서 검증
- [x] `npx playwright test e2e/specs/ --reporter=line` 실행 결과 확인
- [x] KNOWN FAIL 테스트가 올바르게 실패하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)