### PR TITLE
#23 fix: 캘린더 이벤트 요약 표시 버그 수정

### DIFF
--- a/src/calendar/MainCalendarGrid.tsx
+++ b/src/calendar/MainCalendarGrid.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useRef, useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { CalendarDay } from './calendarUtils'
 import type { CalendarEvent } from '../utils/eventTimeUtils'
@@ -40,6 +40,22 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
   const isTagHidden = useTagFilterStore(s => s.isTagHidden)
   const { rowHeight, fontSize, showEventNames } = useCalendarAppearanceStore()
 
+  // 첫 번째 주 컨테이너의 실제 높이를 측정 (flex-1로 인해 minHeight보다 클 수 있음)
+  const [actualRowHeight, setActualRowHeight] = useState(rowHeight)
+  const firstWeekRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = firstWeekRef.current
+    if (!el) return
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        setActualRowHeight(entry.contentRect.height)
+      }
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
   // days를 7일 단위로 주(week) 분할
   const weeks = useMemo(() => {
     const result: CalendarDay[][] = []
@@ -67,8 +83,8 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
     [weeks, filteredEventsByDate],
   )
 
-  // 표시 가능한 이벤트 행 수 계산
-  const maxVisibleRows = Math.max(1, Math.floor((rowHeight - DATE_NUMBER_HEIGHT - EVENT_AREA_TOP_OFFSET) / (EVENT_ROW_HEIGHT + EVENT_ROW_GAP)))
+  // 표시 가능한 이벤트 행 수 계산 (실제 셀 높이 기반)
+  const maxVisibleRows = Math.max(1, Math.floor((actualRowHeight - DATE_NUMBER_HEIGHT - EVENT_AREA_TOP_OFFSET) / (EVENT_ROW_HEIGHT + EVENT_ROW_GAP)))
 
   const totalWeeks = weeks.length
 
@@ -100,6 +116,7 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
             // flex-1로 균등 높이 분배, 마지막 주는 border-b 없음
             <div
               key={wi}
+              ref={wi === 0 ? firstWeekRef : undefined}
               className={`flex-1 relative grid grid-cols-7 ${!isLastWeek ? 'border-b border-border-calendar' : ''}`}
               style={{ minHeight: `${rowHeight}px` }}
             >

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,13 @@
 import '@testing-library/jest-dom'
 import '../src/i18n'
 
+class ResizeObserverMock {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+}
+global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver
+
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: vi.fn().mockImplementation(query => ({


### PR DESCRIPTION
## Summary

- `maxVisibleRows` 계산이 `rowHeight`(store 설정값, minHeight 기준)를 사용하여 실제 셀 높이보다 작게 계산되는 버그 수정
- `ResizeObserver`로 첫 번째 주 컨테이너의 실제 렌더링 높이를 측정하여 `maxVisibleRows` 재계산
- 화면이 넓어져 `flex-1` 셀이 minHeight를 초과해도 이벤트가 올바르게 쌓임
- `tests/setup.ts`에 `ResizeObserver` 클래스 mock 추가

## Test plan

- [ ] 테스트 292개 통과 확인 (`npm test -- --run`)
- [ ] 화면 높이가 충분한 상태에서 이벤트가 "+N more"로 요약되지 않고 모두 표시되는지 확인
- [ ] 화면 높이가 작은 상태에서는 여전히 "+N more"로 요약되는지 확인

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)