### PR TITLE
#22 fix: 캘린더 레이아웃 버그 수정 및 셀 디자인 변경

### DIFF
--- a/src/calendar/MainCalendarGrid.tsx
+++ b/src/calendar/MainCalendarGrid.tsx
@@ -19,7 +19,11 @@ const EVENT_ROW_GAP = 2
 // 날짜 숫자 영역 높이(px)
 const DATE_NUMBER_HEIGHT = 28
 // 날짜 숫자 아래 이벤트 바 시작 오프셋(px)
-const EVENT_AREA_TOP_OFFSET = 8
+const EVENT_AREA_TOP_OFFSET = 4
+
+// 셀 강조 색상 (iOS 레퍼런스)
+const SELECTED_BG = '#303646'
+const TODAY_BG = '#f4f4f4'
 
 interface MainCalendarGridProps {
   days: CalendarDay[]
@@ -64,16 +68,18 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
   )
 
   // 표시 가능한 이벤트 행 수 계산
-  const maxVisibleRows = Math.max(1, Math.floor((rowHeight - DATE_NUMBER_HEIGHT) / (EVENT_ROW_HEIGHT + EVENT_ROW_GAP)))
+  const maxVisibleRows = Math.max(1, Math.floor((rowHeight - DATE_NUMBER_HEIGHT - EVENT_AREA_TOP_OFFSET) / (EVENT_ROW_HEIGHT + EVENT_ROW_GAP)))
+
+  const totalWeeks = weeks.length
 
   return (
     <div className="flex h-full flex-col">
-      {/* 요일 헤더 */}
+      {/* 요일 헤더 — 하단 보더만, 외곽 보더 없음 */}
       <div className="grid grid-cols-7 border-b border-border-calendar shrink-0">
         {WEEKDAY_KEYS.map((key, i) => (
           <div
             key={key}
-            className={`px-3 py-3 text-xs font-medium uppercase tracking-wide ${i === 0 ? 'text-red-400' : 'text-text-secondary'}`}
+            className={`px-3 py-2 text-xs font-medium uppercase tracking-wide ${i === 0 ? 'text-red-400' : 'text-text-secondary'}`}
           >
             {t(`calendar.weekdays.${key}`, key.toUpperCase())}
           </div>
@@ -88,71 +94,81 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
           const hiddenCount = stack.rows.length > maxVisibleRows
             ? stack.rows.slice(maxVisibleRows).reduce((sum, row) => sum + row.length, 0)
             : 0
+          const isLastWeek = wi === totalWeeks - 1
 
           return (
-            <div key={wi} className="flex-1 min-h-0 relative" style={{ minHeight: `${rowHeight}px` }}>
-              {/* 날짜 숫자 행 */}
-              <div className="grid grid-cols-7">
-                {weekDays.map((day, di) => {
-                  const isSelected = selectedDate && formatDateKey(selectedDate) === day.dateKey
-                  const holidayNames = getHolidayNames(day.dateKey)
-                  const isHoliday = holidayNames.length > 0
-                  const isSunday = day.date.getDay() === 0
+            // flex-1로 균등 높이 분배, 마지막 주는 border-b 없음
+            <div
+              key={wi}
+              className={`flex-1 relative grid grid-cols-7 ${!isLastWeek ? 'border-b border-border-calendar' : ''}`}
+              style={{ minHeight: `${rowHeight}px` }}
+            >
+              {weekDays.map((day, di) => {
+                const isSelected = selectedDate != null && formatDateKey(selectedDate) === day.dateKey
+                const holidayNames = getHolidayNames(day.dateKey)
+                const isHoliday = holidayNames.length > 0
+                const isSunday = day.date.getDay() === 0
+                const isLastCol = di === 6
 
-                  // 해당 날짜의 이벤트 (모바일 dots용)
-                  const dayEvents = (filteredEventsByDate.get(day.dateKey) ?? [])
-                  const dotColors: string[] = []
-                  for (const ev of dayEvents.slice(0, 3)) {
-                    const tagId = ev.event.event_tag_id
-                    const color = tagId ? getColorForTagId(tagId) : undefined
-                    dotColors.push(color ?? '#9ca3af')
-                  }
+                // 해당 날짜의 이벤트 (모바일 dots용)
+                const dayEvents = filteredEventsByDate.get(day.dateKey) ?? []
+                const dotColors: string[] = []
+                for (const ev of dayEvents.slice(0, 3)) {
+                  const tagId = ev.event.event_tag_id
+                  const color = tagId ? getColorForTagId(tagId) : undefined
+                  dotColors.push(color ?? '#9ca3af')
+                }
 
-                  const textColor = day.isToday
-                    ? 'font-semibold text-white'
+                // 셀 배경 결정
+                const cellBg = isSelected
+                  ? SELECTED_BG
+                  : day.isToday
+                    ? TODAY_BG
+                    : undefined
+
+                // 날짜 텍스트 색 결정
+                const dateTextColor = isSelected
+                  ? 'text-white'
+                  : day.isToday
+                    ? 'text-[#323232] font-semibold'
                     : !day.isCurrentMonth
                       ? 'text-gray-300'
                       : (isHoliday || isSunday)
                         ? 'text-red-500'
-                        : 'text-text-primary'
+                        : 'text-[#323232]'
 
-                  const selectedClass = isSelected && !day.isToday ? 'ring-2 ring-brand-dark rounded-full' : ''
-
-                  return (
-                    <div
-                      key={di}
-                      className={`flex flex-col p-2 cursor-pointer border-r border-b border-border-calendar hover:bg-gray-50 ${!day.isCurrentMonth ? 'bg-surface-alt' : ''}`}
-                      data-testid="day-cell"
-                      style={{ minHeight: `${rowHeight}px`, fontSize: `${fontSize}px` }}
-                      onClick={() => setSelectedDate(day.date)}
-                      title={holidayNames.join(', ') || undefined}
-                    >
-                      {day.isToday ? (
-                        <div className="flex h-7 w-7 items-center justify-center rounded-full bg-brand-dark text-white font-semibold text-sm">
-                          {day.dayOfMonth}
-                        </div>
-                      ) : (
-                        <div className={`flex h-7 w-7 items-center justify-center text-sm font-medium ${textColor} ${selectedClass}`}>
-                          {day.dayOfMonth}
-                        </div>
-                      )}
-
-                      {/* Mobile: dots */}
-                      {dotColors.length > 0 && (
-                        <div className="md:hidden mt-0.5 flex gap-0.5" data-testid="event-dots">
-                          {dotColors.map((color, j) => (
-                            <span
-                              key={j}
-                              className="inline-block h-1 w-1 rounded-full"
-                              style={{ backgroundColor: color }}
-                            />
-                          ))}
-                        </div>
-                      )}
+                return (
+                  <div
+                    key={di}
+                    className={`flex flex-col pt-1.5 px-1.5 pb-1 cursor-pointer hover:brightness-95 transition-[filter] ${isLastCol ? '' : 'border-r border-border-calendar'} ${!day.isCurrentMonth && !isSelected ? 'bg-surface-alt' : ''}`}
+                    data-testid="day-cell"
+                    style={{
+                      backgroundColor: cellBg,
+                      fontSize: `${fontSize}px`,
+                    }}
+                    onClick={() => setSelectedDate(day.date)}
+                    title={holidayNames.join(', ') || undefined}
+                  >
+                    {/* 날짜 숫자 */}
+                    <div className={`flex h-7 w-7 items-center justify-center text-sm font-medium ${dateTextColor}`}>
+                      {day.dayOfMonth}
                     </div>
-                  )
-                })}
-              </div>
+
+                    {/* Mobile: dots */}
+                    {dotColors.length > 0 && (
+                      <div className="md:hidden mt-0.5 flex gap-0.5" data-testid="event-dots">
+                        {dotColors.map((color, j) => (
+                          <span
+                            key={j}
+                            className="inline-block h-1 w-1 rounded-full"
+                            style={{ backgroundColor: color }}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
 
               {/* Desktop: 이벤트 스팬 행들 (날짜 숫자 아래 절대 위치) */}
               <div

--- a/tests/calendar/MainCalendarGrid.test.tsx
+++ b/tests/calendar/MainCalendarGrid.test.tsx
@@ -148,4 +148,50 @@ describe('MainCalendarGrid', () => {
     const selected = useUiStore.getState().selectedDate
     expect(selected).toBeNull()
   })
+
+  describe('셀 배경 강조 디자인', () => {
+    it('선택된 날 셀 전체에 선택 배경색(#303646)이 적용된다', () => {
+      // given: 3월 10일을 선택된 날로 설정
+      const march10 = marchDays.find(d => d.isCurrentMonth && d.dayOfMonth === 10)!
+      useUiStore.setState({ selectedDate: march10.date })
+
+      // when: MainCalendarGrid 렌더
+      render(<MainCalendarGrid days={marchDays} />)
+
+      // then: 선택된 날 셀에 선택 배경색이 적용된다
+      const cells = screen.getAllByTestId('day-cell')
+      const march10Index = marchDays.findIndex(d => d.isCurrentMonth && d.dayOfMonth === 10)
+      const selectedCell = cells[march10Index]
+      expect(selectedCell).toHaveStyle({ backgroundColor: '#303646' })
+    })
+
+    it('오늘 셀 전체에 오늘 배경색(#f4f4f4)이 적용된다', () => {
+      // given: 오늘(2026-03-15)이 포함된 캘린더, 아무것도 선택 안 됨
+      useUiStore.setState({ selectedDate: null })
+
+      // when: MainCalendarGrid 렌더
+      render(<MainCalendarGrid days={marchDays} />)
+
+      // then: 오늘 셀에 오늘 배경색이 적용된다
+      const cells = screen.getAllByTestId('day-cell')
+      const todayIndex = marchDays.findIndex(d => d.isToday)
+      const todayCell = cells[todayIndex]
+      expect(todayCell).toHaveStyle({ backgroundColor: '#f4f4f4' })
+    })
+
+    it('선택되지 않은 일반 날 셀에는 강조 배경색이 없다', () => {
+      // given: 아무것도 선택되지 않은 상태
+      useUiStore.setState({ selectedDate: null })
+
+      // when: MainCalendarGrid 렌더
+      render(<MainCalendarGrid days={marchDays} />)
+
+      // then: 3월 10일(일반 날) 셀에는 선택/오늘 배경색이 없다
+      const cells = screen.getAllByTestId('day-cell')
+      const march10Index = marchDays.findIndex(d => d.isCurrentMonth && d.dayOfMonth === 10)
+      const normalCell = cells[march10Index]
+      expect(normalCell).not.toHaveStyle({ backgroundColor: '#303646' })
+      expect(normalCell).not.toHaveStyle({ backgroundColor: '#f4f4f4' })
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- 레이아웃 버그 수정: 주 컨테이너를 `grid grid-cols-7`로 변환해 날짜 셀이 주 높이를 직접 채우도록 수정 (중첩된 날짜 숫자 grid + 절대 위치 이벤트 오버레이 구조 유지)
- 외곽 보더 정리: 마지막 주 `border-b` 제거, 마지막 열 `border-r` 제거 (구글 캘린더 스타일 — 내부 격자만)
- 셀 전체 강조 디자인: 날짜 숫자 원형 배경 대신 셀 전체 배경색으로 변경
  - 선택된 날: `#303646` (iOS selectedDayBackground)
  - 오늘 (미선택): `#f4f4f4` (iOS todayBackground)
  - 일반/다른 달: 기존 유지

## Test plan

- [x] 기존 MainCalendarGrid 테스트 전체 통과 (290 passed)
- [x] 선택된 날 셀 배경색 `#303646` 검증 테스트 추가
- [x] 오늘 셀 배경색 `#f4f4f4` 검증 테스트 추가
- [x] 일반 날 강조 배경 없음 검증 테스트 추가
- [x] TypeScript 타입 체크 통과

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)