### PR TITLE
#70 ColorPalette 접근성/안전성 개선

### DIFF
--- a/src/components/ColorPalette.tsx
+++ b/src/components/ColorPalette.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+
 export const PRESET_COLORS = [
   '#ef4444', '#f97316', '#eab308', '#22c55e',
   '#3b82f6', '#8b5cf6', '#ec4899', '#6b7280',
@@ -10,12 +12,16 @@ interface ColorPaletteProps {
 }
 
 export function ColorPalette({ colors = PRESET_COLORS, selected, onChange }: ColorPaletteProps) {
+  const { t } = useTranslation()
   return (
     <div className="flex flex-wrap gap-2">
       {colors.map(color => (
         <button
           key={color}
+          type="button"
           title={color}
+          aria-label={t('common.color_select', { hex: color })}
+          aria-pressed={selected === color}
           onClick={() => onChange(color)}
           className={`h-7 w-7 rounded-full border-2 transition-transform ${
             selected === color ? 'border-gray-800 scale-110' : 'border-transparent'

--- a/src/components/ColorPalette.tsx
+++ b/src/components/ColorPalette.tsx
@@ -20,7 +20,7 @@ export function ColorPalette({ colors = PRESET_COLORS, selected, onChange }: Col
           key={color}
           type="button"
           title={color}
-          aria-label={t('common.color_select', { hex: color })}
+          aria-label={t('common.select_color', { hex: color })}
           aria-pressed={selected === color}
           onClick={() => onChange(color)}
           className={`h-7 w-7 rounded-full border-2 transition-transform ${

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,7 +4,7 @@
   "nav.settings": "Settings",
   "common.save": "Save",
   "common.cancel": "Cancel",
-  "common.color_select": "Select color: {{hex}}",
+  "common.select_color": "Select color: {{hex}}",
   "common.delete": "Delete",
   "common.edit": "Edit",
   "common.back": "← Back",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,6 +4,7 @@
   "nav.settings": "Settings",
   "common.save": "Save",
   "common.cancel": "Cancel",
+  "common.color_select": "Select color: {{hex}}",
   "common.delete": "Delete",
   "common.edit": "Edit",
   "common.back": "← Back",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -4,6 +4,7 @@
   "nav.settings": "설정",
   "common.save": "저장",
   "common.cancel": "취소",
+  "common.color_select": "색상 선택: {{hex}}",
   "common.delete": "삭제",
   "common.edit": "편집",
   "common.back": "← 뒤로",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -4,7 +4,7 @@
   "nav.settings": "설정",
   "common.save": "저장",
   "common.cancel": "취소",
-  "common.color_select": "색상 선택: {{hex}}",
+  "common.select_color": "색상 선택: {{hex}}",
   "common.delete": "삭제",
   "common.edit": "편집",
   "common.back": "← 뒤로",

--- a/tests/components/ColorPalette.test.tsx
+++ b/tests/components/ColorPalette.test.tsx
@@ -1,38 +1,67 @@
-import { describe, it, expect, vi } from 'vitest'
+import { useState } from 'react'
+import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { ColorPalette } from '../../src/components/ColorPalette'
+import { ColorPalette, PRESET_COLORS } from '../../src/components/ColorPalette'
 
-const COLORS = ['#ef4444', '#3b82f6', '#22c55e']
+function labelPattern(hex: string) {
+  return new RegExp(`색상 선택.*${hex}|Select color.*${hex}`)
+}
 
 describe('ColorPalette', () => {
-  it('전달된 색상 버튼을 렌더한다', () => {
+  it('각 프리셋 색상이 aria-label 로 식별 가능한 버튼으로 렌더된다', () => {
     // given / when
-    render(<ColorPalette colors={COLORS} selected="#ef4444" onChange={vi.fn()} />)
-
-    // then: 각 색상마다 버튼이 존재
-    expect(screen.getAllByRole('button')).toHaveLength(3)
-  })
-
-  it('색상 버튼 클릭 시 onChange가 호출된다', async () => {
-    // given
-    const onChange = vi.fn()
-    render(<ColorPalette colors={COLORS} selected="#ef4444" onChange={onChange} />)
-
-    // when: 두 번째 버튼(#3b82f6) 클릭
-    await userEvent.click(screen.getAllByRole('button')[1])
+    render(<ColorPalette selected={PRESET_COLORS[0]} onChange={() => {}} />)
 
     // then
-    expect(onChange).toHaveBeenCalled()
+    for (const hex of PRESET_COLORS) {
+      expect(screen.getByRole('button', { name: labelPattern(hex) })).toBeInTheDocument()
+    }
   })
 
-  it('selected 색상 버튼에 강조 테두리 클래스가 적용된다', () => {
+  it('선택된 색상 버튼은 aria-pressed="true" 가 되고 그 외는 "false" 다', () => {
     // given / when
-    render(<ColorPalette colors={COLORS} selected="#3b82f6" onChange={vi.fn()} />)
+    render(<ColorPalette selected="#22c55e" onChange={() => {}} />)
+
+    // then
+    expect(screen.getByRole('button', { name: labelPattern('#22c55e') })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: labelPattern('#ef4444') })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('모든 버튼은 type="button" 이라 form 내부에서도 submit 을 유발하지 않는다', () => {
+    // given / when
+    render(<ColorPalette selected={PRESET_COLORS[0]} onChange={() => {}} />)
 
     // then
     const buttons = screen.getAllByRole('button')
-    expect(buttons[1]).toHaveClass('border-gray-800')
-    expect(buttons[0]).not.toHaveClass('border-gray-800')
+    for (const b of buttons) expect(b).toHaveAttribute('type', 'button')
+  })
+
+  it('색상 버튼을 클릭하면 해당 색이 선택 상태로 전환된다', async () => {
+    // given — 실제 상태를 가진 Wrapper 로 렌더
+    function Wrapper() {
+      const [selected, setSelected] = useState('#ef4444')
+      return <ColorPalette selected={selected} onChange={setSelected} />
+    }
+    const user = userEvent.setup()
+    render(<Wrapper />)
+    expect(screen.getByRole('button', { name: labelPattern('#ef4444') })).toHaveAttribute('aria-pressed', 'true')
+
+    // when — 다른 색 클릭
+    await user.click(screen.getByRole('button', { name: labelPattern('#22c55e') }))
+
+    // then — 선택 상태가 새 색으로 이동 (사용자 관점 결과)
+    expect(screen.getByRole('button', { name: labelPattern('#22c55e') })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: labelPattern('#ef4444') })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('custom colors prop 이 주어지면 해당 색상만 렌더한다 (기본 PRESET 무시)', () => {
+    // given / when
+    render(<ColorPalette colors={['#000000', '#ffffff']} selected="#000000" onChange={() => {}} />)
+
+    // then
+    expect(screen.getAllByRole('button')).toHaveLength(2)
+    expect(screen.getByRole('button', { name: labelPattern('#000000') })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: labelPattern('#ffffff') })).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
closes #70

## Summary

`src/components/ColorPalette.tsx` 의 각 색상 버튼에 접근성/안전성 속성 3종을 추가한다. 시각 동작은 그대로 유지한다.

- `type="button"` — form 내부 의도치 않은 submit 방지 (재사용 안전성).
- `aria-label="색상 선택: #hex"` — 스크린리더에 옵션의 hex 값을 안내 (i18n 키 `common.color_select` 신규).
- `aria-pressed={selected === color}` — 현재 선택 상태를 보조기술에 전달.

기존 단위 테스트는 border 클래스 같은 구현 세부를 검증하고 있어 CLAUDE.md Testing Philosophy (구현 아닌 동작 검증, `aria-pressed` 같은 사용자 관점 지표 사용)에 맞춰 재작성했다.

## 변경

- `src/components/ColorPalette.tsx` — `useTranslation` 도입, button 속성 3종 추가.
- `tests/components/ColorPalette.test.tsx` — aria 기반 5개 케이스 (렌더 / pressed / type / 클릭 후 상태 전환 / custom colors prop).
- `src/locales/{ko,en}.json` — `common.color_select` 키 추가.

## 영향 범위

`ColorPalette` 호출부는 다음 두 곳이지만 API(`selected`, `onChange`, `colors?`) 불변이라 수정 없음:
- `src/pages/SettingsPage.tsx`
- `src/pages/tagManagement/components/TagEditPanel.tsx`

## Test plan

- [x] 단위/컴포넌트: `npx vitest run` → **65 files / 529 tests 통과** (기존 527 + 신규 2)
- [x] E2E: `p1-tags.spec.ts` + `journey-tag-integration.spec.ts` → **11/11 통과**
  - 기존 E2E 는 `getByTitle('#hex')` 로 색상 버튼을 찾았는데 `title` 속성은 그대로 유지되므로 영향 없음을 실측 확인
- [x] `npm run build` 통과

## 관련

- PR #69 (#68) 리뷰 피드백에서 분기된 후속 작업: https://github.com/sudopark/TodoCalendar-Web/pull/69#pullrequestreview-4158114884

🤖 Generated with [Claude Code](https://claude.com/claude-code)