### PR TITLE
fix: 중앙 캘린더 라인 컬러를 연한 색상으로 변경

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -13,7 +13,7 @@
   --color-brand: #1d4ed8;
   --color-brand-dark: #005bc1;
   --color-border-light: #e2e8f0;
-  --color-border-calendar: #adb3b5;
+  --color-border-calendar: #e2e8f0;
   --color-text-primary: #334155;
   --color-text-secondary: #64748b;
 }


### PR DESCRIPTION
중앙 캘린더의 그리드 라인 컬러를 연한 색상(#e2e8f0)으로 변경하여 디자인을 개선했습니다.

## 변경사항
- `--color-border-calendar` 값을 #adb3b5에서 #e2e8f0(Tailwind slate-200)로 변경
- MainCalendarGrid의 weekday 헤더 및 day 셀 테두리에 적용
- Card 래퍼의 테두리에도 적용

Closes #22