### PR TITLE
#76 fix: 우측 패널 이벤트 새로고침 시 중복 노출 해소

### DIFF
--- a/src/utils/eventTimeUtils.ts
+++ b/src/utils/eventTimeUtils.ts
@@ -94,14 +94,21 @@ export function groupEventsByDate(
     map.set(dateKey, list)
   }
 
-  // 단일 인스턴스(비반복 또는 반복의 한 turn)를 해당 기간 날짜들에 배치
+  // 단일 인스턴스(비반복 또는 반복의 한 turn)를 해당 기간 날짜들에 배치.
+  // 이벤트의 실제 [start, end]가 [lower, upper]를 넘어가도 범위 밖 날짜에는 배치하지 않는다 — 호출자가 지정한 범위에만 책임진다.
+  // 이게 안 지켜지면 다른 범위 fetch와 합쳐질 때 동일 날짜에 같은 이벤트가 여러 번 들어가 중복 노출 (#76).
+  const lowerDate = new Date(lower * 1000)
+  lowerDate.setHours(0, 0, 0, 0)
+  const upperDate = new Date(upper * 1000)
+  upperDate.setHours(0, 0, 0, 0)
+
   const assignInstance = (eventTime: EventTime, calEvent: CalendarEvent) => {
     if (!eventTimeOverlapsRange(eventTime, lower, upper)) return
     const start = eventTimeToStartDate(eventTime)
     const end = eventTimeToEndDate(eventTime)
-    const current = new Date(start)
+    const current = new Date(Math.max(start.getTime(), lowerDate.getTime()))
     current.setHours(0, 0, 0, 0)
-    const endDay = new Date(end)
+    const endDay = new Date(Math.min(end.getTime(), upperDate.getTime()))
     endDay.setHours(0, 0, 0, 0)
     while (current <= endDay) {
       const key = formatDateKey(current)

--- a/tests/stores/calendarEventsStore.test.ts
+++ b/tests/stores/calendarEventsStore.test.ts
@@ -108,6 +108,37 @@ describe('calendarEventsStore — refreshYears', () => {
     expect(events.some(e => e.event.uuid === 'new')).toBe(true)
     expect(events.some(e => e.event.uuid === 'old')).toBe(false)
   })
+
+  it('년도 경계를 넘는 multi-day 이벤트가 새로고침 시 중복되지 않는다 (#76)', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    // 2025-12-31 ~ 2026-01-02 까지 걸친 schedule
+    const crossYear = {
+      uuid: 'cross',
+      name: 'Cross-year',
+      event_time: {
+        time_type: 'period' as const,
+        period_start: Math.floor(new Date(2025, 11, 31, 10, 0).getTime() / 1000),
+        period_end: Math.floor(new Date(2026, 0, 2, 18, 0).getTime() / 1000),
+      },
+    }
+    vi.mocked(todoApi.getTodos).mockResolvedValue([])
+    vi.mocked(scheduleApi.getSchedules).mockResolvedValue([crossYear])
+
+    // 양쪽 년도를 모두 로드한 상태
+    await useCalendarEventsStore.getState().fetchEventsForYear(2025)
+    await useCalendarEventsStore.getState().fetchEventsForYear(2026)
+    expect(useCalendarEventsStore.getState().eventsByDate.get('2025-12-31')).toHaveLength(1)
+    expect(useCalendarEventsStore.getState().eventsByDate.get('2026-01-01')).toHaveLength(1)
+    expect(useCalendarEventsStore.getState().eventsByDate.get('2026-01-02')).toHaveLength(1)
+
+    // 새로고침해도 동일 이벤트가 한 번씩만 노출되어야 함
+    await useCalendarEventsStore.getState().refreshYears([2026])
+
+    expect(useCalendarEventsStore.getState().eventsByDate.get('2025-12-31')).toHaveLength(1)
+    expect(useCalendarEventsStore.getState().eventsByDate.get('2026-01-01')).toHaveLength(1)
+    expect(useCalendarEventsStore.getState().eventsByDate.get('2026-01-02')).toHaveLength(1)
+  })
 })
 
 describe('calendarEventsStore — mutation', () => {

--- a/tests/utils/eventTimeUtils.test.ts
+++ b/tests/utils/eventTimeUtils.test.ts
@@ -129,6 +129,31 @@ describe('groupEventsByDate', () => {
     expect(result.get('2024-06-12')).toHaveLength(1)
   })
 
+  it('년도 경계를 넘는 multi-day 이벤트는 [lower, upper] 안의 날짜에만 배치된다 (#76)', () => {
+    // given: 2025-12-31 ~ 2026-01-02 까지 걸친 schedule
+    const schedules: Schedule[] = [
+      {
+        uuid: 'cross',
+        name: 'Cross-year',
+        event_time: {
+          time_type: 'period',
+          period_start: dateToTimestamp(new Date(2025, 11, 31, 10, 0)),
+          period_end: dateToTimestamp(new Date(2026, 0, 2, 18, 0)),
+        },
+      },
+    ]
+
+    // when: 2026 year fetch
+    const lower = dateToTimestamp(new Date(2026, 0, 1))
+    const upper = dateToTimestamp(new Date(2026, 11, 31, 23, 59, 59))
+    const result = groupEventsByDate([], schedules, lower, upper)
+
+    // then: 2025-12-31은 배치되지 않고 2026 안의 날짜에만 배치
+    expect(result.get('2025-12-31')).toBeUndefined()
+    expect(result.get('2026-01-01')).toHaveLength(1)
+    expect(result.get('2026-01-02')).toHaveLength(1)
+  })
+
   it('범위 밖의 이벤트는 포함하지 않는다', () => {
     const lower = dateToTimestamp(new Date(2024, 5, 1))
     const upper = dateToTimestamp(new Date(2024, 5, 30, 23, 59, 59))


### PR DESCRIPTION
## Summary

이슈 #76: 특정 날을 선택해 우측 패널에 이벤트 리스트가 노출된 상태에서 새로고침을 누르면 같은 이벤트가 한 번씩 더 추가되어 보이는 버그.

## Root cause

`groupEventsByDate`의 `assignInstance` 루프가 이벤트의 실제 `[start, end]` 전체 일자에 분배하면서 호출자가 지정한 `[lower, upper]` 범위를 무시했다. 이 때문에 년도 경계를 넘어가는 multi-day 이벤트(예: 2025-12-31 ~ 2026-01-02)는 다음 두 단계를 거쳐 중복 저장됐다:

1. 어떤 년도(예: 2025)의 fetch가 이벤트의 모든 날짜(2025-12-31, 2026-01-01, 2026-01-02)에 분배 → eventsByDate에 저장
2. 사용자가 새로고침 → `refreshYears([2026])`이 키 prefix 기준으로 `2026-*` 엔트리만 비우고 `2025-12-31`은 유지
3. 2026 재fetch가 동일 multi-day 이벤트를 또 모든 날짜에 분배 → 살아남아 있던 `2025-12-31`에 같은 이벤트가 한 번 더 추가

`refreshYears` 한 번이 끝나면 양 측이 수렴하므로 두 번째 새로고침에서는 더 누적되지 않는다는 사용자 보고와도 일치.

## Fix

`assignInstance` 분배 루프를 호출자가 지정한 `[lower, upper]`로 클램프해 각 fetch가 자기 범위 안의 날짜에만 책임지도록 수정. 인접 년도/월 fetch와의 분배 책임이 겹치지 않게 됨.

- `current = max(start, lowerDate)`
- `endDay = min(end, upperDate)`

## Test plan

- [x] Unit: `groupEventsByDate`가 범위 밖 날짜(2025-12-31)에 배치하지 않고 `[lower, upper]` 안만 채우는지 (`tests/utils/eventTimeUtils.test.ts`)
- [x] Integration: 양 년도 fetch 후 `refreshYears([2026])` 시 `2025-12-31`, `2026-01-01`, `2026-01-02` 각각 한 번씩만 유지되는지 (`tests/stores/calendarEventsStore.test.ts`)
- [x] 기존 19 + 13 테스트 회귀 없음

closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)