### PR TITLE
test(e2e): P2 기능 검증 E2E 스펙 추가 (toast, foremost, holiday, appearance)

### DIFF
--- a/e2e/specs/p2-calendar-appearance.spec.ts
+++ b/e2e/specs/p2-calendar-appearance.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test'
+import { setupAuthContext } from '../helpers/auth'
+
+test.beforeEach(async ({ context }) => {
+  await setupAuthContext(context)
+})
+
+test('localStorage에 rowHeight를 설정하면 캘린더 셀이 해당 높이를 반영한다', async ({ page }) => {
+  // given — localStorage에 커스텀 rowHeight(120px) 설정 후 페이지 로드
+  const customRowHeight = 120
+  await page.addInitScript(({ key, value }) => {
+    localStorage.setItem(key, JSON.stringify(value))
+  }, { key: 'calendar_appearance', value: { rowHeight: customRowHeight, fontSize: 13, showEventNames: true } })
+
+  // when
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // then — day-cell 요소의 minHeight 스타일이 커스텀 값을 반영한다
+  const firstCell = page.getByTestId('day-cell').first()
+  await expect(firstCell).toBeVisible()
+  const minHeight = await firstCell.evaluate(el => (el as HTMLElement).style.minHeight)
+  expect(minHeight).toBe(`${customRowHeight}px`)
+})
+
+test('localStorage에 기본값(rowHeight 70)이 없을 때 캘린더 셀은 기본 높이(70px)를 사용한다', async ({ page }) => {
+  // given — localStorage 없음 (기본값 사용)
+  // no addInitScript — fresh state
+
+  // when
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // then — day-cell minHeight는 기본값 70px
+  const firstCell = page.getByTestId('day-cell').first()
+  await expect(firstCell).toBeVisible()
+  const minHeight = await firstCell.evaluate(el => (el as HTMLElement).style.minHeight)
+  expect(minHeight).toBe('70px')
+})
+
+test('localStorage에 fontSize를 설정하면 캘린더 셀이 해당 폰트 크기를 반영한다', async ({ page }) => {
+  // given — 커스텀 fontSize(16px) 설정
+  const customFontSize = 16
+  await page.addInitScript(({ key, value }) => {
+    localStorage.setItem(key, JSON.stringify(value))
+  }, { key: 'calendar_appearance', value: { rowHeight: 70, fontSize: customFontSize, showEventNames: true } })
+
+  // when
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // then — day-cell의 fontSize 스타일이 커스텀 값을 반영한다
+  const firstCell = page.getByTestId('day-cell').first()
+  await expect(firstCell).toBeVisible()
+  const fontSize = await firstCell.evaluate(el => (el as HTMLElement).style.fontSize)
+  expect(fontSize).toBe(`${customFontSize}px`)
+})
+
+test('rowHeight를 매우 작게 설정해도 캘린더가 정상 렌더된다', async ({ page }) => {
+  // given — 최솟값에 가까운 rowHeight
+  await page.addInitScript(({ key, value }) => {
+    localStorage.setItem(key, JSON.stringify(value))
+  }, { key: 'calendar_appearance', value: { rowHeight: 30, fontSize: 10, showEventNames: false } })
+
+  // when
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // then — 캘린더가 표시되고 day-cell이 30px 높이를 갖는다
+  const firstCell = page.getByTestId('day-cell').first()
+  await expect(firstCell).toBeVisible()
+  const minHeight = await firstCell.evaluate(el => (el as HTMLElement).style.minHeight)
+  expect(minHeight).toBe('30px')
+})

