### PR TITLE
#20 fix: 좌측/중앙 캘린더 월 독립 분리

### DIFF
--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -79,22 +79,22 @@ export default function LeftSidebar() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const sidebarOpen = useUiStore(s => s.sidebarOpen)
-  const currentMonth = useUiStore(s => s.currentMonth)
+  const sidebarMonth = useUiStore(s => s.sidebarMonth)
   const selectedDate = useUiStore(s => s.selectedDate)
   const setSelectedDate = useUiStore(s => s.setSelectedDate)
-  const setCurrentMonth = useUiStore(s => s.setCurrentMonth)
+  const setSidebarMonth = useUiStore(s => s.setSidebarMonth)
   const fetchHolidays = useHolidayStore(s => s.fetchHolidays)
   const getHolidayNames = useHolidayStore(s => s.getHolidayNames)
 
   // 월 변경 시 해당 연도 공휴일 로드 (이전·다음 달 경계 연도 포함)
   useEffect(() => {
-    const year = currentMonth.getFullYear()
-    const month = currentMonth.getMonth()
+    const year = sidebarMonth.getFullYear()
+    const month = sidebarMonth.getMonth()
     const years = new Set([year])
     if (month === 0) years.add(year - 1)
     if (month === 11) years.add(year + 1)
     years.forEach(y => fetchHolidays(y))
-  }, [currentMonth, fetchHolidays])
+  }, [sidebarMonth, fetchHolidays])
 
   const formatWeekdayName = (date: Date) => {
     const dayIndex = date.getDay()
@@ -115,8 +115,8 @@ export default function LeftSidebar() {
                 mode="single"
                 selected={selectedDate ?? undefined}
                 onSelect={(date) => date && setSelectedDate(date)}
-                month={currentMonth}
-                onMonthChange={setCurrentMonth}
+                month={sidebarMonth}
+                onMonthChange={setSidebarMonth}
                 formatters={{ formatWeekdayName }}
                 modifiers={{ sunday: isSundayModifier }}
                 classNames={{

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -17,11 +17,13 @@ interface UiState {
   selectedDate: Date | null
   sidebarOpen: boolean
   currentMonth: Date
+  sidebarMonth: Date
 
   setSelectedDate: (date: Date) => void
   toggleSidebar: () => void
   setSidebarOpen: (open: boolean) => void
   setCurrentMonth: (date: Date) => void
+  setSidebarMonth: (date: Date) => void
   goToPrevMonth: () => void
   goToNextMonth: () => void
   goToToday: () => void
@@ -31,13 +33,17 @@ export const useUiStore = create<UiState>((set, get) => ({
   selectedDate: (() => { const d = new Date(); d.setHours(0, 0, 0, 0); return d; })(),
   sidebarOpen: loadSidebarState(),
   currentMonth: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
+  sidebarMonth: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
 
   setSelectedDate: (date: Date) => {
     const current = get().selectedDate
     if (current && formatDateKey(current) === formatDateKey(date)) {
       set({ selectedDate: null })
     } else {
-      set({ selectedDate: date })
+      set({
+        selectedDate: date,
+        currentMonth: new Date(date.getFullYear(), date.getMonth(), 1),
+      })
     }
   },
 
@@ -56,6 +62,10 @@ export const useUiStore = create<UiState>((set, get) => ({
     set({ currentMonth: new Date(date.getFullYear(), date.getMonth(), 1) })
   },
 
+  setSidebarMonth: (date: Date) => {
+    set({ sidebarMonth: new Date(date.getFullYear(), date.getMonth(), 1) })
+  },
+
   goToPrevMonth: () => {
     set({ currentMonth: navigateMonth(get().currentMonth, -1) })
   },
@@ -66,8 +76,10 @@ export const useUiStore = create<UiState>((set, get) => ({
 
   goToToday: () => {
     const today = new Date()
+    const todayMonth = new Date(today.getFullYear(), today.getMonth(), 1)
     set({
-      currentMonth: new Date(today.getFullYear(), today.getMonth(), 1),
+      currentMonth: todayMonth,
+      sidebarMonth: todayMonth,
       selectedDate: today,
     })
   },

--- a/tests/components/LeftSidebar.test.tsx
+++ b/tests/components/LeftSidebar.test.tsx
@@ -26,7 +26,7 @@ function renderSidebar() {
 describe('LeftSidebar', () => {
   it('사이드바가 열려 있을 때 w-64 클래스가 적용된다', () => {
     // given: 사이드바 열림 상태
-    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1) })
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1), sidebarMonth: new Date(2026, 2, 1) })
 
     // when
     const { container } = renderSidebar()
@@ -38,7 +38,7 @@ describe('LeftSidebar', () => {
 
   it('사이드바가 닫혀 있을 때 w-0 클래스가 적용된다', () => {
     // given: 사이드바 닫힘 상태
-    useUiStore.setState({ sidebarOpen: false, currentMonth: new Date(2026, 2, 1) })
+    useUiStore.setState({ sidebarOpen: false, currentMonth: new Date(2026, 2, 1), sidebarMonth: new Date(2026, 2, 1) })
 
     // when
     const { container } = renderSidebar()
@@ -50,7 +50,7 @@ describe('LeftSidebar', () => {
 
   it('사이드바가 열려 있을 때 달력 그리드를 렌더링한다', () => {
     // given: 사이드바 열림, 2026년 3월
-    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1) })
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1), sidebarMonth: new Date(2026, 2, 1) })
 
     // when
     renderSidebar()
@@ -63,7 +63,7 @@ describe('LeftSidebar', () => {
 
   it('사이드바에 transition-all duration-200 클래스가 적용된다', () => {
     // given
-    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1) })
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1), sidebarMonth: new Date(2026, 2, 1) })
 
     // when
     const { container } = renderSidebar()
@@ -75,7 +75,7 @@ describe('LeftSidebar', () => {
 
   it('모바일에서 숨겨지는 hidden md:flex 클래스가 적용된다', () => {
     // given
-    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1) })
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1), sidebarMonth: new Date(2026, 2, 1) })
 
     // when
     const { container } = renderSidebar()
@@ -87,7 +87,7 @@ describe('LeftSidebar', () => {
 
   it('현재 달의 날짜를 렌더링한다', () => {
     // given: 2026년 3월
-    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1) })
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1), sidebarMonth: new Date(2026, 2, 1) })
 
     // when
     renderSidebar()
@@ -99,7 +99,7 @@ describe('LeftSidebar', () => {
 
   it('날짜를 클릭하면 uiStore의 selectedDate가 변경된다', async () => {
     // given: 2026년 3월, selectedDate 없음
-    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1), selectedDate: null })
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1), sidebarMonth: new Date(2026, 2, 1), selectedDate: null })
 
     // when
     renderSidebar()
@@ -116,7 +116,7 @@ describe('LeftSidebar', () => {
 
   it('이전 달 버튼과 다음 달 버튼이 렌더링된다', () => {
     // given: 사이드바 열림, 2026년 3월
-    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1) })
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1), sidebarMonth: new Date(2026, 2, 1) })
 
     // when
     renderSidebar()
@@ -126,34 +126,36 @@ describe('LeftSidebar', () => {
     expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument()
   })
 
-  it('이전 달 버튼을 클릭하면 currentMonth가 이전 달로 변경된다', async () => {
+  it('이전 달 버튼을 클릭하면 sidebarMonth가 이전 달로 변경되고 currentMonth는 그대로다', async () => {
     // given: 사이드바 열림, 2026년 3월
-    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1) })
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1), sidebarMonth: new Date(2026, 2, 1) })
 
     // when
     renderSidebar()
     const prevButton = screen.getByRole('button', { name: /previous/i })
     await userEvent.click(prevButton)
 
-    // then: currentMonth가 2026년 2월로 변경됨
-    const { currentMonth } = useUiStore.getState()
-    expect(currentMonth.getFullYear()).toBe(2026)
-    expect(currentMonth.getMonth()).toBe(1)
+    // then: sidebarMonth가 2026년 2월로 변경됨, currentMonth는 변경 없음
+    const state = useUiStore.getState()
+    expect(state.sidebarMonth.getFullYear()).toBe(2026)
+    expect(state.sidebarMonth.getMonth()).toBe(1)
+    expect(state.currentMonth.getMonth()).toBe(2)
   })
 
