### PR TITLE
#22 style: 캘린더 그리드 보더 색상 수정

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -13,7 +13,7 @@
   --color-brand: #1d4ed8;
   --color-brand-dark: #005bc1;
   --color-border-light: #e2e8f0;
-  --color-border-calendar: #adb3b5;
+  --color-border-calendar: #e5e7eb;
   --color-text-primary: #334155;
   --color-text-secondary: #64748b;
 }


### PR DESCRIPTION
캘린더 그리드의 보더 색상을 #adb3b5에서 #e5e7eb(gray-200)로 변경합니다.

- CSS 변수 `--color-border-calendar` 업데이트
- MainCalendarGrid 요일 헤더 및 날짜 셀에 적용됨
- MiniCalendar Card 보더에 적용됨