### PR TITLE
#25 fix: 우측 이벤트 패널 디자인 전면 개선

### DIFF
--- a/src/components/CreateEventButton.tsx
+++ b/src/components/CreateEventButton.tsx
@@ -18,18 +18,15 @@ export function CreateEventButton() {
   return (
     <>
       <button
-        className="flex items-center gap-2 rounded-[5px] bg-[#f3f4f7] px-2 w-full hover:brightness-95 transition-colors"
-        style={{ height: 50 }}
+        className="flex items-center justify-center gap-2 rounded-[5px] bg-[#303646] px-3 py-2.5 w-full hover:brightness-110 transition-colors"
         onClick={() => setShowPopup(true)}
       >
         {/* + 아이콘 */}
-        <div className="shrink-0 flex items-center justify-center" style={{ width: 52 }}>
-          <svg className="h-5 w-5 text-[#969696]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-        </div>
+        <svg className="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+        </svg>
 
-        <span className="text-sm text-[#969696]">
+        <span className="text-sm text-white font-medium">
           {t('main.create_event', 'Create')}
         </span>
       </button>

--- a/src/components/CurrentTodoList.tsx
+++ b/src/components/CurrentTodoList.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
-import { useTranslation } from 'react-i18next'
 import { todoApi } from '../api/todoApi'
 import { useCurrentTodosStore } from '../stores/currentTodosStore'
 import { useCalendarEventsStore } from '../stores/calendarEventsStore'
-import { useEventTagStore, DEFAULT_TAG_ID, HOLIDAY_TAG_ID } from '../stores/eventTagStore'
+import { useEventTagStore } from '../stores/eventTagStore'
 import { useTagFilterStore } from '../stores/tagFilterStore'
+import { useTagName } from '../hooks/useTagName'
 import { RepeatingScopeDialog, type RepeatScope } from './RepeatingScopeDialog'
 import { nextRepeatingTime, getStartTimestamp } from '../utils/repeatingTimeCalculator'
 import { refreshAllTodoStores } from '../utils/todoActions'
@@ -16,21 +16,13 @@ interface CurrentTodoListProps {
 }
 
 export function CurrentTodoList({ showHeader = true }: CurrentTodoListProps) {
-  const { t } = useTranslation()
   const todos = useCurrentTodosStore(s => s.todos)
   const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
-  const tags = useEventTagStore(s => s.tags)
   const { isTagHidden } = useTagFilterStore()
+  const getTagName = useTagName()
   const navigate = useNavigate()
   const location = useLocation()
   const [scopeTarget, setScopeTarget] = useState<Todo | null>(null)
-
-  function getTagName(tagId: string | null | undefined): string {
-    if (!tagId) return ''
-    if (tagId === DEFAULT_TAG_ID) return t('tag.default_name', 'Default')
-    if (tagId === HOLIDAY_TAG_ID) return t('tag.holiday_name', 'Holiday')
-    return tags.get(tagId)?.name ?? ''
-  }
 
   async function handleComplete(todo: Todo) {
     if (todo.repeating && todo.event_time) {

--- a/src/components/CurrentTodoList.tsx
+++ b/src/components/CurrentTodoList.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { todoApi } from '../api/todoApi'
 import { useCurrentTodosStore } from '../stores/currentTodosStore'
 import { useCalendarEventsStore } from '../stores/calendarEventsStore'
-import { useEventTagStore } from '../stores/eventTagStore'
+import { useEventTagStore, DEFAULT_TAG_ID, HOLIDAY_TAG_ID } from '../stores/eventTagStore'
 import { useTagFilterStore } from '../stores/tagFilterStore'
 import { RepeatingScopeDialog, type RepeatScope } from './RepeatingScopeDialog'
-import { CellTimeLabel } from './CellTimeLabel'
 import { nextRepeatingTime, getStartTimestamp } from '../utils/repeatingTimeCalculator'
 import { refreshAllTodoStores } from '../utils/todoActions'
 import type { Todo } from '../models'
@@ -16,12 +16,21 @@ interface CurrentTodoListProps {
 }
 
 export function CurrentTodoList({ showHeader = true }: CurrentTodoListProps) {
+  const { t } = useTranslation()
   const todos = useCurrentTodosStore(s => s.todos)
   const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
+  const tags = useEventTagStore(s => s.tags)
   const { isTagHidden } = useTagFilterStore()
   const navigate = useNavigate()
   const location = useLocation()
   const [scopeTarget, setScopeTarget] = useState<Todo | null>(null)
+
+  function getTagName(tagId: string | null | undefined): string {
+    if (!tagId) return ''
+    if (tagId === DEFAULT_TAG_ID) return t('tag.default_name', 'Default')
+    if (tagId === HOLIDAY_TAG_ID) return t('tag.holiday_name', 'Holiday')
+    return tags.get(tagId)?.name ?? ''
+  }
 
   async function handleComplete(todo: Todo) {
     if (todo.repeating && todo.event_time) {
@@ -80,35 +89,34 @@ export function CurrentTodoList({ showHeader = true }: CurrentTodoListProps) {
           const color = todo.event_tag_id
             ? (getColorForTagId(todo.event_tag_id) ?? '#9ca3af')
             : '#9ca3af'
+          const tagName = getTagName(todo.event_tag_id)
           return (
             <div
               key={todo.uuid}
-              className="flex items-center gap-2 rounded-[5px] bg-[#f3f4f7] px-2 hover:brightness-95 cursor-pointer"
-              style={{ height: 50 }}
+              className="flex items-stretch gap-2 rounded-[5px] bg-[#f3f4f7] px-3 py-2.5 hover:brightness-95 cursor-pointer"
               onClick={() => navigate(`/events/${todo.uuid}?type=todo`, {
                 state: { background: location, eventType: 'todo' },
               })}
             >
-              {/* 좌측 시간 영역 52px */}
-              <div className="shrink-0" style={{ width: 52 }}>
-                <CellTimeLabel type="todo" eventTime={todo.event_time} />
-              </div>
-
-              {/* 컬러바 6px */}
+              {/* 컬러바 3px */}
               <div
-                className="shrink-0 self-stretch rounded-[3px] my-2"
-                style={{ width: 6, backgroundColor: color }}
+                className="shrink-0 self-stretch rounded-full"
+                style={{ width: 3, backgroundColor: color }}
               />
 
-              {/* 이벤트 정보 */}
+              {/* 이벤트 정보 3줄 */}
               <div className="flex-1 min-w-0">
-                <p className="truncate text-sm font-medium text-[#323232]">{todo.name}</p>
+                <p className="truncate text-sm font-semibold text-[#323232]">{todo.name}</p>
+                <p className="truncate text-xs text-[#646464]">Todo</p>
+                {tagName && (
+                  <p className="truncate text-[11px] text-[#969696]">{tagName}</p>
+                )}
               </div>
 
               {/* 완료 버튼 */}
               <button
                 aria-label={todo.name}
-                className="shrink-0 h-5 w-5 rounded-full border-2 border-[#ccd0dc] hover:border-[#323232] transition-colors"
+                className="shrink-0 h-5 w-5 rounded-full border-2 border-[#ccd0dc] hover:border-[#323232] transition-colors self-center"
                 onClick={(e) => { e.stopPropagation(); handleComplete(todo) }}
               />
             </div>

--- a/src/components/DayEventList.tsx
+++ b/src/components/DayEventList.tsx
@@ -1,15 +1,34 @@
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useCalendarEventsStore } from '../stores/calendarEventsStore'
-import { useEventTagStore } from '../stores/eventTagStore'
+import { useEventTagStore, DEFAULT_TAG_ID, HOLIDAY_TAG_ID } from '../stores/eventTagStore'
 import { useTagFilterStore } from '../stores/tagFilterStore'
 import { formatDateKey } from '../utils/eventTimeUtils'
-import { CellTimeLabel } from './CellTimeLabel'
 import type { CalendarEvent } from '../utils/eventTimeUtils'
 import type { EventTime } from '../models'
 
+function TimeDescription({ eventTime }: { eventTime?: EventTime }) {
+  if (!eventTime) return <span>Todo</span>
+  switch (eventTime.time_type) {
+    case 'at': {
+      const d = new Date(eventTime.timestamp * 1000)
+      return <span>{d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}</span>
+    }
+    case 'allday':
+      return <span>All day</span>
+    case 'period': {
+      const start = new Date(eventTime.period_start * 1000)
+      const end = new Date(eventTime.period_end * 1000)
+      const fmt = (d: Date) => d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+      return <span>{fmt(start)} - {fmt(end)}</span>
+    }
+  }
+}
+
 function EventItem({ calEvent, onNavigate }: { calEvent: CalendarEvent; onNavigate: () => void }) {
+  const { t } = useTranslation()
   const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
+  const tags = useEventTagStore(s => s.tags)
 
   const { name, event_tag_id, event_time } = calEvent.type === 'todo'
     ? { ...calEvent.event, event_time: calEvent.event.event_time ?? undefined }
@@ -17,42 +36,38 @@ function EventItem({ calEvent, onNavigate }: { calEvent: CalendarEvent; onNaviga
 
   const color = event_tag_id ? (getColorForTagId(event_tag_id) ?? '#9ca3af') : '#9ca3af'
 
+  function getTagName(tagId: string | null | undefined): string {
+    if (!tagId) return ''
+    if (tagId === DEFAULT_TAG_ID) return t('tag.default_name', 'Default')
+    if (tagId === HOLIDAY_TAG_ID) return t('tag.holiday_name', 'Holiday')
+    return tags.get(tagId)?.name ?? ''
+  }
+
+  const tagName = getTagName(event_tag_id)
+
   return (
     <div
-      className="flex items-center gap-2 rounded-[5px] bg-[#f3f4f7] px-2 hover:brightness-95 cursor-pointer"
-      style={{ height: 50 }}
+      className="flex items-stretch gap-2 rounded-[5px] bg-[#f3f4f7] px-3 py-2.5 hover:brightness-95 cursor-pointer"
       onClick={onNavigate}
     >
-      {/* 좌측 시간 영역 52px */}
-      <div className="shrink-0" style={{ width: 52 }}>
-        <CellTimeLabel type={calEvent.type} eventTime={event_time} />
-      </div>
-
-      {/* 컬러바 6px */}
+      {/* 컬러바 3px */}
       <div
-        className="shrink-0 self-stretch rounded-[3px] my-2"
-        style={{ width: 6, backgroundColor: color }}
+        className="shrink-0 self-stretch rounded-full"
+        style={{ width: 3, backgroundColor: color }}
       />
 
-      {/* 이벤트 정보 */}
+      {/* 이벤트 정보 3줄 */}
       <div className="flex-1 min-w-0">
-        <p className="truncate text-sm font-medium text-[#323232]">{name}</p>
-        {event_time && event_time.time_type === 'period' && (
-          <p className="truncate text-xs text-[#646464]">
-            <PeriodDescription eventTime={event_time} />
-          </p>
+        <p className="truncate text-sm font-semibold text-[#323232]">{name}</p>
+        <p className="truncate text-xs text-[#646464]">
+          <TimeDescription eventTime={event_time} />
+        </p>
+        {tagName && (
+          <p className="truncate text-[11px] text-[#969696]">{tagName}</p>
         )}
       </div>
     </div>
   )
-}
-
-function PeriodDescription({ eventTime }: { eventTime: EventTime }) {
-  if (eventTime.time_type !== 'period') return null
-  const start = new Date(eventTime.period_start * 1000)
-  const end = new Date(eventTime.period_end * 1000)
-  const fmt = (d: Date) => d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
-  return <span>{fmt(start)} - {fmt(end)}</span>
 }
 
 interface DayEventListProps {

--- a/src/components/DayEventList.tsx
+++ b/src/components/DayEventList.tsx
@@ -1,48 +1,22 @@
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useCalendarEventsStore } from '../stores/calendarEventsStore'
-import { useEventTagStore, DEFAULT_TAG_ID, HOLIDAY_TAG_ID } from '../stores/eventTagStore'
+import { useEventTagStore } from '../stores/eventTagStore'
 import { useTagFilterStore } from '../stores/tagFilterStore'
+import { useTagName } from '../hooks/useTagName'
+import { TimeDescription } from './TimeDescription'
 import { formatDateKey } from '../utils/eventTimeUtils'
 import type { CalendarEvent } from '../utils/eventTimeUtils'
-import type { EventTime } from '../models'
-
-function TimeDescription({ eventTime }: { eventTime?: EventTime }) {
-  if (!eventTime) return <span>Todo</span>
-  switch (eventTime.time_type) {
-    case 'at': {
-      const d = new Date(eventTime.timestamp * 1000)
-      return <span>{d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}</span>
-    }
-    case 'allday':
-      return <span>All day</span>
-    case 'period': {
-      const start = new Date(eventTime.period_start * 1000)
-      const end = new Date(eventTime.period_end * 1000)
-      const fmt = (d: Date) => d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
-      return <span>{fmt(start)} - {fmt(end)}</span>
-    }
-  }
-}
 
 function EventItem({ calEvent, onNavigate }: { calEvent: CalendarEvent; onNavigate: () => void }) {
-  const { t } = useTranslation()
   const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
-  const tags = useEventTagStore(s => s.tags)
+  const getTagName = useTagName()
 
   const { name, event_tag_id, event_time } = calEvent.type === 'todo'
     ? { ...calEvent.event, event_time: calEvent.event.event_time ?? undefined }
     : { ...calEvent.event, event_time: calEvent.event.event_time }
 
   const color = event_tag_id ? (getColorForTagId(event_tag_id) ?? '#9ca3af') : '#9ca3af'
-
-  function getTagName(tagId: string | null | undefined): string {
-    if (!tagId) return ''
-    if (tagId === DEFAULT_TAG_ID) return t('tag.default_name', 'Default')
-    if (tagId === HOLIDAY_TAG_ID) return t('tag.holiday_name', 'Holiday')
-    return tags.get(tagId)?.name ?? ''
-  }
-
   const tagName = getTagName(event_tag_id)
 
   return (

--- a/src/components/ForemostEventBanner.tsx
+++ b/src/components/ForemostEventBanner.tsx
@@ -1,14 +1,33 @@
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useForemostEventStore } from '../stores/foremostEventStore'
-import { useEventTagStore } from '../stores/eventTagStore'
-import { CellTimeLabel } from './CellTimeLabel'
+import { useEventTagStore, DEFAULT_TAG_ID, HOLIDAY_TAG_ID } from '../stores/eventTagStore'
 import type { Todo } from '../models/Todo'
 import type { Schedule } from '../models/Schedule'
+import type { EventTime } from '../models'
+
+function ForemostTimeDescription({ eventTime }: { eventTime?: EventTime | null }) {
+  if (!eventTime) return <span>Todo</span>
+  switch (eventTime.time_type) {
+    case 'at': {
+      const d = new Date(eventTime.timestamp * 1000)
+      return <span>{d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}</span>
+    }
+    case 'allday':
+      return <span>All day</span>
+    case 'period': {
+      const start = new Date(eventTime.period_start * 1000)
+      const end = new Date(eventTime.period_end * 1000)
+      const fmt = (d: Date) => d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+      return <span>{fmt(start)} - {fmt(end)}</span>
+    }
+  }
+}
 
 export function ForemostEventBanner() {
   const foremostEvent = useForemostEventStore(s => s.foremostEvent)
   const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
+  const tags = useEventTagStore(s => s.tags)
   const navigate = useNavigate()
   const location = useLocation()
   const { t } = useTranslation()
@@ -23,6 +42,15 @@ export function ForemostEventBanner() {
   const eventTime = 'event_time' in event ? event.event_time : undefined
   const eventType = foremostEvent.is_todo ? 'todo' : 'schedule'
 
+  function getTagName(tagId: string | null | undefined): string {
+    if (!tagId) return ''
+    if (tagId === DEFAULT_TAG_ID) return t('tag.default_name', 'Default')
+    if (tagId === HOLIDAY_TAG_ID) return t('tag.holiday_name', 'Holiday')
+    return tags.get(tagId)?.name ?? ''
+  }
+
+  const tagName = getTagName(event.event_tag_id)
+
   return (
     <section>
       <h3 className="px-1 py-2 text-[22px] font-semibold text-[#323232]">
@@ -30,26 +58,26 @@ export function ForemostEventBanner() {
       </h3>
       <button
         data-testid="foremost-banner"
-        className="flex w-full items-center gap-2 rounded-[5px] bg-[#f3f4f7] px-2 text-left hover:brightness-95"
-        style={{ height: 50 }}
+        className="flex w-full items-stretch gap-2 rounded-[5px] bg-[#f3f4f7] px-3 py-2.5 text-left hover:brightness-95"
         onClick={() => navigate(`/events/${event.uuid}?type=${eventType}`, {
           state: { background: location, eventType },
         })}
       >
-        {/* 좌측 시간 영역 52px */}
-        <div className="shrink-0" style={{ width: 52 }}>
-          <CellTimeLabel type={eventType} eventTime={eventTime} />
-        </div>
-
-        {/* 컬러바 6px */}
+        {/* 컬러바 3px */}
         <div
-          className="shrink-0 self-stretch rounded-[3px] my-2"
-          style={{ width: 6, backgroundColor: color }}
+          className="shrink-0 self-stretch rounded-full"
+          style={{ width: 3, backgroundColor: color }}
         />
 
-        {/* 이벤트 정보 */}
+        {/* 이벤트 정보 3줄 */}
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-medium text-[#323232]">{event.name}</p>
+          <p className="truncate text-sm font-semibold text-[#323232]">{event.name}</p>
+          <p className="truncate text-xs text-[#646464]">
+            <ForemostTimeDescription eventTime={eventTime} />
+          </p>
+          {tagName && (
+            <p className="truncate text-[11px] text-[#969696]">{tagName}</p>
+          )}
         </div>
       </button>
     </section>

--- a/src/components/ForemostEventBanner.tsx
+++ b/src/components/ForemostEventBanner.tsx
@@ -1,36 +1,19 @@
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useForemostEventStore } from '../stores/foremostEventStore'
-import { useEventTagStore, DEFAULT_TAG_ID, HOLIDAY_TAG_ID } from '../stores/eventTagStore'
+import { useEventTagStore } from '../stores/eventTagStore'
+import { useTagName } from '../hooks/useTagName'
+import { TimeDescription } from './TimeDescription'
 import type { Todo } from '../models/Todo'
 import type { Schedule } from '../models/Schedule'
-import type { EventTime } from '../models'
-
-function ForemostTimeDescription({ eventTime }: { eventTime?: EventTime | null }) {
-  if (!eventTime) return <span>Todo</span>
-  switch (eventTime.time_type) {
-    case 'at': {
-      const d = new Date(eventTime.timestamp * 1000)
-      return <span>{d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}</span>
-    }
-    case 'allday':
-      return <span>All day</span>
-    case 'period': {
-      const start = new Date(eventTime.period_start * 1000)
-      const end = new Date(eventTime.period_end * 1000)
-      const fmt = (d: Date) => d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
-      return <span>{fmt(start)} - {fmt(end)}</span>
-    }
-  }
-}
 
 export function ForemostEventBanner() {
   const foremostEvent = useForemostEventStore(s => s.foremostEvent)
   const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
-  const tags = useEventTagStore(s => s.tags)
   const navigate = useNavigate()
   const location = useLocation()
   const { t } = useTranslation()
+  const getTagName = useTagName()
 
   if (!foremostEvent?.event) return null
 
@@ -41,14 +24,6 @@ export function ForemostEventBanner() {
 
   const eventTime = 'event_time' in event ? event.event_time : undefined
   const eventType = foremostEvent.is_todo ? 'todo' : 'schedule'
-
-  function getTagName(tagId: string | null | undefined): string {
-    if (!tagId) return ''
-    if (tagId === DEFAULT_TAG_ID) return t('tag.default_name', 'Default')
-    if (tagId === HOLIDAY_TAG_ID) return t('tag.holiday_name', 'Holiday')
-    return tags.get(tagId)?.name ?? ''
-  }
-
   const tagName = getTagName(event.event_tag_id)
 
   return (
@@ -73,7 +48,7 @@ export function ForemostEventBanner() {
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-semibold text-[#323232]">{event.name}</p>
           <p className="truncate text-xs text-[#646464]">
-            <ForemostTimeDescription eventTime={eventTime} />
+            <TimeDescription eventTime={eventTime} />
           </p>
           {tagName && (
             <p className="truncate text-[11px] text-[#969696]">{tagName}</p>

--- a/src/components/QuickTodoInput.tsx
+++ b/src/components/QuickTodoInput.tsx
@@ -40,18 +40,12 @@ export function QuickTodoInput() {
 
   return (
     <div
-      className="flex items-center gap-2 rounded-[5px] bg-[#f3f4f7] px-2 transition-opacity"
-      style={{ height: 50, opacity: focused || value ? 1 : 0.5 }}
+      className="flex items-stretch gap-2 rounded-[5px] bg-[#f3f4f7] border border-gray-200 px-3 py-2.5"
     >
-      {/* 좌측 시간 영역 52px */}
-      <div className="shrink-0 text-center" style={{ width: 52 }}>
-        <p className="text-xs text-[#323232]">Todo</p>
-      </div>
-
-      {/* 컬러바 6px */}
+      {/* 컬러바 3px */}
       <div
-        className="shrink-0 self-stretch rounded-[3px] my-2"
-        style={{ width: 6, backgroundColor: tagColor }}
+        className="shrink-0 self-stretch rounded-full"
+        style={{ width: 3, backgroundColor: tagColor }}
       />
 
       {/* 입력 필드 */}

--- a/src/components/RightEventPanel.tsx
+++ b/src/components/RightEventPanel.tsx
@@ -59,7 +59,7 @@ export function RightEventPanel() {
 
           {/* TODO 섹션 */}
           <div className="mb-4">
-            <h3 className="text-xs font-semibold uppercase tracking-wider text-[#969696] mb-2">TODO</h3>
+            <h3 className="text-xs font-semibold tracking-wider text-[#969696] mb-2">Current Todo</h3>
             <div className="border-t border-border-calendar pt-2">
               <CurrentTodoList showHeader={false} />
             </div>

--- a/src/components/TimeDescription.tsx
+++ b/src/components/TimeDescription.tsx
@@ -1,0 +1,19 @@
+import type { EventTime } from '../models'
+
+export function TimeDescription({ eventTime }: { eventTime?: EventTime | null }) {
+  if (!eventTime) return <span>Todo</span>
+  switch (eventTime.time_type) {
+    case 'at': {
+      const d = new Date(eventTime.timestamp * 1000)
+      return <span>{d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}</span>
+    }
+    case 'allday':
+      return <span>All day</span>
+    case 'period': {
+      const start = new Date(eventTime.period_start * 1000)
+      const end = new Date(eventTime.period_end * 1000)
+      const fmt = (d: Date) => d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+      return <span>{fmt(start)} - {fmt(end)}</span>
+    }
+  }
+}

--- a/src/components/UncompletedTodoList.tsx
+++ b/src/components/UncompletedTodoList.tsx
@@ -4,8 +4,9 @@ import { useTranslation } from 'react-i18next'
 import { todoApi } from '../api/todoApi'
 import { useUncompletedTodosStore } from '../stores/uncompletedTodosStore'
 import { useCalendarEventsStore } from '../stores/calendarEventsStore'
-import { useEventTagStore, DEFAULT_TAG_ID, HOLIDAY_TAG_ID } from '../stores/eventTagStore'
+import { useEventTagStore } from '../stores/eventTagStore'
 import { useTagFilterStore } from '../stores/tagFilterStore'
+import { useTagName } from '../hooks/useTagName'
 import { RepeatingScopeDialog, type RepeatScope } from './RepeatingScopeDialog'
 import { nextRepeatingTime, getStartTimestamp } from '../utils/repeatingTimeCalculator'
 import { refreshAllTodoStores } from '../utils/todoActions'
@@ -16,15 +17,8 @@ export function UncompletedTodoList() {
   const todos = useUncompletedTodosStore(s => s.todos)
   const reload = useUncompletedTodosStore(s => s.fetch)
   const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
-  const tags = useEventTagStore(s => s.tags)
   const { isTagHidden } = useTagFilterStore()
-
-  function getTagName(tagId: string | null | undefined): string {
-    if (!tagId) return ''
-    if (tagId === DEFAULT_TAG_ID) return t('tag.default_name', 'Default')
-    if (tagId === HOLIDAY_TAG_ID) return t('tag.holiday_name', 'Holiday')
-    return tags.get(tagId)?.name ?? ''
-  }
+  const getTagName = useTagName()
   const navigate = useNavigate()
   const location = useLocation()
   const [scopeTarget, setScopeTarget] = useState<Todo | null>(null)

--- a/src/components/UncompletedTodoList.tsx
+++ b/src/components/UncompletedTodoList.tsx
@@ -4,10 +4,9 @@ import { useTranslation } from 'react-i18next'
 import { todoApi } from '../api/todoApi'
 import { useUncompletedTodosStore } from '../stores/uncompletedTodosStore'
 import { useCalendarEventsStore } from '../stores/calendarEventsStore'
-import { useEventTagStore } from '../stores/eventTagStore'
+import { useEventTagStore, DEFAULT_TAG_ID, HOLIDAY_TAG_ID } from '../stores/eventTagStore'
 import { useTagFilterStore } from '../stores/tagFilterStore'
 import { RepeatingScopeDialog, type RepeatScope } from './RepeatingScopeDialog'
-import { CellTimeLabel } from './CellTimeLabel'
 import { nextRepeatingTime, getStartTimestamp } from '../utils/repeatingTimeCalculator'
 import { refreshAllTodoStores } from '../utils/todoActions'
 import type { Todo } from '../models'
@@ -17,7 +16,15 @@ export function UncompletedTodoList() {
   const todos = useUncompletedTodosStore(s => s.todos)
   const reload = useUncompletedTodosStore(s => s.fetch)
   const getColorForTagId = useEventTagStore(s => s.getColorForTagId)
+  const tags = useEventTagStore(s => s.tags)
   const { isTagHidden } = useTagFilterStore()
+
+  function getTagName(tagId: string | null | undefined): string {
+    if (!tagId) return ''
+    if (tagId === DEFAULT_TAG_ID) return t('tag.default_name', 'Default')
+    if (tagId === HOLIDAY_TAG_ID) return t('tag.holiday_name', 'Holiday')
+    return tags.get(tagId)?.name ?? ''
+  }
   const navigate = useNavigate()
   const location = useLocation()
   const [scopeTarget, setScopeTarget] = useState<Todo | null>(null)
@@ -88,35 +95,34 @@ export function UncompletedTodoList() {
           const color = todo.event_tag_id
             ? (getColorForTagId(todo.event_tag_id) ?? '#9ca3af')
             : '#9ca3af'
+          const tagName = getTagName(todo.event_tag_id)
           return (
             <div
               key={todo.uuid}
-              className="flex items-center gap-2 rounded-[5px] bg-[#f3f4f7] px-2 hover:brightness-95 cursor-pointer"
-              style={{ height: 50 }}
+              className="flex items-stretch gap-2 rounded-[5px] bg-[#f3f4f7] px-3 py-2.5 hover:brightness-95 cursor-pointer"
               onClick={() => navigate(`/events/${todo.uuid}?type=todo`, {
                 state: { background: location, eventType: 'todo' },
               })}
             >
-              {/* 좌측 시간 영역 52px */}
-              <div className="shrink-0" style={{ width: 52 }}>
-                <CellTimeLabel type="todo" eventTime={todo.event_time} />
-              </div>
-
-              {/* 컬러바 6px */}
+              {/* 컬러바 3px */}
               <div
-                className="shrink-0 self-stretch rounded-[3px] my-2"
-                style={{ width: 6, backgroundColor: color }}
+                className="shrink-0 self-stretch rounded-full"
+                style={{ width: 3, backgroundColor: color }}
               />
 
               {/* 이벤트 정보 - 미완료 todo는 빨간색 */}
               <div className="flex-1 min-w-0">
-                <p className="truncate text-sm font-medium text-[#ea4444]">{todo.name}</p>
+                <p className="truncate text-sm font-semibold text-[#ea4444]">{todo.name}</p>
+                <p className="truncate text-xs text-[#646464]">Todo</p>
+                {tagName && (
+                  <p className="truncate text-[11px] text-[#969696]">{tagName}</p>
+                )}
               </div>
 
               {/* 완료 버튼 */}
               <button
                 aria-label={todo.name}
-                className="shrink-0 h-5 w-5 rounded-full border-2 border-[#ccd0dc] hover:border-[#323232] transition-colors"
+                className="shrink-0 h-5 w-5 rounded-full border-2 border-[#ccd0dc] hover:border-[#323232] transition-colors self-center"
                 onClick={(e) => { e.stopPropagation(); handleComplete(todo) }}
               />
             </div>

--- a/src/hooks/useTagName.ts
+++ b/src/hooks/useTagName.ts
@@ -1,0 +1,14 @@
+import { useTranslation } from 'react-i18next'
+import { useEventTagStore, DEFAULT_TAG_ID, HOLIDAY_TAG_ID } from '../stores/eventTagStore'
+
+export function useTagName() {
+  const { t } = useTranslation()
+  const tags = useEventTagStore(s => s.tags)
+
+  return function getTagName(tagId: string | null | undefined): string {
+    if (!tagId) return ''
+    if (tagId === DEFAULT_TAG_ID) return t('tag.default_name', 'Default')
+    if (tagId === HOLIDAY_TAG_ID) return t('tag.holiday_name', 'Holiday')
+    return tags.get(tagId)?.name ?? ''
+  }
+}

--- a/tests/components/RightEventPanel.test.tsx
+++ b/tests/components/RightEventPanel.test.tsx
@@ -8,7 +8,9 @@ import { useCurrentTodosStore } from '../../src/stores/currentTodosStore'
 
 vi.mock('../../src/stores/foremostEventStore', () => ({ useForemostEventStore: vi.fn() }))
 vi.mock('../../src/stores/eventTagStore', () => ({
-  useEventTagStore: vi.fn((selector: any) => selector({ getColorForTagId: () => null })),
+  useEventTagStore: vi.fn((selector: any) => selector({ getColorForTagId: () => null, tags: new Map() })),
+  DEFAULT_TAG_ID: 'default',
+  HOLIDAY_TAG_ID: 'holiday',
 }))
 vi.mock('../../src/api/todoApi', () => ({
   todoApi: { createTodo: vi.fn(), getCurrentTodos: vi.fn().mockResolvedValue([]) },
@@ -116,7 +118,7 @@ describe('RightEventPanel', () => {
   it('QuickTodoInput이 하단 고정 영역에 표시된다', () => {
     renderComponent()
 
-    expect(screen.getByText('Todo')).toBeInTheDocument()
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
   })
 
   it('selectedDate가 없어도 CurrentTodoList의 항목이 표시된다', () => {


### PR DESCRIPTION
## Summary
- 이벤트 아이템 3줄 레이아웃 적용: 이벤트명 / 시간(또는 "Todo") / 태그명
- 좌측 색상 띠 6px → 3px (DayEventList, CurrentTodoList, UncompletedTodoList, ForemostEventBanner, QuickTodoInput 전 컴포넌트 공통)
- CellTimeLabel 52px 좌측 영역 제거, 컬러바 좌측 배치로 레이아웃 단순화
- "TODO" 섹션명 → "Current Todo"로 변경
- QuickTodoInput: opacity 조건 제거, border 추가
- CreateEventButton: 진한 배경(#303646) + 흰색 텍스트로 강조 디자인

## Test plan
- [x] TypeScript 빌드 통과 확인
- [x] 기존 RightEventPanel 테스트 수정 후 통과 확인
- [ ] 수동 UI 확인: 이벤트 아이템 3줄 표시 (이름/시간/태그명)
- [ ] 수동 UI 확인: 컬러바 3px 적용
- [ ] 수동 UI 확인: QuickTodoInput + CreateEventButton 하단 강조 디자인

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)