-  it('다음 달 버튼을 클릭하면 currentMonth가 다음 달로 변경된다', async () => {
+  it('다음 달 버튼을 클릭하면 sidebarMonth가 다음 달로 변경되고 currentMonth는 그대로다', async () => {
     // given: 사이드바 열림, 2026년 3월
-    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1) })
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1), sidebarMonth: new Date(2026, 2, 1) })
 
     // when
     renderSidebar()
     const nextButton = screen.getByRole('button', { name: /next/i })
     await userEvent.click(nextButton)
 
-    // then: currentMonth가 2026년 4월로 변경됨
-    const { currentMonth } = useUiStore.getState()
-    expect(currentMonth.getFullYear()).toBe(2026)
-    expect(currentMonth.getMonth()).toBe(3)
+    // then: sidebarMonth가 2026년 4월로 변경됨, currentMonth는 변경 없음
+    const state = useUiStore.getState()
+    expect(state.sidebarMonth.getFullYear()).toBe(2026)
+    expect(state.sidebarMonth.getMonth()).toBe(3)
+    expect(state.currentMonth.getMonth()).toBe(2)
   })
 
   it('렌더링 시 현재 달의 공휴일 fetch가 호출된다', async () => {
@@ -161,7 +163,7 @@ describe('LeftSidebar', () => {
     const { holidayApi } = await import('../../src/api/holidayApi')
     const getHolidaysSpy = vi.spyOn(holidayApi, 'getHolidays')
     useHolidayStore.setState({ holidays: new Map(), loadedYears: new Set() })
-    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1) })
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1), sidebarMonth: new Date(2026, 2, 1) })
 
     // when
     renderSidebar()

