### PR TITLE
#23 feat: 캘린더 이벤트 다일 스팬 표시

### DIFF
--- a/src/calendar/MainCalendarGrid.tsx
+++ b/src/calendar/MainCalendarGrid.tsx
@@ -1,7 +1,9 @@
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { CalendarDay } from './calendarUtils'
 import type { CalendarEvent } from '../utils/eventTimeUtils'
 import { formatDateKey } from '../utils/eventTimeUtils'
+import { buildWeekEventStack, type EventOnWeekRow } from './weekEventStackBuilder'
 import { useUiStore } from '../stores/uiStore'
 import { useCalendarEventsStore } from '../stores/calendarEventsStore'
 import { useHolidayStore } from '../stores/holidayStore'
@@ -10,6 +12,10 @@ import { useTagFilterStore } from '../stores/tagFilterStore'
 import { useCalendarAppearanceStore } from '../stores/calendarAppearanceStore'
 
 const WEEKDAY_KEYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const
+
+// 이벤트 바 높이(px) + 간격
+const EVENT_ROW_HEIGHT = 20
+const EVENT_ROW_GAP = 2
 
 interface MainCalendarGridProps {
   days: CalendarDay[]
@@ -26,9 +32,41 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
   const isTagHidden = useTagFilterStore(s => s.isTagHidden)
   const { rowHeight, fontSize, showEventNames } = useCalendarAppearanceStore()
 
+  // days를 7일 단위로 주(week) 분할
+  const weeks = useMemo(() => {
+    const result: CalendarDay[][] = []
+    for (let i = 0; i < days.length; i += 7) {
+      result.push(days.slice(i, i + 7))
+    }
+    return result
+  }, [days])
+
+  // 숨겨진 태그를 제외한 eventsByDate
+  const filteredEventsByDate = useMemo(() => {
+    const filtered = new Map<string, CalendarEvent[]>()
+    for (const [key, events] of eventsByDate) {
+      const visible = events.filter(ev => !isTagHidden(ev.event.event_tag_id))
+      if (visible.length > 0) {
+        filtered.set(key, visible)
+      }
+    }
+    return filtered
+  }, [eventsByDate, isTagHidden])
+
+  // 주별 이벤트 스택 계산
+  const weekStacks = useMemo(
+    () => weeks.map(weekDays => buildWeekEventStack(weekDays, filteredEventsByDate)),
+    [weeks, filteredEventsByDate],
+  )
+
+  // 날짜 숫자 영역 높이 (대략 28px)
+  const dateNumberHeight = 28
+  // 표시 가능한 이벤트 행 수 계산
+  const maxVisibleRows = Math.max(1, Math.floor((rowHeight - dateNumberHeight) / (EVENT_ROW_HEIGHT + EVENT_ROW_GAP)))
+
   return (
     <div className="flex h-full flex-col">
-      {/* Weekday header row */}
+      {/* 요일 헤더 */}
       <div className="grid grid-cols-7 border-b border-border-calendar shrink-0">
         {WEEKDAY_KEYS.map((key, i) => (
           <div
@@ -40,95 +78,135 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
         ))}
       </div>
 
-      {/* Day cells grid */}
-      <div className="grid grid-cols-7 flex-1" style={{ gridAutoRows: '1fr' }}>
-        {days.map((day, i) => {
-          const isSelected = selectedDate && formatDateKey(selectedDate) === day.dateKey
-          const holidayNames = getHolidayNames(day.dateKey)
-          const isHoliday = holidayNames.length > 0
-          const isSunday = day.date.getDay() === 0
-
-          const events = (eventsByDate.get(day.dateKey) ?? []).filter(ev => !isTagHidden(ev.event.event_tag_id))
-          const dotColors: string[] = []
-          for (const ev of events.slice(0, 3)) {
-            const tagId = ev.event.event_tag_id
-            const color = tagId ? getColorForTagId(tagId) : undefined
-            dotColors.push(color ?? '#9ca3af')
-          }
-
-          const textColor = day.isToday
-            ? 'font-semibold text-white'
-            : !day.isCurrentMonth
-              ? 'text-gray-300'
-              : (isHoliday || isSunday)
-                ? 'text-red-500'
-                : 'text-text-primary'
-
-          const bgClass = day.isToday ? 'bg-brand-dark rounded-full' : ''
-          const selectedClass = isSelected && !day.isToday ? 'ring-2 ring-brand-dark rounded-full' : ''
+      {/* 주 단위 반복 */}
+      <div className="flex flex-1 flex-col" style={{ minHeight: 0 }}>
+        {weeks.map((weekDays, wi) => {
+          const stack = weekStacks[wi]
+          const visibleRows = stack.rows.slice(0, maxVisibleRows)
+          const hiddenCount = stack.rows.length > maxVisibleRows
+            ? stack.rows.slice(maxVisibleRows).reduce((sum, row) => sum + row.length, 0)
+            : 0
 
           return (
-            <div
-              key={i}
-              className={`flex flex-col p-2 cursor-pointer border-r border-b border-border-calendar hover:bg-gray-50 ${!day.isCurrentMonth ? 'bg-surface-alt' : ''}`}
-              data-testid="day-cell"
-              style={{ minHeight: `${rowHeight}px`, fontSize: `${fontSize}px` }}
-              onClick={() => setSelectedDate(day.date)}
-              title={holidayNames.join(', ') || undefined}
-            >
-              {day.isToday ? (
-                <div className="flex h-7 w-7 items-center justify-center rounded-full bg-brand-dark text-white font-semibold text-sm">
-                  {day.dayOfMonth}
-                </div>
-              ) : (
-                <div className={`flex h-7 w-7 items-center justify-center text-sm font-medium ${textColor} ${selectedClass}`}>
-                  {day.dayOfMonth}
-                </div>
-              )}
-              {/* Desktop: color bars with event names */}
-              {events.length > 0 && (
-                <div className="hidden md:block mt-1 space-y-0.5 w-full">
-                  {events.slice(0, 2).map((ev, j) => {
+            <div key={wi} className="flex-1 min-h-0 relative" style={{ minHeight: `${rowHeight}px` }}>
+              {/* 날짜 숫자 행 */}
+              <div className="grid grid-cols-7">
+                {weekDays.map((day, di) => {
+                  const isSelected = selectedDate && formatDateKey(selectedDate) === day.dateKey
+                  const holidayNames = getHolidayNames(day.dateKey)
+                  const isHoliday = holidayNames.length > 0
+                  const isSunday = day.date.getDay() === 0
+
+                  // 해당 날짜의 이벤트 (모바일 dots용)
+                  const dayEvents = (filteredEventsByDate.get(day.dateKey) ?? [])
+                  const dotColors: string[] = []
+                  for (const ev of dayEvents.slice(0, 3)) {
                     const tagId = ev.event.event_tag_id
-                    const color = tagId ? getColorForTagId(tagId) : '#9ca3af'
-                    return (
+                    const color = tagId ? getColorForTagId(tagId) : undefined
+                    dotColors.push(color ?? '#9ca3af')
+                  }
+
+                  const textColor = day.isToday
+                    ? 'font-semibold text-white'
+                    : !day.isCurrentMonth
+                      ? 'text-gray-300'
+                      : (isHoliday || isSunday)
+                        ? 'text-red-500'
+                        : 'text-text-primary'
+
+                  const selectedClass = isSelected && !day.isToday ? 'ring-2 ring-brand-dark rounded-full' : ''
+
+                  return (
+                    <div
+                      key={di}
+                      className={`flex flex-col p-2 cursor-pointer border-r border-b border-border-calendar hover:bg-gray-50 ${!day.isCurrentMonth ? 'bg-surface-alt' : ''}`}
+                      data-testid="day-cell"
+                      style={{ minHeight: `${rowHeight}px`, fontSize: `${fontSize}px` }}
+                      onClick={() => setSelectedDate(day.date)}
+                      title={holidayNames.join(', ') || undefined}
+                    >
+                      {day.isToday ? (
+                        <div className="flex h-7 w-7 items-center justify-center rounded-full bg-brand-dark text-white font-semibold text-sm">
+                          {day.dayOfMonth}
+                        </div>
+                      ) : (
+                        <div className={`flex h-7 w-7 items-center justify-center text-sm font-medium ${textColor} ${selectedClass}`}>
+                          {day.dayOfMonth}
+                        </div>
+                      )}
+
+                      {/* Mobile: dots */}
+                      {dotColors.length > 0 && (
+                        <div className="md:hidden mt-0.5 flex gap-0.5" data-testid="event-dots">
+                          {dotColors.map((color, j) => (
+                            <span
+                              key={j}
+                              className="inline-block h-1 w-1 rounded-full"
+                              style={{ backgroundColor: color }}
+                            />
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+
+              {/* Desktop: 이벤트 스팬 행들 (날짜 숫자 아래 절대 위치) */}
+              <div
+                className="hidden md:block absolute left-0 right-0 pointer-events-none"
+                style={{ top: `${dateNumberHeight + 8}px` }}
+              >
+                {visibleRows.map((row, ri) => (
+                  <div
+                    key={ri}
+                    className="grid grid-cols-7 relative"
+                    style={{ height: `${EVENT_ROW_HEIGHT}px`, marginBottom: `${EVENT_ROW_GAP}px` }}
+                  >
+                    {row.map((ev) => (
                       <div
-                        key={j}
-                        className="truncate rounded px-1.5 py-0.5 text-[10px] leading-tight text-white cursor-pointer"
-                        style={{ backgroundColor: color ?? '#9ca3af' }}
+                        key={ev.event.event.uuid}
+                        className="truncate rounded px-1.5 py-0.5 text-[10px] leading-tight text-white cursor-pointer pointer-events-auto"
                         data-testid="event-bar"
+                        style={{
+                          gridColumn: `${ev.startCol} / ${ev.endCol + 1}`,
+                          backgroundColor: getEventColor(ev, getColorForTagId),
+                        }}
                         onClick={(e) => {
                           e.stopPropagation()
-                          onEventClick?.(ev, e.currentTarget.getBoundingClientRect())
+                          onEventClick?.(ev.event, e.currentTarget.getBoundingClientRect())
                         }}
                       >
-                        {showEventNames ? ev.event.name : '\u00A0'}
+                        {showEventNames ? ev.event.event.name : '\u00A0'}
                       </div>
-                    )
-                  })}
-                  {events.length > 2 && (
-                    <div className="text-[9px] text-text-secondary px-0.5">
-                      +{events.length - 2}
+                    ))}
+                  </div>
+                ))}
+
+                {/* +N more 표시 */}
+                {hiddenCount > 0 && (
+                  <div className="grid grid-cols-7">
+                    <div className="col-span-7 text-[9px] text-text-secondary px-2 pointer-events-auto">
+                      +{hiddenCount} more
                     </div>
-                  )}
-                </div>
-              )}
-              {/* Mobile: dots */}
-              {dotColors.length > 0 && (
-                <div className="md:hidden mt-0.5 flex gap-0.5" data-testid="event-dots">
-                  {dotColors.map((color, j) => (
-                    <span
-                      key={j}
-                      className="inline-block h-1 w-1 rounded-full"
-                      style={{ backgroundColor: color }}
-                    />
-                  ))}
-                </div>
-              )}
+                  </div>
+                )}
+              </div>
             </div>
           )
         })}
       </div>
     </div>
   )
+}
+
+function getEventColor(
+  ev: EventOnWeekRow,
+  getColorForTagId: (tagId: string) => string | null | undefined,
+): string {
+  const tagId = ev.event.event.event_tag_id
+  if (tagId) {
+    return getColorForTagId(tagId) ?? '#9ca3af'
+  }
+  return '#9ca3af'
 }

--- a/src/calendar/MainCalendarGrid.tsx
+++ b/src/calendar/MainCalendarGrid.tsx
@@ -16,6 +16,10 @@ const WEEKDAY_KEYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const
 // 이벤트 바 높이(px) + 간격
 const EVENT_ROW_HEIGHT = 20
 const EVENT_ROW_GAP = 2
+// 날짜 숫자 영역 높이(px)
+const DATE_NUMBER_HEIGHT = 28
+// 날짜 숫자 아래 이벤트 바 시작 오프셋(px)
+const EVENT_AREA_TOP_OFFSET = 8
 
 interface MainCalendarGridProps {
   days: CalendarDay[]
@@ -59,10 +63,8 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
     [weeks, filteredEventsByDate],
   )
 
-  // 날짜 숫자 영역 높이 (대략 28px)
-  const dateNumberHeight = 28
   // 표시 가능한 이벤트 행 수 계산
-  const maxVisibleRows = Math.max(1, Math.floor((rowHeight - dateNumberHeight) / (EVENT_ROW_HEIGHT + EVENT_ROW_GAP)))
+  const maxVisibleRows = Math.max(1, Math.floor((rowHeight - DATE_NUMBER_HEIGHT) / (EVENT_ROW_HEIGHT + EVENT_ROW_GAP)))
 
   return (
     <div className="flex h-full flex-col">
@@ -155,7 +157,7 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
               {/* Desktop: 이벤트 스팬 행들 (날짜 숫자 아래 절대 위치) */}
               <div
                 className="hidden md:block absolute left-0 right-0 pointer-events-none"
-                style={{ top: `${dateNumberHeight + 8}px` }}
+                style={{ top: `${DATE_NUMBER_HEIGHT + EVENT_AREA_TOP_OFFSET}px` }}
               >
                 {visibleRows.map((row, ri) => (
                   <div

--- a/src/calendar/weekEventStackBuilder.ts
+++ b/src/calendar/weekEventStackBuilder.ts
@@ -81,13 +81,12 @@ export function buildWeekEventStack(
 
   while (remaining.length > 0) {
     const row: EventOnWeekRow[] = []
-    const used: DeduplicatedEvent[] = []
+    const usedUuids = new Set<string>()
 
-    fillRow(remaining, row, used, 1, weekDays.length)
+    fillRow(remaining, row, usedUuids, 1, weekDays.length)
 
     // remaining에서 used 제거
-    const usedSet = new Set(used.map(e => e.event.event.uuid))
-    remaining = remaining.filter(e => !usedSet.has(e.event.event.uuid))
+    remaining = remaining.filter(e => !usedUuids.has(e.event.event.uuid))
 
     rows.push(row)
   }
@@ -113,7 +112,7 @@ export function buildWeekEventStack(
 function fillRow(
   candidates: DeduplicatedEvent[],
   row: EventOnWeekRow[],
-  used: DeduplicatedEvent[],
+  usedUuids: Set<string>,
   rangeStart: number,
   rangeEnd: number,
 ): void {
@@ -122,7 +121,7 @@ function fillRow(
   // 범위 내에 맞는 이벤트 중 가장 긴 것 찾기
   const fitting = candidates.filter(
     e => e.startCol >= rangeStart && e.endCol <= rangeEnd
-      && !used.some(u => u.event.event.uuid === e.event.event.uuid)
+      && !usedUuids.has(e.event.event.uuid)
   )
 
   if (fitting.length === 0) return
@@ -135,15 +134,15 @@ function fillRow(
     startCol: best.startCol,
     endCol: best.endCol,
   })
-  used.push(best)
+  usedUuids.add(best.event.event.uuid)
 
   // 왼쪽 빈 공간
   if (best.startCol > rangeStart) {
-    fillRow(candidates, row, used, rangeStart, best.startCol - 1)
+    fillRow(candidates, row, usedUuids, rangeStart, best.startCol - 1)
   }
 
   // 오른쪽 빈 공간
   if (best.endCol < rangeEnd) {
-    fillRow(candidates, row, used, best.endCol + 1, rangeEnd)
+    fillRow(candidates, row, usedUuids, best.endCol + 1, rangeEnd)
   }
 }

--- a/src/calendar/weekEventStackBuilder.ts
+++ b/src/calendar/weekEventStackBuilder.ts
@@ -1,0 +1,149 @@
+import type { CalendarDay } from './calendarUtils'
+import type { CalendarEvent } from '../utils/eventTimeUtils'
+
+export interface EventOnWeekRow {
+  event: CalendarEvent
+  startCol: number   // 1-based (1=일, 7=토)
+  endCol: number     // 1-based, inclusive
+}
+
+export type EventRow = EventOnWeekRow[]
+
+export interface WeekEventStack {
+  rows: EventRow[]
+}
+
+interface DeduplicatedEvent {
+  event: CalendarEvent
+  startCol: number
+  endCol: number
+  spanLength: number
+}
+
+/**
+ * 주(week) 단위로 이벤트를 행에 스택하여 배치한다.
+ *
+ * 알고리즘:
+ * 1. eventsByDate에서 해당 주에 걸치는 이벤트를 수집하고, uuid 기준으로 dedup
+ * 2. 각 이벤트의 startCol/endCol 계산
+ * 3. 길이(긴 것 우선) → 시작일 → 이름 순으로 정렬
+ * 4. Greedy bin-packing: 가장 긴 이벤트를 행에 넣고, 좌/우 빈 공간에 맞는 이벤트를 재귀적으로 채움
+ * 5. 행 정렬: 커버 일수 desc → 첫 이벤트 시작일 asc
+ */
+export function buildWeekEventStack(
+  weekDays: CalendarDay[],
+  eventsByDate: Map<string, CalendarEvent[]>,
+): WeekEventStack {
+  if (weekDays.length === 0) return { rows: [] }
+
+  // dateKey → column index (1-based) 매핑
+  const dateKeyToCol = new Map<string, number>()
+  weekDays.forEach((day, i) => {
+    dateKeyToCol.set(day.dateKey, i + 1)
+  })
+
+  // 이벤트 수집 + uuid dedup + startCol/endCol 계산
+  const eventMap = new Map<string, DeduplicatedEvent>()
+
+  for (const day of weekDays) {
+    const events = eventsByDate.get(day.dateKey) ?? []
+    const col = dateKeyToCol.get(day.dateKey)!
+
+    for (const ev of events) {
+      const uuid = ev.event.uuid
+      const existing = eventMap.get(uuid)
+      if (existing) {
+        // 범위 확장
+        existing.startCol = Math.min(existing.startCol, col)
+        existing.endCol = Math.max(existing.endCol, col)
+        existing.spanLength = existing.endCol - existing.startCol + 1
+      } else {
+        eventMap.set(uuid, {
+          event: ev,
+          startCol: col,
+          endCol: col,
+          spanLength: 1,
+        })
+      }
+    }
+  }
+
+  if (eventMap.size === 0) return { rows: [] }
+
+  // 정렬: 길이 desc → 시작일 asc → 이름 asc
+  let remaining = Array.from(eventMap.values()).sort((a, b) => {
+    if (b.spanLength !== a.spanLength) return b.spanLength - a.spanLength
+    if (a.startCol !== b.startCol) return a.startCol - b.startCol
+    return a.event.event.name.localeCompare(b.event.event.name)
+  })
+
+  const rows: EventRow[] = []
+
+  while (remaining.length > 0) {
+    const row: EventOnWeekRow[] = []
+    const used: DeduplicatedEvent[] = []
+
+    fillRow(remaining, row, used, 1, weekDays.length)
+
+    // remaining에서 used 제거
+    const usedSet = new Set(used.map(e => e.event.event.uuid))
+    remaining = remaining.filter(e => !usedSet.has(e.event.event.uuid))
+
+    rows.push(row)
+  }
+
+  // 행 정렬: 총 커버 일수 desc → 첫 이벤트 시작일 asc
+  rows.sort((a, b) => {
+    const coverA = a.reduce((sum, e) => sum + (e.endCol - e.startCol + 1), 0)
+    const coverB = b.reduce((sum, e) => sum + (e.endCol - e.startCol + 1), 0)
+    if (coverB !== coverA) return coverB - coverA
+    const firstStartA = Math.min(...a.map(e => e.startCol))
+    const firstStartB = Math.min(...b.map(e => e.startCol))
+    return firstStartA - firstStartB
+  })
+
+  return { rows }
+}
+
+/**
+ * 재귀적으로 행에 이벤트를 채운다.
+ * rangeStart ~ rangeEnd 범위 내에서 가장 긴 이벤트를 배치하고,
+ * 좌/우 빈 공간에 재귀적으로 더 채운다.
+ */
+function fillRow(
+  candidates: DeduplicatedEvent[],
+  row: EventOnWeekRow[],
+  used: DeduplicatedEvent[],
+  rangeStart: number,
+  rangeEnd: number,
+): void {
+  if (rangeStart > rangeEnd) return
+
+  // 범위 내에 맞는 이벤트 중 가장 긴 것 찾기
+  const fitting = candidates.filter(
+    e => e.startCol >= rangeStart && e.endCol <= rangeEnd
+      && !used.some(u => u.event.event.uuid === e.event.event.uuid)
+  )
+
+  if (fitting.length === 0) return
+
+  // 이미 정렬되어 있으므로 첫 번째가 가장 긴 것
+  const best = fitting[0]
+
+  row.push({
+    event: best.event,
+    startCol: best.startCol,
+    endCol: best.endCol,
+  })
+  used.push(best)
+
+  // 왼쪽 빈 공간
+  if (best.startCol > rangeStart) {
+    fillRow(candidates, row, used, rangeStart, best.startCol - 1)
+  }
+
+  // 오른쪽 빈 공간
+  if (best.endCol < rangeEnd) {
+    fillRow(candidates, row, used, best.endCol + 1, rangeEnd)
+  }
+}

--- a/tests/calendar/weekEventStackBuilder.test.ts
+++ b/tests/calendar/weekEventStackBuilder.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import {
-  buildWeekEventStack,
-  type EventOnWeekRow,
-  type WeekEventStack,
-} from '../../src/calendar/weekEventStackBuilder'
+import { buildWeekEventStack } from '../../src/calendar/weekEventStackBuilder'
 import type { CalendarDay } from '../../src/calendar/calendarUtils'
 import type { CalendarEvent } from '../../src/utils/eventTimeUtils'
 import type { Todo } from '../../src/models/Todo'

--- a/tests/calendar/weekEventStackBuilder.test.ts
+++ b/tests/calendar/weekEventStackBuilder.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildWeekEventStack,
+  type EventOnWeekRow,
+  type WeekEventStack,
+} from '../../src/calendar/weekEventStackBuilder'
+import type { CalendarDay } from '../../src/calendar/calendarUtils'
+import type { CalendarEvent } from '../../src/utils/eventTimeUtils'
+import type { Todo } from '../../src/models/Todo'
+import type { Schedule } from '../../src/models/Schedule'
+
+// Helper: 주어진 날짜 범위의 CalendarDay[] 생성 (일~토, 7일)
+function makeWeekDays(startDate: Date): CalendarDay[] {
+  const days: CalendarDay[] = []
+  for (let i = 0; i < 7; i++) {
+    const date = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate() + i)
+    const y = date.getFullYear()
+    const m = String(date.getMonth() + 1).padStart(2, '0')
+    const d = String(date.getDate()).padStart(2, '0')
+    days.push({
+      date,
+      dayOfMonth: date.getDate(),
+      dateKey: `${y}-${m}-${d}`,
+      isCurrentMonth: true,
+      isToday: false,
+    })
+  }
+  return days
+}
+
+// Helper: Todo CalendarEvent 생성
+function makeTodoEvent(uuid: string, name: string, tagId?: string): CalendarEvent {
+  return {
+    type: 'todo',
+    event: {
+      uuid,
+      name,
+      is_current: false,
+      event_tag_id: tagId ?? null,
+      event_time: { time_type: 'at', timestamp: 0 },
+    } as Todo,
+  }
+}
+
+function makeScheduleEvent(uuid: string, name: string, tagId?: string): CalendarEvent {
+  return {
+    type: 'schedule',
+    event: {
+      uuid,
+      name,
+      event_tag_id: tagId ?? null,
+      event_time: { time_type: 'at', timestamp: 0 },
+    } as Schedule,
+  }
+}
+
+// 2026-03-01 is a Sunday
+const weekStart = new Date(2026, 2, 1) // Sun Mar 1
+const weekDays = makeWeekDays(weekStart)
+
+describe('buildWeekEventStack', () => {
+  it('이벤트가 없는 주는 빈 rows를 반환한다', () => {
+    // given: 빈 eventsByDate
+    const eventsByDate = new Map<string, CalendarEvent[]>()
+
+    // when
+    const result = buildWeekEventStack(weekDays, eventsByDate)
+
+    // then
+    expect(result.rows).toEqual([])
+  })
+
+  it('단일 1일 이벤트는 1행 1이벤트로 배치된다', () => {
+    // given: 화요일(col=3)에 이벤트 하나
+    const ev = makeTodoEvent('t1', 'Buy milk')
+    const eventsByDate = new Map<string, CalendarEvent[]>([
+      ['2026-03-03', [ev]], // Tuesday = col 3
+    ])
+
+    // when
+    const result = buildWeekEventStack(weekDays, eventsByDate)
+
+    // then: 1행, startCol=3, endCol=3
+    expect(result.rows.length).toBe(1)
+    expect(result.rows[0].length).toBe(1)
+    expect(result.rows[0][0].startCol).toBe(3)
+    expect(result.rows[0][0].endCol).toBe(3)
+    expect(result.rows[0][0].event.event.uuid).toBe('t1')
+  })
+
+  it('다일 이벤트(월~수)는 1행에 startCol=2, endCol=4로 배치된다', () => {
+    // given: 월~수에 걸치는 같은 이벤트
+    const ev = makeScheduleEvent('s1', 'Conference')
+    const eventsByDate = new Map<string, CalendarEvent[]>([
+      ['2026-03-02', [ev]], // Mon = col 2
+      ['2026-03-03', [ev]], // Tue = col 3
+      ['2026-03-04', [ev]], // Wed = col 4
+    ])
+
+    // when
+    const result = buildWeekEventStack(weekDays, eventsByDate)
+
+    // then: 1행, span 2~4
+    expect(result.rows.length).toBe(1)
+    expect(result.rows[0].length).toBe(1)
+    expect(result.rows[0][0].startCol).toBe(2)
+    expect(result.rows[0][0].endCol).toBe(4)
+    expect(result.rows[0][0].event.event.uuid).toBe('s1')
+  })
+
+  it('겹치는 이벤트 2개는 서로 다른 행에 배치된다', () => {
+    // given: 화요일에 2개의 서로 다른 이벤트
+    const ev1 = makeTodoEvent('t1', 'Task A')
+    const ev2 = makeTodoEvent('t2', 'Task B')
+    const eventsByDate = new Map<string, CalendarEvent[]>([
+      ['2026-03-03', [ev1, ev2]], // 둘 다 화요일
+    ])
+
+    // when
+    const result = buildWeekEventStack(weekDays, eventsByDate)
+
+    // then: 2행, 각각 1이벤트
+    expect(result.rows.length).toBe(2)
+    const allUuids = result.rows.map(row => row.map(e => e.event.event.uuid)).flat()
+    expect(allUuids).toContain('t1')
+    expect(allUuids).toContain('t2')
+  })
+
+  it('겹치지 않는 이벤트 2개는 같은 행에 배치된다', () => {
+    // given: 월요일에 ev1, 금요일에 ev2 (겹치지 않음)
+    const ev1 = makeTodoEvent('t1', 'Morning task')
+    const ev2 = makeTodoEvent('t2', 'Evening task')
+    const eventsByDate = new Map<string, CalendarEvent[]>([
+      ['2026-03-02', [ev1]], // Mon = col 2
+      ['2026-03-06', [ev2]], // Fri = col 6
+    ])
+
+    // when
+    const result = buildWeekEventStack(weekDays, eventsByDate)
+
+    // then: 1행에 2이벤트
+    expect(result.rows.length).toBe(1)
+    expect(result.rows[0].length).toBe(2)
+  })
+
+  it('긴 이벤트가 먼저 배치되고, 짧은 이벤트가 빈 공간에 채워진다', () => {
+    // given: 월~금 이벤트 + 토 이벤트
+    const longEv = makeScheduleEvent('s1', 'Long event')
+    const shortEv = makeTodoEvent('t1', 'Short event')
+    const eventsByDate = new Map<string, CalendarEvent[]>([
+      ['2026-03-02', [longEv]],           // Mon
+      ['2026-03-03', [longEv]],           // Tue
+      ['2026-03-04', [longEv]],           // Wed
+      ['2026-03-05', [longEv]],           // Thu
+      ['2026-03-06', [longEv]],           // Fri
+      ['2026-03-07', [shortEv]],          // Sat
+    ])
+
+    // when
+    const result = buildWeekEventStack(weekDays, eventsByDate)
+
+    // then: 1행에 2이벤트 (긴 것 + 토요일 것), 긴 것이 먼저
+    expect(result.rows.length).toBe(1)
+    expect(result.rows[0].length).toBe(2)
+    // 긴 이벤트: col 2~6, 짧은 이벤트: col 7
+    const sorted = [...result.rows[0]].sort((a, b) => a.startCol - b.startCol)
+    expect(sorted[0].event.event.uuid).toBe('s1')
+    expect(sorted[0].startCol).toBe(2)
+    expect(sorted[0].endCol).toBe(6)
+    expect(sorted[1].event.event.uuid).toBe('t1')
+    expect(sorted[1].startCol).toBe(7)
+    expect(sorted[1].endCol).toBe(7)
+  })
+
+  it('복잡한 케이스: 여러 이벤트가 올바르게 스택된다', () => {
+    // given:
+    //   A: 일~수 (col 1~4)
+    //   B: 수~토 (col 4~7) — A와 수요일 겹침
+    //   C: 금 (col 6) — B와 겹침
+    //   D: 일 (col 1) — A와 겹침
+    const evA = makeScheduleEvent('A', 'Event A')
+    const evB = makeScheduleEvent('B', 'Event B')
+    const evC = makeTodoEvent('C', 'Event C')
+    const evD = makeTodoEvent('D', 'Event D')
+    const eventsByDate = new Map<string, CalendarEvent[]>([
+      ['2026-03-01', [evA, evD]],         // Sun: A, D
+      ['2026-03-02', [evA]],              // Mon: A
+      ['2026-03-03', [evA]],              // Tue: A
+      ['2026-03-04', [evA, evB]],         // Wed: A, B
+      ['2026-03-05', [evB]],              // Thu: B
+      ['2026-03-06', [evB, evC]],         // Fri: B, C
+      ['2026-03-07', [evB]],              // Sat: B
+    ])
+
+    // when
+    const result = buildWeekEventStack(weekDays, eventsByDate)
+
+    // then: A(4일), B(4일)가 길어서 먼저 배치
+    // A와 B는 수요일에 겹침 → 다른 행
+    // D(1일)는 A와 일요일 겹침 → A와 다른 행, B와 겹치지 않으면 같은 행 가능? D는 col1, B는 col4~7 → 겹치지 않음 → B와 같은 행
+    // C(1일)는 B와 금요일 겹침 → B와 다른 행, A와 겹치지 않으면 같은 행 가능? C는 col6, A는 col1~4 → 겹치지 않음 → A와 같은 행
+
+    // 최소 2행
+    expect(result.rows.length).toBeGreaterThanOrEqual(2)
+
+    // 모든 이벤트가 포함되어야 함
+    const allUuids = result.rows.flatMap(row => row.map(e => e.event.event.uuid))
+    expect(allUuids).toContain('A')
+    expect(allUuids).toContain('B')
+    expect(allUuids).toContain('C')
+    expect(allUuids).toContain('D')
+
+    // A와 B는 같은 행에 있으면 안 됨 (겹침)
+    const rowOfA = result.rows.findIndex(row => row.some(e => e.event.event.uuid === 'A'))
+    const rowOfB = result.rows.findIndex(row => row.some(e => e.event.event.uuid === 'B'))
+    expect(rowOfA).not.toBe(rowOfB)
+  })
+
+  it('동일 이벤트가 여러 날짜에 중복 등록되어도 uuid 기준 dedup된다', () => {
+    // given: 같은 uuid의 이벤트가 3일에 걸쳐 등록
+    const ev = makeTodoEvent('t1', 'Duplicated')
+    const eventsByDate = new Map<string, CalendarEvent[]>([
+      ['2026-03-02', [ev]],
+      ['2026-03-03', [ev]],
+      ['2026-03-04', [ev]],
+    ])
+
+    // when
+    const result = buildWeekEventStack(weekDays, eventsByDate)
+
+    // then: 1개의 이벤트만 결과에 존재
+    const allUuids = result.rows.flatMap(row => row.map(e => e.event.event.uuid))
+    expect(allUuids.filter(u => u === 't1').length).toBe(1)
+  })
+
+  it('주 경계를 넘는 이벤트는 해당 주 범위로 클램핑된다', () => {
+    // given: 이벤트가 이전 주부터 이번 주 화요일까지 걸쳐있지만
+    //        eventsByDate에는 이번 주 날짜만 존재
+    const ev = makeScheduleEvent('s1', 'Clamped event')
+    const eventsByDate = new Map<string, CalendarEvent[]>([
+      ['2026-03-01', [ev]], // Sun = col 1 (주 시작)
+      ['2026-03-02', [ev]], // Mon = col 2
+      ['2026-03-03', [ev]], // Tue = col 3
+    ])
+
+    // when
+    const result = buildWeekEventStack(weekDays, eventsByDate)
+
+    // then: startCol=1, endCol=3
+    expect(result.rows.length).toBe(1)
+    expect(result.rows[0][0].startCol).toBe(1)
+    expect(result.rows[0][0].endCol).toBe(3)
+  })
+
+  it('행 정렬: 커버하는 총 일수가 많은 행이 위에 온다', () => {
+    // given:
+    //   row1에 1일짜리 이벤트 2개 (총 2일 커버)
+    //   row2에 5일짜리 이벤트 1개 (총 5일 커버)
+    const short1 = makeTodoEvent('s1', 'Short 1')
+    const short2 = makeTodoEvent('s2', 'Short 2')
+    const long1 = makeScheduleEvent('l1', 'Long one')
+    const eventsByDate = new Map<string, CalendarEvent[]>([
+      ['2026-03-01', [short1, long1]],  // Sun: short1, long1
+      ['2026-03-02', [long1]],          // Mon
+      ['2026-03-03', [long1]],          // Tue
+      ['2026-03-04', [long1]],          // Wed
+      ['2026-03-05', [long1]],          // Thu
+      ['2026-03-07', [short2]],         // Sat: short2
+    ])
+
+    // when
+    const result = buildWeekEventStack(weekDays, eventsByDate)
+
+    // then: 긴 이벤트가 먼저 배치되므로 첫 행에 long1 포함
+    const firstRowUuids = result.rows[0].map(e => e.event.event.uuid)
+    expect(firstRowUuids).toContain('l1')
+  })
+})


### PR DESCRIPTION
## Summary
- **weekEventStackBuilder**: 주(week) 단위 greedy bin-packing 알고리즘 구현. 긴 이벤트 우선 배치, 좌/우 빈 공간에 재귀적으로 채움. uuid 기준 dedup 포함.
- **MainCalendarGrid 리라이트**: 날짜별 분절 표시에서 CSS Grid `gridColumn` span 기반 다일 이벤트 연속 표시로 변경. 셀 높이 초과 시 "+N more" 축약. 모바일은 기존 dots 유지.

## Test plan
- [x] weekEventStackBuilder 단위 테스트 10개 통과 (빈 주, 단일/다일 이벤트, 겹침/비겹침, 복잡한 스택, dedup, 클램핑, 행 정렬)
- [x] 기존 MainCalendarGrid 테스트 6개 통과 (요일 헤더, 셀 수, 날짜 선택, 이벤트 바, 클릭 이벤트)
- [x] 전체 테스트 스위트 313개 통과
- [ ] E2E 테스트로 다일 이벤트 스팬 렌더링 확인

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)