--- a/e2e/specs/p2-foremost.spec.ts
+++ b/e2e/specs/p2-foremost.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test'
+import { setupAuthContext } from '../helpers/auth'
+
+const MOCK_TODO_EVENT = {
+  uuid: 'foremost-todo-uuid',
+  name: '중요한 할 일',
+  event_tag_id: null,
+  event_time: null,
+  is_current: true,
+}
+
+const MOCK_FOREMOST_WITH_EVENT = {
+  event_id: 'foremost-todo-uuid',
+  is_todo: true,
+  event: MOCK_TODO_EVENT,
+}
+
+test.beforeEach(async ({ context }) => {
+  await setupAuthContext(context)
+})
+
+test('GET /v1/foremost/event 가 이벤트를 반환하면 메인 페이지에 배너가 표시된다', async ({ page }) => {
+  // given — foremost API가 이벤트를 반환하도록 모킹
+  await page.route('**/v1/foremost/event', async route => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_FOREMOST_WITH_EVENT),
+      })
+    } else {
+      await route.continue()
+    }
+  })
+
+  // when — 메인 페이지로 이동
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // then — ForemostEventBanner가 표시된다
+  await expect(page.getByTestId('foremost-banner')).toBeVisible()
+})
+
+test('Foremost 배너에 이벤트 이름이 표시된다', async ({ page }) => {
+  // given — foremost API가 이름이 있는 이벤트를 반환
+  await page.route('**/v1/foremost/event', async route => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_FOREMOST_WITH_EVENT),
+      })
+    } else {
+      await route.continue()
+    }
+  })
+
+  // when
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // then — 이벤트 이름이 배너에 보인다
+  await expect(page.getByTestId('foremost-banner')).toContainText('중요한 할 일')
+})
+
+test('GET /v1/foremost/event 가 404를 반환하면 배너가 표시되지 않는다', async ({ page }) => {
+  // given — foremost API가 404 (등록된 foremost 없음)
+  await page.route('**/v1/foremost/event', async route => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({ status: 404, body: '' })
+    } else {
+      await route.continue()
+    }
+  })
+
+  // when
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // then — 배너가 없다
+  await expect(page.getByTestId('foremost-banner')).not.toBeVisible()
+})
+
+test('GET /v1/foremost/event 가 event: null 을 반환하면 배너가 표시되지 않는다', async ({ page }) => {
+  // given — event 필드가 null인 foremost 응답
+  await page.route('**/v1/foremost/event', async route => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ event_id: 'some-id', is_todo: true, event: null }),
+      })
+    } else {
+      await route.continue()
+    }
+  })
+
+  // when
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // then — event가 없으므로 배너가 렌더되지 않는다
+  await expect(page.getByTestId('foremost-banner')).not.toBeVisible()
+})

--- a/e2e/specs/p2-holiday.spec.ts
+++ b/e2e/specs/p2-holiday.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test'
+import { setupAuthContext } from '../helpers/auth'
+
+// Today is 2026-04-11, so current month is April 2026
+const APRIL_HOLIDAYS = [
+  { summary: '어린이날', start: { date: '2026-05-05' }, end: { date: '2026-05-06' } },
+  // Put a holiday in April to test current month rendering
+  { summary: '식목일', start: { date: '2026-04-05' }, end: { date: '2026-04-06' } },
+]
+
+test.beforeEach(async ({ context }) => {
+  await setupAuthContext(context)
+})
+
+test('GET /v1/holiday 가 공휴일을 반환하면 해당 날짜가 캘린더에 빨간색으로 표시된다', async ({ page }) => {
+  // given — 공휴일 API가 4월 5일을 공휴일로 반환
+  await page.route('**/v1/holiday**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: APRIL_HOLIDAYS }),
+    })
+  })
+
+  // when
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // then — 4월 5일 날짜 숫자가 빨간색 텍스트 클래스를 갖는다
+  // CalendarGrid에서 holiday 날짜에 'text-red-500' 클래스 적용됨
+  const holidayCell = page.getByTestId('day-cell').filter({
+    has: page.locator('div.text-red-500', { hasText: '5' }),
+  }).first()
+  await expect(holidayCell).toBeVisible()
+})
+
+test('공휴일 날짜 셀에 title 속성으로 공휴일 이름이 설정된다', async ({ page }) => {
+  // given — 공휴일 API 모킹
+  await page.route('**/v1/holiday**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: APRIL_HOLIDAYS }),
+    })
+  })
+
+  // when
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // then — 4월 5일 셀의 title 속성에 공휴일 이름이 포함된다
+  const holidayCell = page.getByTestId('day-cell').filter({
+    has: page.locator('div', { hasText: '5' }),
+  }).first()
+  // title 속성에 공휴일 이름이 있어야 함
+  await expect(holidayCell).toHaveAttribute('title', /식목일/)
+})
+
+test('GET /v1/holiday 가 빈 목록을 반환하면 일요일을 제외한 날짜는 빨간색이 아니다', async ({ page }) => {
+  // given — 공휴일 없음
+  await page.route('**/v1/holiday**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [] }),
+    })
+  })
+
+  // when
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  // then — 4월 13일(월요일)은 빨간색 텍스트가 아니다
+  // Monday 13 should have text-gray-900, not text-red-500
+  const mondayCell = page.getByTestId('day-cell').filter({
+    has: page.locator('div.text-gray-900', { hasText: '13' }),
+  }).first()
+  await expect(mondayCell).toBeVisible()
+})

