### PR TITLE
#25 feat: 우측 패널을 드로워 오버레이로 변경

### DIFF
--- a/src/components/RightEventPanel.tsx
+++ b/src/components/RightEventPanel.tsx
@@ -13,13 +13,28 @@ export function RightEventPanel() {
   const { i18n } = useTranslation()
   const selectedDate = useUiStore(s => s.selectedDate)
   const foremostEvent = useForemostEventStore(s => s.foremostEvent)
+  const toggleRightPanel = useUiStore(s => s.toggleRightPanel)
   const dateLocale = i18n.language === 'en' ? 'en-US' : 'ko-KR'
 
   return (
     <div className="w-80 shrink-0 border-l border-border-calendar bg-surface flex flex-col h-full overflow-hidden">
+      {/* 접기 버튼 */}
+      <div className="flex items-center justify-end px-2 pt-2">
+        <button
+          onClick={toggleRightPanel}
+          aria-label="패널 닫기"
+          className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+
       {/* 스크롤 영역 */}
       <ScrollArea className="flex-1 overflow-y-auto">
-        <div className="p-4 flex flex-col gap-4">
+        <div className="p-4 pt-0 flex flex-col gap-4">
           {foremostEvent && <ForemostEventBanner />}
           <UncompletedTodoList />
           <CurrentTodoList showHeader={false} />

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -3,18 +3,28 @@ import LeftSidebar from '../components/LeftSidebar'
 import MainCalendar from '../calendar/MainCalendar'
 import { RightEventPanel } from '../components/RightEventPanel'
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
+import { useUiStore } from '../stores/uiStore'
 
 export function MainPage() {
   useKeyboardShortcuts()
+  const rightPanelOpen = useUiStore(s => s.rightPanelOpen)
 
   return (
     <div className="h-screen bg-slate-800 p-2">
       <div className="flex h-full flex-col rounded-2xl bg-surface overflow-hidden shadow-xl">
         <TopToolbar />
-        <div className="flex flex-1 min-h-0">
+        <div className="flex flex-1 min-h-0 relative overflow-hidden">
           <LeftSidebar />
           <MainCalendar />
-          <RightEventPanel />
+
+          {/* 드로워: absolute positioning으로 캘린더 위에 오버레이 */}
+          <div
+            className={`absolute right-0 top-0 bottom-0 w-80 z-10 bg-surface shadow-xl transition-transform duration-300 ease-in-out ${
+              rightPanelOpen ? 'translate-x-0' : 'translate-x-full'
+            }`}
+          >
+            <RightEventPanel />
+          </div>
         </div>
       </div>
     </div>

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -42,7 +42,7 @@ export const useUiStore = create<UiState>((set, get) => ({
   setSelectedDate: (date: Date) => {
     const current = get().selectedDate
     if (current && formatDateKey(current) === formatDateKey(date)) {
-      set({ selectedDate: null })
+      set({ selectedDate: null, rightPanelOpen: false })
     } else {
       set({
         selectedDate: date,

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -18,6 +18,7 @@ interface UiState {
   sidebarOpen: boolean
   currentMonth: Date
   sidebarMonth: Date
+  rightPanelOpen: boolean
 
   setSelectedDate: (date: Date) => void
   toggleSidebar: () => void
@@ -27,6 +28,8 @@ interface UiState {
   goToPrevMonth: () => void
   goToNextMonth: () => void
   goToToday: () => void
+  toggleRightPanel: () => void
+  setRightPanelOpen: (open: boolean) => void
 }
 
 export const useUiStore = create<UiState>((set, get) => ({
@@ -34,6 +37,7 @@ export const useUiStore = create<UiState>((set, get) => ({
   sidebarOpen: loadSidebarState(),
   currentMonth: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
   sidebarMonth: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
+  rightPanelOpen: false,
 
   setSelectedDate: (date: Date) => {
     const current = get().selectedDate
@@ -43,6 +47,7 @@ export const useUiStore = create<UiState>((set, get) => ({
       set({
         selectedDate: date,
         currentMonth: new Date(date.getFullYear(), date.getMonth(), 1),
+        rightPanelOpen: true,
       })
     }
   },
@@ -82,5 +87,13 @@ export const useUiStore = create<UiState>((set, get) => ({
       sidebarMonth: todayMonth,
       selectedDate: today,
     })
+  },
+
+  toggleRightPanel: () => {
+    set({ rightPanelOpen: !get().rightPanelOpen })
+  },
+
+  setRightPanelOpen: (open: boolean) => {
+    set({ rightPanelOpen: open })
   },
 }))

--- a/tests/components/RightEventPanel.test.tsx
+++ b/tests/components/RightEventPanel.test.tsx
@@ -61,6 +61,12 @@ describe('RightEventPanel', () => {
     expect(screen.getByRole('button', { name: '새 이벤트' })).toBeInTheDocument()
   })
 
+  it('패널 닫기 버튼이 표시된다', () => {
+    renderComponent()
+
+    expect(screen.getByRole('button', { name: '패널 닫기' })).toBeInTheDocument()
+  })
+
   it('foremostEvent가 없으면 ForemostEventBanner가 표시되지 않는다', () => {
     // given: foremost event 없음
     mockForemostStore(null)

--- a/tests/stores/uiStore.test.ts
+++ b/tests/stores/uiStore.test.ts
@@ -9,6 +9,7 @@ describe('uiStore', () => {
       sidebarOpen: true,
       currentMonth: new Date(2026, 3, 1),
       sidebarMonth: new Date(2026, 3, 1),
+      rightPanelOpen: false,
     })
   })
 
@@ -168,15 +169,14 @@ describe('uiStore', () => {
     expect(useUiStore.getState().rightPanelOpen).toBe(true)
   })
 
-  it('같은 날짜를 다시 선택하여 해제해도 rightPanelOpen은 유지된다', () => {
+  it('같은 날짜를 다시 선택하여 해제하면 rightPanelOpen이 false가 된다', () => {
     const date = new Date(2026, 3, 15)
-    useUiStore.setState({ rightPanelOpen: true, selectedDate: null })
+    useUiStore.setState({ rightPanelOpen: false, selectedDate: null })
     useUiStore.getState().setSelectedDate(date)
     expect(useUiStore.getState().rightPanelOpen).toBe(true)
-    // 같은 날짜 다시 선택 → selectedDate null
+    // 같은 날짜 다시 선택 → selectedDate null, 드로워 닫힘
     useUiStore.getState().setSelectedDate(date)
     expect(useUiStore.getState().selectedDate).toBeNull()
-    // 패널은 열린 상태 유지
-    expect(useUiStore.getState().rightPanelOpen).toBe(true)
+    expect(useUiStore.getState().rightPanelOpen).toBe(false)
   })
 })

--- a/tests/stores/uiStore.test.ts
+++ b/tests/stores/uiStore.test.ts
@@ -136,4 +136,47 @@ describe('uiStore', () => {
     // sidebarMonth는 그대로 6월
     expect(state.sidebarMonth.getMonth()).toBe(5)
   })
+
+  // -- rightPanelOpen --
+
+  it('rightPanelOpen 초기값은 false이다', () => {
+    useUiStore.setState({ rightPanelOpen: false })
+    expect(useUiStore.getState().rightPanelOpen).toBe(false)
+  })
+
+  it('toggleRightPanel로 패널 열기/닫기를 토글한다', () => {
+    useUiStore.setState({ rightPanelOpen: false })
+    useUiStore.getState().toggleRightPanel()
+    expect(useUiStore.getState().rightPanelOpen).toBe(true)
+
+    useUiStore.getState().toggleRightPanel()
+    expect(useUiStore.getState().rightPanelOpen).toBe(false)
+  })
+
+  it('setRightPanelOpen으로 패널 상태를 직접 설정한다', () => {
+    useUiStore.setState({ rightPanelOpen: false })
+    useUiStore.getState().setRightPanelOpen(true)
+    expect(useUiStore.getState().rightPanelOpen).toBe(true)
+
+    useUiStore.getState().setRightPanelOpen(false)
+    expect(useUiStore.getState().rightPanelOpen).toBe(false)
+  })
+
+  it('날짜를 선택하면 rightPanelOpen이 true가 된다', () => {
+    useUiStore.setState({ rightPanelOpen: false, selectedDate: null })
+    useUiStore.getState().setSelectedDate(new Date(2026, 3, 15))
+    expect(useUiStore.getState().rightPanelOpen).toBe(true)
+  })
+
+  it('같은 날짜를 다시 선택하여 해제해도 rightPanelOpen은 유지된다', () => {
+    const date = new Date(2026, 3, 15)
+    useUiStore.setState({ rightPanelOpen: true, selectedDate: null })
+    useUiStore.getState().setSelectedDate(date)
+    expect(useUiStore.getState().rightPanelOpen).toBe(true)
+    // 같은 날짜 다시 선택 → selectedDate null
+    useUiStore.getState().setSelectedDate(date)
+    expect(useUiStore.getState().selectedDate).toBeNull()
+    // 패널은 열린 상태 유지
+    expect(useUiStore.getState().rightPanelOpen).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary
- uiStore에 `rightPanelOpen` 상태 추가 (toggle/set/날짜 선택 시 자동 열림)
- MainPage 레이아웃을 flex row에서 relative + absolute 드로워 구조로 변경
- RightEventPanel이 MainCalendar 위에 오버레이되며 slide-in/out 애니메이션 적용
- 패널 상단에 닫기 버튼 추가

Closes #25

## Test plan
- [x] uiStore rightPanelOpen 관련 테스트 5개 추가 및 통과
- [x] RightEventPanel 닫기 버튼 테스트 추가 및 통과
- [x] 기존 전체 테스트 301개 통과 (Firebase 환경변수 미설정 4개 제외)
- [ ] E2E 테스트로 드로워 열림/닫힘 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)