### PR TITLE
fix(UI): 캘린더 목록 타이틀 및 버튼 수정

### DIFF
--- a/src/components/CalendarList.tsx
+++ b/src/components/CalendarList.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom'
 import { useEventTagStore } from '../stores/eventTagStore'
 import { useTagFilterStore } from '../stores/tagFilterStore'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Button } from '@/components/ui/button'
 
 export default function CalendarList() {
   const { t } = useTranslation()
@@ -16,7 +17,7 @@ export default function CalendarList() {
   return (
     <div className="flex flex-col">
       <p className="text-text-secondary text-xs font-medium uppercase tracking-wider mb-3">
-        {t('main.calendar_list', '내 캘린더')}
+        {t('main.event_types', '이벤트 종류')}
       </p>
 
       <div className="flex flex-col gap-1">
@@ -44,12 +45,13 @@ export default function CalendarList() {
       </div>
 
       <div className="py-2 mt-2">
-        <button
+        <Button
+          variant="link"
+          size="sm"
           onClick={() => navigate('/tags', { state: { background: location } })}
-          className="text-xs text-brand hover:text-blue-700"
         >
           {t('tag.manage', '태그 관리')} &gt;
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/tests/components/CalendarList.test.tsx
+++ b/tests/components/CalendarList.test.tsx
@@ -38,7 +38,7 @@ describe('CalendarList', () => {
     renderCalendarList()
 
     // then
-    expect(screen.getByText('내 캘린더')).toBeInTheDocument()
+    expect(screen.getByText('이벤트 종류')).toBeInTheDocument()
     expect(screen.getByText('업무')).toBeInTheDocument()
     expect(screen.getByText('개인')).toBeInTheDocument()
   })
@@ -106,7 +106,7 @@ describe('CalendarList', () => {
     renderCalendarList()
 
     // then
-    expect(screen.getByText('내 캘린더')).toBeInTheDocument()
+    expect(screen.getByText('이벤트 종류')).toBeInTheDocument()
     expect(screen.queryByText('업무')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- 좌측 사이드바 '내 캘린더' 섹션 타이틀을 '이벤트 종류'로 변경
- 태그 관리 버튼을 shadcn Button 컴포넌트로 변경 (variant=link, size=sm)
- 테스트 업데이트

Closes #21

## Test Plan
- [x] npm test -- --run 통과 (모든 테스트 309개 통과)