### PR TITLE
#23 fix: 중앙 캘린더 at-time/period 이벤트 표시 구분

### DIFF
--- a/src/calendar/MainCalendarGrid.tsx
+++ b/src/calendar/MainCalendarGrid.tsx
@@ -198,23 +198,37 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
                     className="grid grid-cols-7 relative"
                     style={{ height: `${EVENT_ROW_HEIGHT}px`, marginBottom: `${EVENT_ROW_GAP}px` }}
                   >
-                    {row.map((ev) => (
-                      <div
-                        key={ev.event.event.uuid}
-                        className="truncate rounded px-1.5 py-0.5 text-[10px] leading-tight text-white cursor-pointer pointer-events-auto"
-                        data-testid="event-bar"
-                        style={{
-                          gridColumn: `${ev.startCol} / ${ev.endCol + 1}`,
-                          backgroundColor: getEventColor(ev, getColorForTagId),
-                        }}
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          onEventClick?.(ev.event, e.currentTarget.getBoundingClientRect())
-                        }}
-                      >
-                        {showEventNames ? ev.event.event.name : '\u00A0'}
-                      </div>
-                    ))}
+                    {row.map((ev) => {
+                      const timeType = getEventTimeType(ev)
+                      const color = getEventColor(ev, getColorForTagId)
+                      const isAtTime = timeType === 'at'
+
+                      return (
+                        <div
+                          key={ev.event.event.uuid}
+                          className={`truncate rounded px-1.5 py-0.5 text-[10px] leading-tight cursor-pointer pointer-events-auto ${
+                            isAtTime ? 'flex items-center text-[#45454a]' : 'text-white'
+                          }`}
+                          data-testid="event-bar"
+                          style={{
+                            gridColumn: `${ev.startCol} / ${ev.endCol + 1}`,
+                            backgroundColor: isAtTime ? 'transparent' : color,
+                          }}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            onEventClick?.(ev.event, e.currentTarget.getBoundingClientRect())
+                          }}
+                        >
+                          {isAtTime && (
+                            <span
+                              className="inline-block h-[6px] w-[6px] rounded-full mr-1 shrink-0"
+                              style={{ backgroundColor: color }}
+                            />
+                          )}
+                          {showEventNames ? ev.event.event.name : '\u00A0'}
+                        </div>
+                      )
+                    })}
                   </div>
                 ))}
 
@@ -244,4 +258,12 @@ function getEventColor(
     return getColorForTagId(tagId) ?? '#9ca3af'
   }
   return '#9ca3af'
+}
+
+export function getEventTimeType(ev: EventOnWeekRow): string {
+  const calEvent = ev.event
+  if (calEvent.type === 'todo') {
+    return calEvent.event.event_time?.time_type ?? 'at'
+  }
+  return calEvent.event.event_time.time_type
 }