--- a/e2e/specs/p2-toast.spec.ts
+++ b/e2e/specs/p2-toast.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test'
+import { setupAuthContext } from '../helpers/auth'
+
+test.beforeEach(async ({ context }) => {
+  await setupAuthContext(context)
+})
+
+test('태그 생성 API가 500 에러를 반환하면 에러 토스트 알림이 표시된다', async ({ page }) => {
+  // given — 태그 생성 API를 500으로 모킹, 태그 목록은 빈 배열 반환
+  await page.route('**/v1/tags/all', async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  })
+  await page.route('**/v1/tags/tag', async route => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ message: 'Internal Server Error' }) })
+    } else {
+      await route.continue()
+    }
+  })
+
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+  await page.goto('/tags')
+  await expect(page.getByRole('heading', { name: '태그 관리' })).toBeVisible()
+
+  // when — 태그 이름을 입력하고 추가 버튼 클릭
+  await page.getByPlaceholder('새 태그 이름').fill('에러 태그')
+  await page.getByRole('button', { name: '추가' }).click()
+
+  // then — 에러 토스트 알림이 나타난다
+  await expect(page.getByRole('alert')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByRole('alert').first()).toContainText(/태그|실패|오류|error/i)
+})
+
+test('API 에러 토스트는 일정 시간 뒤 자동으로 사라진다', async ({ page }) => {
+  // given — 태그 생성 API를 500으로 모킹
+  await page.route('**/v1/tags/all', async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  })
+  await page.route('**/v1/tags/tag', async route => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ message: 'Internal Server Error' }) })
+    } else {
+      await route.continue()
+    }
+  })
+
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+  await page.goto('/tags')
+  await expect(page.getByRole('heading', { name: '태그 관리' })).toBeVisible()
+
+  // when — 에러를 유발해 토스트가 표시되게 한다
+  await page.getByPlaceholder('새 태그 이름').fill('사라질 태그')
+  await page.getByRole('button', { name: '추가' }).click()
+  await expect(page.getByRole('alert')).toBeVisible({ timeout: 5000 })
+
+  // then — 3초 뒤 토스트가 사라진다 (3000ms auto-dismiss + 여유 시간)
+  await expect(page.getByRole('alert')).not.toBeVisible({ timeout: 5000 })
+})
+
+test('에러 토스트를 클릭하면 즉시 사라진다', async ({ page }) => {
+  // given — 태그 생성 API를 500으로 모킹
+  await page.route('**/v1/tags/all', async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  })
+  await page.route('**/v1/tags/tag', async route => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ message: 'error' }) })
+    } else {
+      await route.continue()
+    }
+  })
+
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+  await page.goto('/tags')
+  await expect(page.getByRole('heading', { name: '태그 관리' })).toBeVisible()
+
+  await page.getByPlaceholder('새 태그 이름').fill('클릭 제거 태그')
+  await page.getByRole('button', { name: '추가' }).click()
+  await expect(page.getByRole('alert')).toBeVisible({ timeout: 5000 })
+
+  // when — 토스트를 클릭
+  await page.getByRole('alert').first().click()
+
+  // then — 즉시 사라진다
+  await expect(page.getByRole('alert')).not.toBeVisible()
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   globalSetup: './e2e/global-setup.ts',
   use: {
-    baseURL: 'http://localhost:5175',
+    baseURL: 'http://localhost:5173',
     screenshot: 'only-on-failure',
     trace: 'on-first-retry',
   },
@@ -22,7 +22,7 @@ export default defineConfig({
   ],
   webServer: {
     command: 'npm run dev',
-    port: 5175,
+    port: 5173,
     reuseExistingServer: !process.env.CI,
   },
 })


### PR DESCRIPTION
## Summary

- `p2-toast.spec.ts`: API 500 에러 발생 시 에러 토스트 표시 / 3초 auto-dismiss / 클릭 dismiss (3개)
- `p2-foremost.spec.ts`: foremost 이벤트 존재 시 배너 표시 + 이름 노출, 404/null 시 배너 없음 (4개)
- `p2-holiday.spec.ts`: 공휴일 날짜 빨간색 텍스트, title 속성에 공휴일 이름, 빈 목록 시 일반 색상 (3개)
- `p2-calendar-appearance.spec.ts`: localStorage rowHeight/fontSize 값이 day-cell 인라인 스타일에 반영, 기본값 70px, 극단값 동작 (4개)

`playwright.config.ts` baseURL과 webServer.port를 5175 → 5173으로 수정.

## Test plan

- [x] 14개 신규 스펙 모두 HEADED 모드 통과 (14/14)
- [x] 전체 스펙 headless 통과 (101/101)

🤖 Generated with [Claude Code](https://claude.com/claude-code)