### PR TITLE
fix(ui): 오버레이 백드롭 클릭 시 닫기 기능 추가

### DIFF
--- a/e2e/specs/journey-overlay-close.spec.ts
+++ b/e2e/specs/journey-overlay-close.spec.ts
@@ -62,12 +62,9 @@ test('Todo 폼에서 취소 버튼을 클릭하면 오버레이가 닫히고 메
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Test 2: FAB → Todo 폼 → 어두운 백드롭 클릭 → 오버레이 닫힘 여부
-// NOTE: App.tsx를 보면 background가 있을 때 fixed inset-0 z-50 bg-black/30 div가 렌더됨
-//       하지만 backdrop에 onClick 핸들러가 없으므로 클릭해도 닫히지 않는다.
-//       이 테스트는 현재 동작을 문서화한다.
+// Test 2: FAB → Todo 폼 → 어두운 백드롭 클릭 → 오버레이 닫힘
 // ─────────────────────────────────────────────────────────────────────────────
-test('Todo 폼 뒤의 백드롭을 클릭해도 오버레이는 닫히지 않는다 (backdrop handler 없음)', async ({ page }) => {
+test('Todo 폼 뒤의 백드롭을 클릭하면 오버레이가 닫히고 메인 페이지로 돌아간다', async ({ page }) => {
   // given
   await setupBasicMocks(page)
   await page.goto('/')
@@ -78,13 +75,12 @@ test('Todo 폼 뒤의 백드롭을 클릭해도 오버레이는 닫히지 않는
   await page.getByRole('button', { name: 'Todo', exact: true }).click()
   await expect(page).toHaveURL(/\/todos\/new/)
 
-  // 백드롭 영역 (fixed inset-0 z-50 bg-black/30) 클릭
-  // 오버레이 div 바깥쪽, 왼쪽 상단 영역을 클릭
-  await page.mouse.click(10, 10)
+  // 백드롭 영역 클릭 — data-testid로 백드롭 div를 정확히 타겟
+  await page.getByTestId('overlay-backdrop').click()
 
-  // then — 오버레이가 여전히 표시된다 (backdrop close 미구현)
-  // 백드롭 클릭 핸들러가 없으므로 URL은 변경되지 않음
-  await expect(page).toHaveURL(/\/todos\/new/)
+  // then — 오버레이가 닫히고 메인 페이지 URL로 복귀한다
+  await expect(page).toHaveURL('/')
+  await expect(page.getByRole('heading', { name: '새 Todo' })).not.toBeVisible()
 })
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from 'react'
-import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, useLocation, useNavigate } from 'react-router-dom'
 import { AuthGuard } from './components/AuthGuard'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { Header } from './components/Header'
@@ -19,6 +19,7 @@ const NotFoundPage = React.lazy(() => import('./pages/NotFoundPage').then(m => (
 
 function AppRoutes() {
   const location = useLocation()
+  const navigate = useNavigate()
   const background = (location.state as { background?: typeof location } | null)?.background
 
   return (
@@ -53,21 +54,31 @@ function AppRoutes() {
           fixed inset-0 z-50 으로 뷰포트 전체를 덮어 스크롤 없이 보이도록 한다.
           배경 페이지의 Header가 이미 표시 중이므로 Header 불필요. */}
       {background && (
-        <div className="fixed inset-0 z-50 overflow-y-auto bg-black/30">
-          <Suspense fallback={<LoadingSkeleton />}>
-            <Routes>
-              {[
-                ['/events/:id', <EventDetailPage />],
-                ['/todos/new', <TodoFormPage />],
-                ['/todos/:id/edit', <TodoFormPage />],
-                ['/schedules/new', <ScheduleFormPage />],
-                ['/schedules/:id/edit', <ScheduleFormPage />],
-                ['/tags', <TagManagementPage />],
-              ].map(([path, element]) => (
-                <Route key={path as string} path={path as string} element={<AuthGuard>{element as React.ReactElement}</AuthGuard>} />
-              ))}
-            </Routes>
-          </Suspense>
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          {/* 백드롭: 클릭 시 이전 페이지로 복귀 */}
+          <div
+            className="fixed inset-0 bg-black/30"
+            data-testid="overlay-backdrop"
+            aria-label="오버레이 닫기"
+            onClick={() => navigate(-1)}
+          />
+          {/* 폼 콘텐츠: 백드롭 위에 렌더. stopPropagation으로 백드롭 클릭과 분리 */}
+          <div className="relative" onClick={e => e.stopPropagation()}>
+            <Suspense fallback={<LoadingSkeleton />}>
+              <Routes>
+                {[
+                  ['/events/:id', <EventDetailPage />],
+                  ['/todos/new', <TodoFormPage />],
+                  ['/todos/:id/edit', <TodoFormPage />],
+                  ['/schedules/new', <ScheduleFormPage />],
+                  ['/schedules/:id/edit', <ScheduleFormPage />],
+                  ['/tags', <TagManagementPage />],
+                ].map(([path, element]) => (
+                  <Route key={path as string} path={path as string} element={<AuthGuard>{element as React.ReactElement}</AuthGuard>} />
+                ))}
+              </Routes>
+            </Suspense>
+          </div>
         </div>
       )}
     </>


### PR DESCRIPTION
## Summary

- `App.tsx`의 오버레이 컨테이너를 백드롭 div와 콘텐츠 div로 분리
- 백드롭(`data-testid="overlay-backdrop"`) 클릭 시 `navigate(-1)`로 이전 페이지 복귀
- 폼 콘텐츠 wrapper에 `stopPropagation` 적용하여 폼 내부 클릭과 백드롭 클릭을 분리
- E2E 테스트(`journey-overlay-close.spec.ts`)의 Test 2를 "닫히지 않는다"에서 "닫힌다"로 업데이트

## Test plan

- [x] `npx playwright test e2e/specs/journey-overlay-close.spec.ts` — 3/3 통과
- [x] `npx playwright test e2e/specs/` — 133/133 통과
- [x] `npm run build` — 빌드 성공
- [x] `npm test` — 254/254 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)