### PR TITLE
#21 fix: 내 캘린더 목록 iOS 스타일 태그 디자인 적용

### DIFF
--- a/src/components/CalendarList.tsx
+++ b/src/components/CalendarList.tsx
@@ -3,8 +3,6 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useEventTagStore, DEFAULT_TAG_ID, HOLIDAY_TAG_ID } from '../stores/eventTagStore'
 import { useTagFilterStore } from '../stores/tagFilterStore'
-import { Checkbox } from '@/components/ui/checkbox'
-import { Button } from '@/components/ui/button'
 import type { EventTag } from '../models'
 
 export default function CalendarList() {
@@ -30,11 +28,22 @@ export default function CalendarList() {
 
   return (
     <div className="flex flex-col">
-      <p className="text-text-secondary text-xs font-medium uppercase tracking-wider mb-3">
-        {t('main.event_types', '이벤트 종류')}
-      </p>
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-text-secondary text-xs font-medium uppercase tracking-wider">
+          {t('main.event_types', '이벤트 종류')}
+        </p>
+        <button
+          onClick={() => navigate('/tags', { state: { background: location } })}
+          className="p-1 rounded hover:bg-gray-100 text-[#969696] hover:text-[#646464] transition-colors"
+          aria-label={t('tag.manage', '태그 관리')}
+        >
+          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      </div>
 
-      <div className="flex flex-col gap-1">
+      <div className="flex flex-col gap-1.5">
         {allTags.map(tag => {
           const hidden = hiddenTagIds.has(tag.uuid)
           const color = tag.color_hex ?? '#9ca3af'
@@ -42,31 +51,26 @@ export default function CalendarList() {
           return (
             <div
               key={tag.uuid}
-              className={`flex items-center gap-3 py-1.5 cursor-pointer rounded hover:bg-gray-100 px-1 ${hidden ? 'opacity-50' : ''}`}
+              className={`flex items-center gap-3 py-2.5 px-3 cursor-pointer rounded-lg bg-[#f3f4f7] hover:brightness-95 transition-[filter] ${hidden ? 'opacity-50' : ''}`}
               onClick={() => toggleTag(tag.uuid)}
             >
-              <Checkbox
-                checked={!hidden}
-                aria-label={hidden ? `${tag.name} 표시` : `${tag.name} 숨기기`}
-                className="h-4 w-4 rounded-sm border-2 pointer-events-none"
-                style={!hidden ? { backgroundColor: color, borderColor: color } : { borderColor: color }}
-                tabIndex={-1}
-              />
-              <span className="text-text-primary text-sm truncate">{tag.name}</span>
+              <div
+                className="shrink-0 h-5 w-5 rounded-full flex items-center justify-center"
+                style={!hidden
+                  ? { backgroundColor: color }
+                  : { border: `2px solid ${color}`, backgroundColor: 'transparent' }
+                }
+              >
+                {!hidden && (
+                  <svg className="h-3 w-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                  </svg>
+                )}
+              </div>
+              <span className="flex-1 text-sm text-[#323232] truncate">{tag.name}</span>
             </div>
           )
         })}
-      </div>
-
-      <div className="py-2 mt-2">
-        <Button
-          variant="link"
-          size="sm"
-          onClick={() => navigate('/tags', { state: { background: location } })}
-          className="text-xs px-0 h-auto"
-        >
-          {t('tag.manage', '태그 관리')} &gt;
-        </Button>
       </div>
     </div>
   )

--- a/tests/components/CalendarList.test.tsx
+++ b/tests/components/CalendarList.test.tsx
@@ -41,7 +41,7 @@ describe('CalendarList', () => {
     useTagFilterStore.setState({ hiddenTagIds: new Set() })
   })
 
-  it('태그 목록과 섹션 헤더를 렌더링한다', () => {
+  it('태그 목록과 "이벤트 종류" 헤더를 렌더링한다', () => {
     // given / when
     renderCalendarList()
 
@@ -49,6 +49,14 @@ describe('CalendarList', () => {
     expect(screen.getByText('이벤트 종류')).toBeInTheDocument()
     expect(screen.getByText('업무')).toBeInTheDocument()
     expect(screen.getByText('개인')).toBeInTheDocument()
+  })
+
+  it('헤더 우측에 태그 관리 진입용 chevron 버튼이 렌더된다', () => {
+    // given / when
+    renderCalendarList()
+
+    // then
+    expect(screen.getByRole('button', { name: /태그 관리/i })).toBeInTheDocument()
   })
 
   it('기본 태그와 공휴일 태그가 항상 상단에 표시된다', () => {
@@ -89,15 +97,7 @@ describe('CalendarList', () => {
     expect(holidayIdx).toBeLessThan(personalIdx)
   })
 
-  it('태그 관리 링크가 렌더된다', () => {
-    // given / when
-    renderCalendarList()
-
-    // then
-    expect(screen.getByRole('button', { name: /태그 관리/i })).toBeInTheDocument()
-  })
-
-  it('태그 숨기기 버튼 클릭 시 태그가 숨김 상태로 변경된다', () => {
+  it('태그 행 클릭 시 태그가 숨김 상태로 변경된다', () => {
     // given: 태그 모두 보임
     renderCalendarList()
 
@@ -122,7 +122,7 @@ describe('CalendarList', () => {
     expect(personalTagRow).toBeInTheDocument()
   })
 
-  it('숨긴 태그 표시 버튼 클릭 시 태그가 다시 표시된다', () => {
+  it('숨긴 태그 행 클릭 시 태그가 다시 표시된다', () => {
     // given: tag-1 숨김 상태
     useTagFilterStore.setState({ hiddenTagIds: new Set(['tag-1']) })
     renderCalendarList()
@@ -135,7 +135,7 @@ describe('CalendarList', () => {
     expect(useTagFilterStore.getState().hiddenTagIds.has('tag-1')).toBe(false)
   })
 
-  it('태그 관리 버튼 클릭 시 /tags 경로로 이동한다', () => {
+  it('헤더 chevron 버튼 클릭 시 /tags 경로로 이동한다', () => {
     // given / when
     renderCalendarList()
     fireEvent.click(screen.getByRole('button', { name: /태그 관리/i }))
@@ -156,5 +156,33 @@ describe('CalendarList', () => {
     expect(screen.queryByText('업무')).not.toBeInTheDocument()
     expect(screen.getByText('기본')).toBeInTheDocument()
     expect(screen.getByText('공휴일')).toBeInTheDocument()
+  })
+
+  it('활성 태그는 색상으로 채워진 원형 아이콘을 표시한다', () => {
+    // given: 태그 모두 보임
+    useTagFilterStore.setState({ hiddenTagIds: new Set() })
+
+    // when
+    renderCalendarList()
+
+    // then: 업무 태그 행에서 원형 체크 표시 컨테이너가 존재한다
+    const tagRow = screen.getByText('업무').closest('.cursor-pointer')!
+    const circleIcon = tagRow.querySelector('.rounded-full')
+    expect(circleIcon).toBeInTheDocument()
+  })
+
+  it('숨긴 태그는 빈 원(테두리만) 아이콘을 표시한다', () => {
+    // given: tag-1 숨김 상태
+    useTagFilterStore.setState({ hiddenTagIds: new Set(['tag-1']) })
+
+    // when
+    renderCalendarList()
+
+    // then: 숨긴 '업무' 태그 행의 원형 아이콘 내에 체크마크 svg가 없다
+    const tagRow = screen.getByText('업무').closest('.cursor-pointer')!
+    const circleIcon = tagRow.querySelector('.rounded-full')
+    expect(circleIcon).toBeInTheDocument()
+    // 숨김 상태 — 내부에 svg 체크마크가 없어야 한다
+    expect(circleIcon?.querySelector('svg')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

- `CalendarList.tsx` 헤더를 "이벤트 종류" 텍스트 + 우측 chevron 버튼으로 변경 (태그관리 진입)
- 하단 `Button` 태그관리 링크 제거 — 헤더 chevron으로 기능 통합
- 태그 행 UI를 iOS 스타일 원형 체크마크로 리디자인:
  - 활성: tag color로 채운 원 + 흰색 체크마크 SVG
  - 비활성(숨김): tag color 테두리만의 빈 원, `opacity-50`
  - 행 배경 `bg-[#f3f4f7]`, `rounded-lg`, `py-2.5 px-3`
- 불필요한 `Checkbox`, `Button` import 제거

## Test plan

- [x] `tests/components/CalendarList.test.tsx` 12개 테스트 전체 통과
- [x] 헤더 "이벤트 종류" 텍스트 + 태그 관리 chevron 버튼 렌더 확인
- [x] 기본/공휴일 태그 항상 상단 표시 확인
- [x] 태그 클릭 시 숨김/표시 토글 동작 확인
- [x] 숨긴 태그 `opacity-50` + 빈 원 표시 확인
- [x] 활성 태그 색상 채운 원형 아이콘 확인
- [x] 전체 303개 테스트 통과 (기존 4개 Firebase 설정 오류는 이 PR과 무관한 사전 실패)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)