### PR TITLE
#20 fix: 미니캘린더 달 전환 버튼 복원

### DIFF
--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -121,7 +121,7 @@ export default function LeftSidebar() {
                 modifiers={{ sunday: isSundayModifier }}
                 classNames={{
                   root: 'w-full',
-                  months: 'flex flex-col gap-0',
+                  months: 'relative flex flex-col gap-0',
                   month: 'flex w-full flex-col gap-2',
                   month_caption: 'flex h-7 w-full items-center justify-center px-7',
                   caption_label: 'text-sm font-semibold text-text-primary select-none',

--- a/tests/components/LeftSidebar.test.tsx
+++ b/tests/components/LeftSidebar.test.tsx
@@ -114,6 +114,48 @@ describe('LeftSidebar', () => {
     expect(selectedDate?.getFullYear()).toBe(2026)
   })
 
+  it('이전 달 버튼과 다음 달 버튼이 렌더링된다', () => {
+    // given: 사이드바 열림, 2026년 3월
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1) })
+
+    // when
+    renderSidebar()
+
+    // then: 이전/다음 달 네비게이션 버튼이 표시됨
+    expect(screen.getByRole('button', { name: /previous/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument()
+  })
+
+  it('이전 달 버튼을 클릭하면 currentMonth가 이전 달로 변경된다', async () => {
+    // given: 사이드바 열림, 2026년 3월
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1) })
+
+    // when
+    renderSidebar()
+    const prevButton = screen.getByRole('button', { name: /previous/i })
+    await userEvent.click(prevButton)
+
+    // then: currentMonth가 2026년 2월로 변경됨
+    const { currentMonth } = useUiStore.getState()
+    expect(currentMonth.getFullYear()).toBe(2026)
+    expect(currentMonth.getMonth()).toBe(1)
+  })
+
+  it('다음 달 버튼을 클릭하면 currentMonth가 다음 달로 변경된다', async () => {
+    // given: 사이드바 열림, 2026년 3월
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1) })
+
+    // when
+    renderSidebar()
+    const nextButton = screen.getByRole('button', { name: /next/i })
+    await userEvent.click(nextButton)
+
+    // then: currentMonth가 2026년 4월로 변경됨
+    const { currentMonth } = useUiStore.getState()
+    expect(currentMonth.getFullYear()).toBe(2026)
+    expect(currentMonth.getMonth()).toBe(3)
+  })
+
   it('렌더링 시 현재 달의 공휴일 fetch가 호출된다', async () => {
     // given: holidayApi mock, 2026년 3월
     const { holidayApi } = await import('../../src/api/holidayApi')


### PR DESCRIPTION
## Summary

- `months` 컨테이너에 누락된 `relative` 클래스를 추가하여 절대 위치로 렌더링되는 `nav` 버튼이 캘린더 헤더 영역 안에 정확히 위치하도록 수정
- react-day-picker v9는 `<nav>` 요소에 `absolute inset-x-0 top-0`를 적용하는데, 부모 `months` div에 `relative`가 없어서 버튼이 의도한 위치에서 벗어나 보이지 않았음

## Root Cause

`LeftSidebar.tsx`의 `classNames.months` 커스터마이징에서 `relative` 를 누락:
```tsx
// 수정 전
months: 'flex flex-col gap-0'

// 수정 후
months: 'relative flex flex-col gap-0'
```

## Test plan

- [x] 이전 달(`<`) / 다음 달(`>`) 버튼이 렌더링됨을 검증하는 테스트 추가
- [x] 이전 달 버튼 클릭 시 `currentMonth`가 이전 달로 변경됨을 검증
- [x] 다음 달 버튼 클릭 시 `currentMonth`가 다음 달로 변경됨을 검증
- [x] `npm test -- --run` 전체 322개 테스트 통과

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)