### PR TITLE
#21 fix: 기본/공휴일 태그 항상 표시

### DIFF
--- a/src/components/CalendarList.tsx
+++ b/src/components/CalendarList.tsx
@@ -1,9 +1,11 @@
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useLocation } from 'react-router-dom'
-import { useEventTagStore } from '../stores/eventTagStore'
+import { useEventTagStore, DEFAULT_TAG_ID, HOLIDAY_TAG_ID } from '../stores/eventTagStore'
 import { useTagFilterStore } from '../stores/tagFilterStore'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Button } from '@/components/ui/button'
+import type { EventTag } from '../models'
 
 export default function CalendarList() {
   const { t } = useTranslation()
@@ -11,8 +13,20 @@ export default function CalendarList() {
   const location = useLocation()
 
   const tags = useEventTagStore(s => s.tags)
+  const defaultTagColors = useEventTagStore(s => s.defaultTagColors)
   const hiddenTagIds = useTagFilterStore(s => s.hiddenTagIds)
   const toggleTag = useTagFilterStore(s => s.toggleTag)
+
+  const allTags = useMemo<EventTag[]>(() => {
+    const defaultTags: EventTag[] = [
+      { uuid: DEFAULT_TAG_ID, name: t('tag.default_name', '기본'), color_hex: defaultTagColors?.default },
+      { uuid: HOLIDAY_TAG_ID, name: t('tag.holiday_name', '공휴일'), color_hex: defaultTagColors?.holiday },
+    ]
+    const userTags = Array.from(tags.values()).filter(
+      tag => tag.uuid !== DEFAULT_TAG_ID && tag.uuid !== HOLIDAY_TAG_ID
+    )
+    return [...defaultTags, ...userTags]
+  }, [tags, defaultTagColors, t])
 
   return (
     <div className="flex flex-col">
@@ -21,7 +35,7 @@ export default function CalendarList() {
       </p>
 
       <div className="flex flex-col gap-1">
-        {Array.from(tags.values()).map(tag => {
+        {allTags.map(tag => {
           const hidden = hiddenTagIds.has(tag.uuid)
           const color = tag.color_hex ?? '#9ca3af'
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -78,6 +78,8 @@
   "settings.account_delete_failed": "Failed to delete account",
   "settings.delete_account_confirm": "Deleting your account will erase all data. Continue?",
   "settings.current_tz": "Current: {{tz}}",
+  "tag.default_name": "Default",
+  "tag.holiday_name": "Holiday",
   "tag.manage": "Manage Tags",
   "tag.new_placeholder": "New tag name",
   "tag.add": "Add",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -78,6 +78,8 @@
   "settings.account_delete_failed": "계정 삭제에 실패했습니다",
   "settings.delete_account_confirm": "계정을 삭제하면 모든 데이터가 사라집니다. 계속할까요?",
   "settings.current_tz": "현재: {{tz}}",
+  "tag.default_name": "기본",
+  "tag.holiday_name": "공휴일",
   "tag.manage": "태그 관리",
   "tag.new_placeholder": "새 태그 이름",
   "tag.add": "추가",

--- a/src/stores/eventTagStore.ts
+++ b/src/stores/eventTagStore.ts
@@ -1,12 +1,18 @@
 import { create } from 'zustand'
 import { eventTagApi } from '../api/eventTagApi'
+import { settingApi } from '../api/settingApi'
 import { useCalendarEventsStore } from './calendarEventsStore'
 import { useCurrentTodosStore } from './currentTodosStore'
 import { useUncompletedTodosStore } from './uncompletedTodosStore'
 import type { EventTag } from '../models'
+import type { DefaultTagColors } from '../models'
+
+export const DEFAULT_TAG_ID = 'default'
+export const HOLIDAY_TAG_ID = 'holiday'
 
 interface EventTagState {
   tags: Map<string, EventTag>
+  defaultTagColors: DefaultTagColors | null
   fetchAll: () => Promise<void>
   getColorForTagId: (id: string) => string | null | undefined
   createTag: (name: string, color_hex?: string) => Promise<EventTag>
@@ -18,20 +24,29 @@ interface EventTagState {
 
 export const useEventTagStore = create<EventTagState>((set, get) => ({
   tags: new Map(),
+  defaultTagColors: null,
 
   fetchAll: async () => {
     try {
-      const list = await eventTagApi.getAllTags()
+      const [list, defaultColors] = await Promise.all([
+        eventTagApi.getAllTags(),
+        settingApi.getDefaultTagColors(),
+      ])
       const map = new Map<string, EventTag>()
       for (const tag of list) map.set(tag.uuid, tag)
-      set({ tags: map })
+      set({ tags: map, defaultTagColors: defaultColors })
     } catch (e) {
       console.warn('태그 로드 실패:', e)
       throw e
     }
   },
 
-  getColorForTagId: (id: string) => get().tags.get(id)?.color_hex,
+  getColorForTagId: (id: string) => {
+    const { tags, defaultTagColors } = get()
+    if (id === DEFAULT_TAG_ID) return defaultTagColors?.default
+    if (id === HOLIDAY_TAG_ID) return defaultTagColors?.holiday
+    return tags.get(id)?.color_hex
+  },
 
   createTag: async (name: string, color_hex?: string) => {
     const tag = await eventTagApi.createTag({ name, color_hex })
@@ -63,5 +78,5 @@ export const useEventTagStore = create<EventTagState>((set, get) => ({
     useUncompletedTodosStore.getState().fetch().catch(() => {})
   },
 
-  reset: () => set({ tags: new Map() }),
+  reset: () => set({ tags: new Map(), defaultTagColors: null }),
 }))

--- a/tests/components/CalendarList.test.tsx
+++ b/tests/components/CalendarList.test.tsx
@@ -5,6 +5,9 @@ import CalendarList from '../../src/components/CalendarList'
 import { useEventTagStore } from '../../src/stores/eventTagStore'
 import { useTagFilterStore } from '../../src/stores/tagFilterStore'
 import type { EventTag } from '../../src/models'
+import type { DefaultTagColors } from '../../src/models'
+
+vi.mock('../../src/firebase', () => ({ auth: {} }))
 
 const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async () => {
@@ -16,6 +19,11 @@ const mockTags: EventTag[] = [
   { uuid: 'tag-1', name: '업무', color_hex: '#3b82f6' },
   { uuid: 'tag-2', name: '개인', color_hex: '#10b981' },
 ]
+
+const mockDefaultColors: DefaultTagColors = {
+  default: '#aaaaaa',
+  holiday: '#ff0000',
+}
 
 function renderCalendarList() {
   return render(
@@ -29,7 +37,7 @@ describe('CalendarList', () => {
   beforeEach(() => {
     mockNavigate.mockReset()
     const tagMap = new Map<string, EventTag>(mockTags.map(t => [t.uuid, t]))
-    useEventTagStore.setState({ tags: tagMap })
+    useEventTagStore.setState({ tags: tagMap, defaultTagColors: mockDefaultColors })
     useTagFilterStore.setState({ hiddenTagIds: new Set() })
   })
 
@@ -41,6 +49,44 @@ describe('CalendarList', () => {
     expect(screen.getByText('이벤트 종류')).toBeInTheDocument()
     expect(screen.getByText('업무')).toBeInTheDocument()
     expect(screen.getByText('개인')).toBeInTheDocument()
+  })
+
+  it('기본 태그와 공휴일 태그가 항상 상단에 표시된다', () => {
+    // given / when
+    renderCalendarList()
+
+    // then
+    expect(screen.getByText('기본')).toBeInTheDocument()
+    expect(screen.getByText('공휴일')).toBeInTheDocument()
+  })
+
+  it('태그가 없어도 기본/공휴일 태그는 표시된다', () => {
+    // given: 사용자 태그 없음
+    useEventTagStore.setState({ tags: new Map(), defaultTagColors: mockDefaultColors })
+
+    // when
+    renderCalendarList()
+
+    // then
+    expect(screen.getByText('기본')).toBeInTheDocument()
+    expect(screen.getByText('공휴일')).toBeInTheDocument()
+  })
+
+  it('기본/공휴일 태그는 사용자 태그보다 먼저 렌더된다', () => {
+    // given / when
+    renderCalendarList()
+
+    const allTagNames = screen.getAllByText(/기본|공휴일|업무|개인/).map(el => el.textContent)
+
+    // then: 기본, 공휴일이 업무/개인 앞에 온다
+    const defaultIdx = allTagNames.indexOf('기본')
+    const holidayIdx = allTagNames.indexOf('공휴일')
+    const workIdx = allTagNames.indexOf('업무')
+    const personalIdx = allTagNames.indexOf('개인')
+    expect(defaultIdx).toBeLessThan(workIdx)
+    expect(holidayIdx).toBeLessThan(workIdx)
+    expect(defaultIdx).toBeLessThan(personalIdx)
+    expect(holidayIdx).toBeLessThan(personalIdx)
   })
 
   it('태그 관리 링크가 렌더된다', () => {
@@ -98,9 +144,9 @@ describe('CalendarList', () => {
     expect(mockNavigate.mock.calls[0][0]).toBe('/tags')
   })
 
-  it('태그가 없으면 태그 행 없이 헤더만 표시한다', () => {
+  it('태그가 없으면 기본/공휴일 태그만 표시한다', () => {
     // given: 태그 없음
-    useEventTagStore.setState({ tags: new Map() })
+    useEventTagStore.setState({ tags: new Map(), defaultTagColors: mockDefaultColors })
 
     // when
     renderCalendarList()
@@ -108,5 +154,7 @@ describe('CalendarList', () => {
     // then
     expect(screen.getByText('이벤트 종류')).toBeInTheDocument()
     expect(screen.queryByText('업무')).not.toBeInTheDocument()
+    expect(screen.getByText('기본')).toBeInTheDocument()
+    expect(screen.getByText('공휴일')).toBeInTheDocument()
   })
 })

--- a/tests/stores/eventTagStore.test.ts
+++ b/tests/stores/eventTagStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { useEventTagStore } from '../../src/stores/eventTagStore'
+import { useEventTagStore, DEFAULT_TAG_ID, HOLIDAY_TAG_ID } from '../../src/stores/eventTagStore'
 
 vi.mock('../../src/firebase', () => ({ auth: {} }))
 
@@ -12,9 +12,15 @@ vi.mock('../../src/api/eventTagApi', () => ({
   },
 }))
 
+vi.mock('../../src/api/settingApi', () => ({
+  settingApi: {
+    getDefaultTagColors: vi.fn(),
+  },
+}))
+
 describe('eventTagStore', () => {
   beforeEach(() => {
-    useEventTagStore.setState({ tags: new Map() })
+    useEventTagStore.setState({ tags: new Map(), defaultTagColors: null })
     vi.clearAllMocks()
   })
 
@@ -28,10 +34,12 @@ describe('eventTagStore', () => {
   it('태그를 불러온 후 해당 태그의 ID로 색상을 조회할 수 있다', async () => {
     // given: API가 태그 목록을 반환한다
     const { eventTagApi } = await import('../../src/api/eventTagApi')
+    const { settingApi } = await import('../../src/api/settingApi')
     vi.mocked(eventTagApi.getAllTags).mockResolvedValue([
       { uuid: 'tag-1', name: 'Work', color_hex: '#ff0000' },
       { uuid: 'tag-2', name: 'Personal', color_hex: '#00ff00' },
     ])
+    vi.mocked(settingApi.getDefaultTagColors).mockResolvedValue({ default: '#aaaaaa', holiday: '#bbbbbb' })
 
     // when: 태그 목록을 불러온다
     await useEventTagStore.getState().fetchAll()
@@ -44,9 +52,11 @@ describe('eventTagStore', () => {
   it('존재하지 않는 태그 ID는 색상을 찾을 수 없다', async () => {
     // given: API가 특정 태그들을 반환한다
     const { eventTagApi } = await import('../../src/api/eventTagApi')
+    const { settingApi } = await import('../../src/api/settingApi')
     vi.mocked(eventTagApi.getAllTags).mockResolvedValue([
       { uuid: 'tag-1', name: 'Work', color_hex: '#ff0000' },
     ])
+    vi.mocked(settingApi.getDefaultTagColors).mockResolvedValue({ default: '#aaaaaa', holiday: '#bbbbbb' })
     await useEventTagStore.getState().fetchAll()
 
     // when: 등록되지 않은 ID로 색상 조회
@@ -57,9 +67,11 @@ describe('eventTagStore', () => {
   it('API 호출이 실패해도 이전에 불러온 태그 색상은 유지된다', async () => {
     // given: 태그가 이미 로드되어 있다
     const { eventTagApi } = await import('../../src/api/eventTagApi')
+    const { settingApi } = await import('../../src/api/settingApi')
     vi.mocked(eventTagApi.getAllTags).mockResolvedValue([
       { uuid: 'tag-1', name: 'Work', color_hex: '#ff0000' },
     ])
+    vi.mocked(settingApi.getDefaultTagColors).mockResolvedValue({ default: '#aaaaaa', holiday: '#bbbbbb' })
     await useEventTagStore.getState().fetchAll()
 
     // when: 재로드가 실패한다
@@ -71,13 +83,57 @@ describe('eventTagStore', () => {
   })
 })
 
+describe('eventTagStore — well-known 태그 ID 색상 처리', () => {
+  beforeEach(() => {
+    useEventTagStore.setState({ tags: new Map(), defaultTagColors: null })
+    vi.clearAllMocks()
+  })
+
+  it('fetchAll 후 default ID로 기본 태그 색상을 조회할 수 있다', async () => {
+    // given
+    const { eventTagApi } = await import('../../src/api/eventTagApi')
+    const { settingApi } = await import('../../src/api/settingApi')
+    vi.mocked(eventTagApi.getAllTags).mockResolvedValue([])
+    vi.mocked(settingApi.getDefaultTagColors).mockResolvedValue({ default: '#123456', holiday: '#abcdef' })
+
+    // when
+    await useEventTagStore.getState().fetchAll()
+
+    // then
+    expect(useEventTagStore.getState().getColorForTagId(DEFAULT_TAG_ID)).toBe('#123456')
+  })
+
+  it('fetchAll 후 holiday ID로 공휴일 태그 색상을 조회할 수 있다', async () => {
+    // given
+    const { eventTagApi } = await import('../../src/api/eventTagApi')
+    const { settingApi } = await import('../../src/api/settingApi')
+    vi.mocked(eventTagApi.getAllTags).mockResolvedValue([])
+    vi.mocked(settingApi.getDefaultTagColors).mockResolvedValue({ default: '#123456', holiday: '#abcdef' })
+
+    // when
+    await useEventTagStore.getState().fetchAll()
+
+    // then
+    expect(useEventTagStore.getState().getColorForTagId(HOLIDAY_TAG_ID)).toBe('#abcdef')
+  })
+
+  it('defaultTagColors가 없으면 well-known ID 색상도 찾을 수 없다', () => {
+    // given: defaultTagColors null 상태
+    // when / then
+    expect(useEventTagStore.getState().getColorForTagId(DEFAULT_TAG_ID)).toBeUndefined()
+    expect(useEventTagStore.getState().getColorForTagId(HOLIDAY_TAG_ID)).toBeUndefined()
+  })
+})
+
 describe('eventTagStore — reset', () => {
   it('reset 호출 시 초기 상태로 돌아간다', async () => {
     // given: 태그가 있는 상태
     const { eventTagApi } = await import('../../src/api/eventTagApi')
+    const { settingApi } = await import('../../src/api/settingApi')
     vi.mocked(eventTagApi.getAllTags).mockResolvedValue([
       { uuid: 'tag-1', name: 'Work', color_hex: '#ff0000' },
     ])
+    vi.mocked(settingApi.getDefaultTagColors).mockResolvedValue({ default: '#123456', holiday: '#abcdef' })
     await useEventTagStore.getState().fetchAll()
 
     // when: reset 호출
@@ -85,12 +141,14 @@ describe('eventTagStore — reset', () => {
 
     // then: 빈 상태
     expect(useEventTagStore.getState().getColorForTagId('tag-1')).toBeUndefined()
+    expect(useEventTagStore.getState().getColorForTagId(DEFAULT_TAG_ID)).toBeUndefined()
+    expect(useEventTagStore.getState().getColorForTagId(HOLIDAY_TAG_ID)).toBeUndefined()
   })
 })
 
 describe('eventTagStore — CRUD', () => {
   beforeEach(() => {
-    useEventTagStore.setState({ tags: new Map() })
+    useEventTagStore.setState({ tags: new Map(), defaultTagColors: null })
     vi.clearAllMocks()
   })
 
@@ -106,7 +164,7 @@ describe('eventTagStore — CRUD', () => {
 
   it('updateTag를 호출하면 변경된 색상으로 조회된다', async () => {
     // given: 태그가 있는 상태
-    useEventTagStore.setState({ tags: new Map([['tag-1', { uuid: 'tag-1', name: '업무', color_hex: '#ff0000' }]]) })
+    useEventTagStore.setState({ tags: new Map([['tag-1', { uuid: 'tag-1', name: '업무', color_hex: '#ff0000' }]]), defaultTagColors: null })
     const { eventTagApi } = await import('../../src/api/eventTagApi')
     vi.mocked(eventTagApi.updateTag).mockResolvedValue({ uuid: 'tag-1', name: '업무', color_hex: '#0000ff' })
     // when: 색상 수정
@@ -117,7 +175,7 @@ describe('eventTagStore — CRUD', () => {
 
   it('deleteTag를 호출하면 해당 태그를 더 이상 조회할 수 없다', async () => {
     // given: 태그가 있는 상태
-    useEventTagStore.setState({ tags: new Map([['tag-1', { uuid: 'tag-1', name: '업무', color_hex: '#ff0000' }]]) })
+    useEventTagStore.setState({ tags: new Map([['tag-1', { uuid: 'tag-1', name: '업무', color_hex: '#ff0000' }]]), defaultTagColors: null })
     const { eventTagApi } = await import('../../src/api/eventTagApi')
     vi.mocked(eventTagApi.deleteTag).mockResolvedValue({ status: 'ok' })
     // when: 삭제


### PR DESCRIPTION
## Summary

- `eventTagStore`에 `defaultTagColors` 상태 추가, `fetchAll()` 시 `settingApi.getDefaultTagColors()` 병렬 호출
- `DEFAULT_TAG_ID`, `HOLIDAY_TAG_ID` 상수 export — well-known 태그 ID 통일
- `getColorForTagId()`에서 `'default'`/`'holiday'` ID를 `defaultTagColors`로 처리
- `CalendarList`가 `useMemo`로 `[기본, 공휴일, ...사용자태그]` 순서로 항상 렌더
- ko/en 로케일에 `tag.default_name`, `tag.holiday_name` 키 추가

## Test plan

- [ ] `npm test -- --run` 전체 통과 (293 tests, 4 pre-existing Firebase failures 제외)
- [ ] CalendarList에 기본/공휴일 태그가 항상 상단에 표시되는지 확인
- [ ] 사용자 태그가 없어도 기본/공휴일 태그가 표시되는지 확인
- [ ] 태그 토글(숨기기/표시)이 기본/공휴일 태그에도 동작하는지 확인

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)