### PR TITLE
#25 fix: 우측 패널 iOS 디자인 및 정렬 로직 적용

### DIFF
--- a/src/components/CurrentTodoList.tsx
+++ b/src/components/CurrentTodoList.tsx
@@ -93,26 +93,26 @@ export function CurrentTodoList({ showHeader = true }: CurrentTodoListProps) {
             ? (getColorForTagId(todo.event_tag_id) ?? '#9ca3af')
             : '#9ca3af'
           return (
-            <li key={todo.uuid} className="flex items-center gap-2 px-3 py-2">
+            <li key={todo.uuid} className="flex items-stretch gap-3 rounded-lg px-3 py-2.5 hover:bg-gray-50">
+              <div className="w-1 shrink-0 rounded-full" style={{ backgroundColor: color }} />
               <input
                 type="checkbox"
                 aria-label={todo.name}
-                className="h-4 w-4 rounded border-gray-300"
+                className="h-4 w-4 rounded border-gray-300 self-center shrink-0"
                 onChange={() => handleComplete(todo)}
               />
               <button
-                className="flex flex-1 items-center gap-2 rounded text-left hover:bg-gray-50"
+                className="flex flex-1 items-center min-w-0 rounded text-left"
                 onClick={() => navigate(`/events/${todo.uuid}?type=todo`, {
                   state: { background: location, eventType: 'todo' },
                 })}
               >
-                <span className="h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: color }} />
-                <span className="truncate text-sm text-gray-900">{todo.name}</span>
+                <span className="truncate text-sm font-medium text-[#323232]">{todo.name}</span>
               </button>
               {todo.repeating && (
                 <button
                   onClick={() => handleSkip(todo)}
-                  className="shrink-0 text-xs text-gray-400 hover:text-gray-600"
+                  className="shrink-0 text-xs text-[#969696] hover:text-gray-600 self-center"
                 >
                   {t('todo.skip')}
                 </button>

--- a/src/components/DayEventList.tsx
+++ b/src/components/DayEventList.tsx
@@ -82,11 +82,7 @@ export function DayEventList({ selectedDate }: DayEventListProps) {
     return et.period_start
   }
 
-  const todos = allEvents.filter(e => e.type === 'todo')
-  const schedules = allEvents.filter(e => e.type === 'schedule')
-  todos.sort((a, b) => getTimestamp(a) - getTimestamp(b))
-  schedules.sort((a, b) => getTimestamp(a) - getTimestamp(b))
-  const sorted = [...todos, ...schedules]
+  const sorted = [...allEvents].sort((a, b) => getTimestamp(a) - getTimestamp(b))
 
   return (
     <div>

--- a/src/components/DayEventList.tsx
+++ b/src/components/DayEventList.tsx
@@ -23,16 +23,13 @@ function EventItem({ calEvent, onNavigate }: { calEvent: CalendarEvent; onNaviga
   const editPath = calEvent.type === 'todo' ? `/todos/${uuid}/edit` : `/schedules/${uuid}/edit`
 
   return (
-    <div className="relative flex w-full items-start gap-3 rounded-lg px-3 py-2 hover:bg-gray-50">
-      <button className="flex flex-1 items-start gap-3 text-left" onClick={onNavigate}>
-        <span
-          className="mt-1 h-3 w-3 shrink-0 rounded-full"
-          style={{ backgroundColor: color }}
-        />
+    <div className="relative flex w-full items-stretch gap-3 rounded-lg px-3 py-2.5 hover:bg-gray-50">
+      <div className="w-1 shrink-0 rounded-full" style={{ backgroundColor: color }} />
+      <button className="flex flex-1 items-start text-left min-w-0" onClick={onNavigate}>
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-medium text-gray-900">{name}</p>
+          <p className="truncate text-sm font-medium text-[#323232]">{name}</p>
           {event_time && (
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-[#969696]">
               <EventTimeDisplay eventTime={event_time} />
             </p>
           )}
@@ -40,7 +37,7 @@ function EventItem({ calEvent, onNavigate }: { calEvent: CalendarEvent; onNaviga
       </button>
       <button
         aria-label={t('common.menu')}
-        className="shrink-0 rounded p-1 text-gray-400 hover:bg-gray-100"
+        className="shrink-0 rounded p-1 text-gray-400 hover:bg-gray-100 self-center"
         onClick={e => { e.stopPropagation(); setMenuOpen(o => !o) }}
       >
         ···

--- a/src/components/ForemostEventBanner.tsx
+++ b/src/components/ForemostEventBanner.tsx
@@ -26,24 +26,21 @@ export function ForemostEventBanner() {
   return (
     <button
       data-testid="foremost-banner"
-      className="flex w-full items-start gap-3 rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 text-left hover:bg-blue-100"
+      className="flex w-full items-stretch gap-3 rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 text-left hover:bg-blue-100"
       onClick={() => navigate(`/events/${event.uuid}?type=${eventType}`, {
         state: { background: location, eventType },
       })}
     >
-      <span
-        className="mt-0.5 h-3 w-3 shrink-0 rounded-full"
-        style={{ backgroundColor: color }}
-      />
+      <div className="w-1 shrink-0 rounded-full" style={{ backgroundColor: color }} />
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-semibold text-gray-900">{event.name}</p>
+        <p className="truncate text-sm font-semibold text-[#323232]">{event.name}</p>
         {eventTime && (
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-[#969696]">
             <EventTimeDisplay eventTime={eventTime} />
           </p>
         )}
       </div>
-      <span className="text-xs text-blue-400">{t('event.pinned')}</span>
+      <span className="text-xs text-blue-400 self-center">{t('event.pinned')}</span>
     </button>
   )
 }

--- a/src/components/RightEventPanel.tsx
+++ b/src/components/RightEventPanel.tsx
@@ -16,8 +16,8 @@ export function RightEventPanel() {
   const dateLocale = i18n.language === 'en' ? 'en-US' : 'ko-KR'
 
   return (
-    <div className="w-80 shrink-0 border-l border-border-calendar bg-surface-alt flex flex-col">
-      <ScrollArea className="flex-1">
+    <div className="w-80 shrink-0 border-l border-border-calendar bg-surface-alt flex flex-col h-full overflow-hidden">
+      <ScrollArea className="flex-1 overflow-y-auto">
         <div className="p-6">
           <h1 className="text-xl font-bold text-text-primary mb-6">{t('main.events_title')}</h1>
           {foremostEvent && (

--- a/src/components/UncompletedTodoList.tsx
+++ b/src/components/UncompletedTodoList.tsx
@@ -84,26 +84,26 @@ export function UncompletedTodoList() {
             ? (getColorForTagId(todo.event_tag_id) ?? '#9ca3af')
             : '#9ca3af'
           return (
-            <li key={todo.uuid} className="flex items-center gap-2 px-3 py-2">
+            <li key={todo.uuid} className="flex items-stretch gap-3 rounded-lg px-3 py-2.5 hover:bg-gray-50">
+              <div className="w-1 shrink-0 rounded-full" style={{ backgroundColor: color }} />
               <input
                 type="checkbox"
                 aria-label={todo.name}
-                className="h-4 w-4 rounded border-gray-300"
+                className="h-4 w-4 rounded border-gray-300 self-center shrink-0"
                 onChange={() => handleComplete(todo)}
               />
               <button
-                className="flex flex-1 items-center gap-2 rounded text-left hover:bg-gray-50"
+                className="flex flex-1 items-center min-w-0 rounded text-left"
                 onClick={() => navigate(`/events/${todo.uuid}?type=todo`, {
                   state: { background: location, eventType: 'todo' },
                 })}
               >
-                <span className="h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: color }} />
-                <span className="truncate text-sm text-gray-900">{todo.name}</span>
+                <span className="truncate text-sm font-medium text-[#323232]">{todo.name}</span>
               </button>
               {todo.repeating && (
                 <button
                   onClick={() => handleSkip(todo)}
-                  className="shrink-0 text-xs text-gray-400 hover:text-gray-600"
+                  className="shrink-0 text-xs text-[#969696] hover:text-gray-600 self-center"
                 >
                   {t('todo.skip')}
                 </button>

--- a/tests/components/DayEventList.test.tsx
+++ b/tests/components/DayEventList.test.tsx
@@ -56,13 +56,15 @@ describe('DayEventList', () => {
     expect(screen.getByText('이벤트가 없습니다')).toBeInTheDocument()
   })
 
-  it('Todo와 Schedule 이벤트를 Todo 먼저, Schedule 순으로 표시한다', () => {
-    const todo = { uuid: 't1', name: '할 일', is_current: false, event_time: null }
-    const schedule = { uuid: 's1', name: '일정', event_time: { time_type: 'at' as const, timestamp: 1710480600 } }
+  it('이벤트를 시간순으로 혼합 정렬하여 표시한다', () => {
+    const todoEarly = { uuid: 't1', name: '아침 할 일', is_current: false, event_time: { time_type: 'at' as const, timestamp: 1710468000 } }
+    const scheduleMid = { uuid: 's1', name: '점심 일정', event_time: { time_type: 'at' as const, timestamp: 1710480600 } }
+    const todoLate = { uuid: 't2', name: '저녁 할 일', is_current: false, event_time: { time_type: 'at' as const, timestamp: 1710504000 } }
     const eventsByDate = new Map([
       ['2024-03-15', [
-        { type: 'schedule' as const, event: schedule },
-        { type: 'todo' as const, event: todo },
+        { type: 'todo' as const, event: todoLate },
+        { type: 'schedule' as const, event: scheduleMid },
+        { type: 'todo' as const, event: todoEarly },
       ]],
     ])
 
@@ -71,8 +73,28 @@ describe('DayEventList', () => {
     renderComponent(new Date(2024, 2, 15))
 
     const listItems = screen.getAllByRole('listitem')
-    expect(listItems[0]).toHaveTextContent('할 일')
-    expect(listItems[1]).toHaveTextContent('일정')
+    expect(listItems[0]).toHaveTextContent('아침 할 일')
+    expect(listItems[1]).toHaveTextContent('점심 일정')
+    expect(listItems[2]).toHaveTextContent('저녁 할 일')
+  })
+
+  it('시간이 없는 이벤트는 목록 끝에 표시한다', () => {
+    const todoNoTime = { uuid: 't1', name: '시간 없는 할 일', is_current: false, event_time: null }
+    const scheduleWithTime = { uuid: 's1', name: '시간 있는 일정', event_time: { time_type: 'at' as const, timestamp: 1710480600 } }
+    const eventsByDate = new Map([
+      ['2024-03-15', [
+        { type: 'todo' as const, event: todoNoTime },
+        { type: 'schedule' as const, event: scheduleWithTime },
+      ]],
+    ])
+
+    mockCalendarEventsStore(eventsByDate)
+
+    renderComponent(new Date(2024, 2, 15))
+
+    const listItems = screen.getAllByRole('listitem')
+    expect(listItems[0]).toHaveTextContent('시간 있는 일정')
+    expect(listItems[1]).toHaveTextContent('시간 없는 할 일')
   })
 
   it('이벤트를 클릭하면 해당 이벤트 상세 페이지로 이동한다', async () => {


### PR DESCRIPTION
## Summary
- 이벤트 아이템 디자인을 iOS 앱 스타일로 변경: 원형 dot -> 세로 컬러 바(w-1, rounded-full)
- DayEventList, CurrentTodoList, UncompletedTodoList, ForemostEventBanner 디자인 통일
- 이벤트 정렬을 타입별 분리(todo -> schedule)에서 시간순 혼합 정렬로 변경
- RightEventPanel 스크롤 영역 overflow 보강 (이벤트 리스트 스크롤 + 하단 고정)

## Test plan
- [x] DayEventList 시간순 혼합 정렬 테스트 추가 및 통과
- [x] 시간 없는 이벤트 후순위 배치 테스트 추가 및 통과
- [x] 전체 테스트 281개 통과 (기존 Firebase 키 관련 5개 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)