--- a/tests/stores/uiStore.test.ts
+++ b/tests/stores/uiStore.test.ts
@@ -8,6 +8,7 @@ describe('uiStore', () => {
       selectedDate: null,
       sidebarOpen: true,
       currentMonth: new Date(2026, 3, 1),
+      sidebarMonth: new Date(2026, 3, 1),
     })
   })
 
@@ -92,16 +93,47 @@ describe('uiStore', () => {
   })
 
   it('goToToday로 오늘 날짜와 해당 월로 이동한다', () => {
-    useUiStore.setState({ currentMonth: new Date(2020, 0, 1), selectedDate: null })
+    useUiStore.setState({ currentMonth: new Date(2020, 0, 1), sidebarMonth: new Date(2020, 0, 1), selectedDate: null })
     useUiStore.getState().goToToday()
 
     const today = new Date()
     const state = useUiStore.getState()
     expect(state.currentMonth.getFullYear()).toBe(today.getFullYear())
     expect(state.currentMonth.getMonth()).toBe(today.getMonth())
+    expect(state.sidebarMonth.getFullYear()).toBe(today.getFullYear())
+    expect(state.sidebarMonth.getMonth()).toBe(today.getMonth())
     expect(state.selectedDate).not.toBeNull()
     expect(state.selectedDate!.getFullYear()).toBe(today.getFullYear())
     expect(state.selectedDate!.getMonth()).toBe(today.getMonth())
     expect(state.selectedDate!.getDate()).toBe(today.getDate())
+  })
+
+  // -- sidebarMonth --
+
+  it('setSidebarMonth로 사이드바 캘린더 월을 독립적으로 변경한다', () => {
+    useUiStore.setState({ currentMonth: new Date(2026, 3, 1), sidebarMonth: new Date(2026, 3, 1) })
+    useUiStore.getState().setSidebarMonth(new Date(2026, 5, 15))
+    const state = useUiStore.getState()
+    expect(state.sidebarMonth.getFullYear()).toBe(2026)
+    expect(state.sidebarMonth.getMonth()).toBe(5)
+    expect(state.sidebarMonth.getDate()).toBe(1)
+    // 중앙 캘린더는 변경되지 않음
+    expect(state.currentMonth.getMonth()).toBe(3)
+  })
+
+  it('좌측 캘린더에서 날짜를 선택하면 중앙 캘린더(currentMonth)가 해당 월로 변경된다', () => {
+    useUiStore.setState({ currentMonth: new Date(2026, 3, 1), sidebarMonth: new Date(2026, 5, 1), selectedDate: null })
+    useUiStore.getState().setSelectedDate(new Date(2026, 5, 10))
+    const state = useUiStore.getState()
+    expect(state.selectedDate?.getMonth()).toBe(5)
+    expect(state.currentMonth.getMonth()).toBe(5)
+  })
+
+  it('setSelectedDate는 sidebarMonth를 변경하지 않는다', () => {
+    useUiStore.setState({ currentMonth: new Date(2026, 3, 1), sidebarMonth: new Date(2026, 5, 1), selectedDate: null })
+    useUiStore.getState().setSelectedDate(new Date(2026, 3, 10))
+    const state = useUiStore.getState()
+    // sidebarMonth는 그대로 6월
+    expect(state.sidebarMonth.getMonth()).toBe(5)
   })
 })


### PR DESCRIPTION
## Summary

- `uiStore`에 `sidebarMonth` 독립 상태 추가 — 좌측 미니 캘린더 전용 월 관리
- `LeftSidebar`의 `month`/`onMonthChange`를 `sidebarMonth`/`setSidebarMonth`로 교체
- 동기화 규칙 구현:
  - 좌측 날짜 선택 → `selectedDate` 변경 + `currentMonth`(중앙)를 해당 월로 이동
  - 좌측 달 변경 → `sidebarMonth`만 변경, `currentMonth` 독립 유지
  - 중앙 달 변경 → `currentMonth`만 변경, `sidebarMonth` 독립 유지
  - 중앙 날짜 선택 → `selectedDate` 변경, `sidebarMonth` 불변
  - 오늘 버튼 → `currentMonth` + `sidebarMonth` 모두 이번 달로 리셋

## Test plan

- [ ] `npm test -- --run` 전체 테스트 328개 통과 확인
- [ ] 좌측 달 이동 버튼 클릭 시 중앙 캘린더 월이 변경되지 않음
- [ ] 좌측 날짜 선택 시 중앙 캘린더가 해당 월로 이동함
- [ ] 중앙 캘린더 달 이동 시 좌측 캘린더 월이 변경되지 않음

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)