--- a/src/calendar/MainCalendarGrid.tsx
+++ b/src/calendar/MainCalendarGrid.tsx
@@ -206,8 +206,8 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
                       return (
                         <div
                           key={ev.event.event.uuid}
-                          className={`truncate rounded px-1.5 py-0.5 text-[10px] leading-tight cursor-pointer pointer-events-auto ${
-                            isAtTime ? 'flex items-center text-[#45454a]' : 'text-white'
+                          className={`flex items-center rounded px-1.5 py-0.5 text-[10px] leading-tight cursor-pointer pointer-events-auto overflow-hidden ${
+                            isAtTime ? 'text-[#45454a]' : 'text-white'
                           }`}
                           data-testid="event-bar"
                           style={{
@@ -219,13 +219,14 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
                             onEventClick?.(ev.event, e.currentTarget.getBoundingClientRect())
                           }}
                         >
-                          {isAtTime && (
-                            <span
-                              className="inline-block h-[6px] w-[6px] rounded-full mr-1 shrink-0"
-                              style={{ backgroundColor: color }}
-                            />
-                          )}
-                          {showEventNames ? ev.event.event.name : '\u00A0'}
+                          <span
+                            className="inline-block h-[6px] w-[6px] rounded-full mr-1 shrink-0"
+                            style={{ backgroundColor: isAtTime ? color : 'rgba(255,255,255,0.8)' }}
+                          />
+                          {isAtTime
+                            ? <span className="truncate min-w-0">{showEventNames ? ev.event.event.name : '\u00A0'}</span>
+                            : (showEventNames ? ev.event.event.name : '\u00A0')
+                          }
                         </div>
                       )
                     })}
@@ -260,7 +261,7 @@ function getEventColor(
   return '#9ca3af'
 }
 
-export function getEventTimeType(ev: EventOnWeekRow): string {
+export function getEventTimeType(ev: EventOnWeekRow): 'at' | 'period' | 'allday' {
   const calEvent = ev.event
   if (calEvent.type === 'todo') {
     return calEvent.event.event_time?.time_type ?? 'at'

--- a/tests/calendar/MainCalendarGrid.test.tsx
+++ b/tests/calendar/MainCalendarGrid.test.tsx
@@ -9,6 +9,7 @@ import { useHolidayStore } from '../../src/stores/holidayStore'
 import { useEventTagStore } from '../../src/stores/eventTagStore'
 import type { CalendarEvent } from '../../src/utils/eventTimeUtils'
 
+vi.mock('../../src/firebase', () => ({ auth: {} }))
 vi.mock('../../src/api/todoApi', () => ({
   todoApi: { getTodos: vi.fn(async () => []) },
 }))

--- a/tests/calendar/eventTimeType.test.ts
+++ b/tests/calendar/eventTimeType.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getEventTimeType } from '../../src/calendar/MainCalendarGrid'
+
+vi.mock('../../src/firebase', () => ({ auth: {} }))
+vi.mock('../../src/api/todoApi', () => ({
+  todoApi: { getTodos: vi.fn(async () => []) },
+}))
+vi.mock('../../src/api/scheduleApi', () => ({
+  scheduleApi: { getSchedules: vi.fn(async () => []) },
+}))
+import type { EventOnWeekRow } from '../../src/calendar/weekEventStackBuilder'
+
+function makeAtTimeTodo(): EventOnWeekRow {
+  return {
+    event: {
+      type: 'todo',
+      event: {
+        uuid: 't1',
+        name: '시점 할 일',
+        is_current: false,
+        event_tag_id: null,
+        event_time: { time_type: 'at', timestamp: 1700000000 },
+      },
+    },
+    startCol: 1,
+    endCol: 1,
+  }
+}
+
+function makeTodoWithoutEventTime(): EventOnWeekRow {
+  return {
+    event: {
+      type: 'todo',
+      event: {
+        uuid: 't2',
+        name: '이벤트 시간 없는 할 일',
+        is_current: false,
+        event_tag_id: null,
+        event_time: null,
+      },
+    },
+    startCol: 2,
+    endCol: 2,
+  }
+}
+
+function makePeriodSchedule(): EventOnWeekRow {
+  return {
+    event: {
+      type: 'schedule',
+      event: {
+        uuid: 's1',
+        name: '기간 일정',
+        event_tag_id: null,
+        event_time: { time_type: 'period', period_start: 1700000000, period_end: 1700086400 },
+      },
+    },
+    startCol: 1,
+    endCol: 2,
+  }
+}
+
+function makeAllDaySchedule(): EventOnWeekRow {
+  return {
+    event: {
+      type: 'schedule',
+      event: {
+        uuid: 's2',
+        name: '종일 일정',
+        event_tag_id: null,
+        event_time: { time_type: 'allday', period_start: 1700000000, period_end: 1700086400, seconds_from_gmt: 32400 },
+      },
+    },
+    startCol: 3,
+    endCol: 5,
+  }
+}
+
+function makeAtTimeSchedule(): EventOnWeekRow {
+  return {
+    event: {
+      type: 'schedule',
+      event: {
+        uuid: 's3',
+        name: '시점 일정',
+        event_tag_id: null,
+        event_time: { time_type: 'at', timestamp: 1700000000 },
+      },
+    },
+    startCol: 1,
+    endCol: 1,
+  }
+}
+
+describe('getEventTimeType', () => {
+  it('todo에 at 타입 event_time이 있으면 at을 반환한다', () => {
+    // given
+    const ev = makeAtTimeTodo()
+
+    // when
+    const result = getEventTimeType(ev)
+
+    // then
+    expect(result).toBe('at')
+  })
+
+  it('todo에 event_time이 없으면 at을 반환한다', () => {
+    // given
+    const ev = makeTodoWithoutEventTime()
+
+    // when
+    const result = getEventTimeType(ev)
+
+    // then
+    expect(result).toBe('at')
+  })
+
+  it('schedule에 period 타입 event_time이 있으면 period를 반환한다', () => {
+    // given
+    const ev = makePeriodSchedule()
+
+    // when
+    const result = getEventTimeType(ev)
+
+    // then
+    expect(result).toBe('period')
+  })
+
+  it('schedule에 allday 타입 event_time이 있으면 allday를 반환한다', () => {
+    // given
+    const ev = makeAllDaySchedule()
+
+    // when
+    const result = getEventTimeType(ev)
+
+    // then
+    expect(result).toBe('allday')
+  })
+
+  it('schedule에 at 타입 event_time이 있으면 at을 반환한다', () => {
+    // given
+    const ev = makeAtTimeSchedule()
+
+    // when
+    const result = getEventTimeType(ev)
+
+    // then
+    expect(result).toBe('at')
+  })
+})


### PR DESCRIPTION
## Summary

- at-time 이벤트(시점): 배경색 제거, 이벤트 색상 6px dot + `#45454a` 텍스트로 표시
- period/allday 이벤트(기간): 기존과 동일하게 배경색 + white 텍스트 유지
- `getEventTimeType` 헬퍼 함수 export → 5개 유닛 테스트 추가
- 사전 실패하던 `MainCalendarGrid.test.tsx` firebase mock 누락 수정

Closes #23

## Test plan

- [ ] `getEventTimeType` 유닛 테스트 5개 통과 확인
- [ ] `MainCalendarGrid.test.tsx` 9개 테스트 통과 확인
- [ ] at-time todo/schedule 이벤트 바가 투명 배경 + colored dot으로 렌더링되는지 시각 확인
- [ ] period/allday 이벤트 바가 기존 배경색으로 렌더링되는지 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)