### PR TITLE
#20 fix: 좌측 미니캘린더에 이벤트 추가 버튼 추가

### DIFF
--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -1,10 +1,12 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { DayButton } from 'react-day-picker'
 import { useUiStore } from '../stores/uiStore'
 import { useHolidayStore } from '../stores/holidayStore'
 import { Calendar } from '@/components/ui/calendar'
 import CalendarList from './CalendarList'
+import { TypeSelectorPopup } from './TypeSelectorPopup'
 import { formatDateKey } from '../utils/eventTimeUtils'
 import { cn } from '@/lib/utils'
 import { SIDEBAR_WIDTH_CLASS } from '../constants/layout'
@@ -75,6 +77,9 @@ function MiniCalendarDayButton({
 
 export default function LeftSidebar() {
   const { t } = useTranslation()
+  const [showCreatePopup, setShowCreatePopup] = useState(false)
+  const navigate = useNavigate()
+  const location = useLocation()
   const sidebarOpen = useUiStore(s => s.sidebarOpen)
   const sidebarMonth = useUiStore(s => s.sidebarMonth)
   const selectedDate = useUiStore(s => s.selectedDate)
@@ -82,6 +87,12 @@ export default function LeftSidebar() {
   const setSidebarMonth = useUiStore(s => s.setSidebarMonth)
   const fetchHolidays = useHolidayStore(s => s.fetchHolidays)
   const getHolidayNames = useHolidayStore(s => s.getHolidayNames)
+
+  function handleCreateSelect(type: 'todo' | 'schedule') {
+    setShowCreatePopup(false)
+    const path = type === 'todo' ? '/todos/new' : '/schedules/new'
+    navigate(path, { state: { background: location } })
+  }
 
   // 월 변경 시 해당 연도 공휴일 로드 (이전·다음 달 경계 연도 포함)
   useEffect(() => {
@@ -107,6 +118,28 @@ export default function LeftSidebar() {
     >
       <div className="flex-1 overflow-y-auto flex flex-col">
         <div className="px-3 pt-4">
+          {/* 이벤트 추가 버튼 */}
+          <div className="mb-2 relative">
+            <button
+              data-testid="sidebar-create-event"
+              className="flex items-center gap-2 rounded-[5px] bg-[#f3f4f7] px-2 w-full hover:brightness-95 transition-colors"
+              style={{ height: 50 }}
+              onClick={() => setShowCreatePopup(true)}
+            >
+              <div className="shrink-0 flex items-center justify-center" style={{ width: 52 }}>
+                <svg className="h-5 w-5 text-[#969696]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+              </div>
+              <span className="text-sm text-[#969696]">{t('main.create_event', 'Create')}</span>
+            </button>
+            {showCreatePopup && (
+              <TypeSelectorPopup
+                onSelect={handleCreateSelect}
+                onClose={() => setShowCreatePopup(false)}
+              />
+            )}
+          </div>
           <div>
             <div className="p-3">
               <Calendar

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -137,6 +137,7 @@ export default function LeftSidebar() {
               <TypeSelectorPopup
                 onSelect={handleCreateSelect}
                 onClose={() => setShowCreatePopup(false)}
+                positionClassName="absolute top-full left-0 mt-1 w-full"
               />
             )}
           </div>

--- a/src/components/TypeSelectorPopup.tsx
+++ b/src/components/TypeSelectorPopup.tsx
@@ -1,13 +1,14 @@
 interface TypeSelectorPopupProps {
   onSelect: (type: 'todo' | 'schedule') => void
   onClose: () => void
+  positionClassName?: string
 }
 
-export function TypeSelectorPopup({ onSelect, onClose }: TypeSelectorPopupProps) {
+export function TypeSelectorPopup({ onSelect, onClose, positionClassName = 'fixed bottom-20 right-4' }: TypeSelectorPopupProps) {
   return (
     <>
       <div data-testid="popup-backdrop" className="fixed inset-0 z-40" onClick={onClose} />
-      <div className="fixed bottom-20 right-4 z-50 overflow-hidden rounded-xl bg-white shadow-xl">
+      <div className={`${positionClassName} z-50 overflow-hidden rounded-xl bg-white shadow-xl`}>
         <button
           className="flex w-full px-6 py-4 text-left text-sm font-medium hover:bg-gray-50"
           onClick={() => onSelect('todo')}

--- a/tests/components/LeftSidebar.test.tsx
+++ b/tests/components/LeftSidebar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
@@ -6,13 +6,19 @@ import LeftSidebar from '../../src/components/LeftSidebar'
 import { useUiStore } from '../../src/stores/uiStore'
 import { useHolidayStore } from '../../src/stores/holidayStore'
 
+vi.mock('../../src/firebase', () => ({
+  auth: {},
+  db: {},
+}))
+
 vi.mock('../../src/api/holidayApi', () => ({
   holidayApi: { getHolidays: async () => ({ items: [] }) },
 }))
 
+const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom')
-  return { ...actual, useNavigate: () => vi.fn() }
+  return { ...actual, useNavigate: () => mockNavigate }
 })
 
 function renderSidebar() {
@@ -24,6 +30,10 @@ function renderSidebar() {
 }
 
 describe('LeftSidebar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('사이드바가 열려 있을 때 w-64 클래스가 적용된다', () => {
     // given: 사이드바 열림 상태
     useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1), sidebarMonth: new Date(2026, 2, 1) })
@@ -173,5 +183,55 @@ describe('LeftSidebar', () => {
       expect(useHolidayStore.getState().loadedYears.has(2026)).toBe(true)
     })
     getHolidaysSpy.mockRestore()
+  })
+
+  it('이벤트 추가 버튼이 렌더링된다', () => {
+    // given: 사이드바 열림
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1), sidebarMonth: new Date(2026, 2, 1) })
+
+    // when
+    renderSidebar()
+
+    // then: 이벤트 추가 버튼이 표시됨
+    expect(screen.getByTestId('sidebar-create-event')).toBeInTheDocument()
+  })
+
+  it('이벤트 추가 버튼을 클릭하면 TypeSelectorPopup이 나타난다', async () => {
+    // given: 사이드바 열림
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1), sidebarMonth: new Date(2026, 2, 1) })
+
+    // when
+    renderSidebar()
+    await userEvent.click(screen.getByTestId('sidebar-create-event'))
+
+    // then: Todo / Schedule 선택 팝업이 표시됨
+    expect(screen.getByText('Todo')).toBeInTheDocument()
+    expect(screen.getByText('Schedule')).toBeInTheDocument()
+  })
+
+  it('TypeSelectorPopup에서 Todo를 선택하면 /todos/new로 이동한다', async () => {
+    // given: 사이드바 열림
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1), sidebarMonth: new Date(2026, 2, 1) })
+
+    // when
+    renderSidebar()
+    await userEvent.click(screen.getByTestId('sidebar-create-event'))
+    await userEvent.click(screen.getByText('Todo'))
+
+    // then: /todos/new 경로로 navigate
+    expect(mockNavigate.mock.calls[0][0]).toBe('/todos/new')
+  })
+
+  it('TypeSelectorPopup에서 Schedule을 선택하면 /schedules/new로 이동한다', async () => {
+    // given: 사이드바 열림
+    useUiStore.setState({ sidebarOpen: true, currentMonth: new Date(2026, 2, 1), sidebarMonth: new Date(2026, 2, 1) })
+
+    // when
+    renderSidebar()
+    await userEvent.click(screen.getByTestId('sidebar-create-event'))
+    await userEvent.click(screen.getByText('Schedule'))
+
+    // then: /schedules/new 경로로 navigate
+    expect(mockNavigate.mock.calls[0][0]).toBe('/schedules/new')
   })
 })


### PR DESCRIPTION
## Summary

- `LeftSidebar.tsx`에 미니캘린더 위에 이벤트 추가 버튼 추가
- 우측 패널 하단의 `CreateEventButton`과 동일한 동작: 클릭 시 `TypeSelectorPopup` 표시 → Todo/Schedule 선택 → 해당 경로 이동
- `CreateEventButton`은 import하지 않고 패턴만 복사해 독립 구현 (이슈 #25가 원본 수정 예정)
- `useTranslation`으로 'Create' 텍스트 i18n 적용

## Changes

- `src/components/LeftSidebar.tsx`: `useState`, `useNavigate`, `useLocation`, `TypeSelectorPopup` 추가; 버튼 + 팝업 JSX 추가
- `tests/components/LeftSidebar.test.tsx`: 버튼 렌더링, 팝업 표시, Todo/Schedule 선택 네비게이션 케이스 4개 추가

## Test plan

- [ ] `data-testid="sidebar-create-event"` 버튼이 렌더링된다
- [ ] 버튼 클릭 시 TypeSelectorPopup(Todo/Schedule)이 나타난다
- [ ] Todo 선택 → `/todos/new`로 이동
- [ ] Schedule 선택 → `/schedules/new`로 이동
- [ ] 전체 테스트 통과: `npm test -- --run` (316 tests pass)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)