### PR TITLE
fix: fetchEventsForYear 동시 호출 중복 저장 차단 (#76 follow-up)

### DIFF
--- a/src/stores/calendarEventsStore.ts
+++ b/src/stores/calendarEventsStore.ts
@@ -16,6 +16,11 @@ interface CalendarEventsState {
   reset: () => void
 }
 
+// 진행 중인 fetch promise 추적 — StrictMode 등으로 동일 년도 fetch가 동시에 호출돼도
+// 단일 promise를 공유하도록 한다. 둘 다 loadedYears에 들어가기 전에 시작되어
+// 같은 데이터를 두 번 merge하던 race condition 차단.
+const fetchInFlight = new Map<number, Promise<void>>()
+
 export const useCalendarEventsStore = create<CalendarEventsState>((set, get) => ({
   eventsByDate: new Map(),
   loading: false,
@@ -23,29 +28,46 @@ export const useCalendarEventsStore = create<CalendarEventsState>((set, get) => 
 
   fetchEventsForYear: async (year: number) => {
     if (get().loadedYears.has(year)) return
-    set({ loading: true })
-    try {
-      const range = yearRange(year)
-      const [todos, schedules] = await Promise.all([
-        todoApi.getTodos(range.lower, range.upper),
-        scheduleApi.getSchedules(range.lower, range.upper),
-      ])
-      const yearEvents = groupEventsByDate(todos, schedules, range.lower, range.upper)
-      const merged = new Map(get().eventsByDate)
-      for (const [key, events] of yearEvents) {
-        const existing = merged.get(key) ?? []
-        merged.set(key, [...existing, ...events])
+    const existing = fetchInFlight.get(year)
+    if (existing) return existing
+
+    const promise = (async () => {
+      set({ loading: true })
+      try {
+        const range = yearRange(year)
+        const [todos, schedules] = await Promise.all([
+          todoApi.getTodos(range.lower, range.upper),
+          scheduleApi.getSchedules(range.lower, range.upper),
+        ])
+        const yearEvents = groupEventsByDate(todos, schedules, range.lower, range.upper)
+        const merged = new Map(get().eventsByDate)
+        for (const [key, events] of yearEvents) {
+          const existingDayEvents = merged.get(key) ?? []
+          merged.set(key, [...existingDayEvents, ...events])
+        }
+        const newLoadedYears = new Set(get().loadedYears)
+        newLoadedYears.add(year)
+        set({ eventsByDate: merged, loading: false, loadedYears: newLoadedYears })
+      } catch (e) {
+        console.warn('이벤트 로드 실패:', e)
+        set({ loading: false })
       }
-      const newLoadedYears = new Set(get().loadedYears)
-      newLoadedYears.add(year)
-      set({ eventsByDate: merged, loading: false, loadedYears: newLoadedYears })
-    } catch (e) {
-      console.warn('이벤트 로드 실패:', e)
-      set({ loading: false })
+    })()
+    fetchInFlight.set(year, promise)
+    try {
+      await promise
+    } finally {
+      fetchInFlight.delete(year)
     }
   },
 
   refreshYears: async (years: number[]) => {
+    // 진행 중인 fetch가 있으면 먼저 끝나기를 기다린다 — cleaned 상태를 그 fetch가 덮어쓰지 않도록.
+    const pending = years.map(y => fetchInFlight.get(y)).filter((p): p is Promise<void> => p !== undefined)
+    if (pending.length > 0) {
+      await Promise.allSettled(pending)
+    }
+
     const newLoadedYears = new Set(get().loadedYears)
     years.forEach(y => newLoadedYears.delete(y))
     const cleaned = new Map<string, CalendarEvent[]>()

--- a/tests/stores/calendarEventsStore.test.ts
+++ b/tests/stores/calendarEventsStore.test.ts
@@ -82,6 +82,24 @@ describe('calendarEventsStore — fetchEventsForYear', () => {
 
     expect(useCalendarEventsStore.getState().loadedYears.has(2025)).toBe(false)
   })
+
+  it('동일 년도 동시 호출 시 중복 저장되지 않는다 (StrictMode 대응 #76)', async () => {
+    const { todoApi } = await import('../../src/api/todoApi')
+    const { scheduleApi } = await import('../../src/api/scheduleApi')
+    vi.mocked(todoApi.getTodos).mockResolvedValue([
+      { uuid: 't1', name: 'A', is_current: false, event_time: { time_type: 'at' as const, timestamp: MARCH31_TIMESTAMP } },
+    ])
+    vi.mocked(scheduleApi.getSchedules).mockResolvedValue([])
+
+    // StrictMode useEffect double-invocation을 시뮬레이션 — 두 호출 모두 loadedYears 등록 전에 시작
+    await Promise.all([
+      useCalendarEventsStore.getState().fetchEventsForYear(2025),
+      useCalendarEventsStore.getState().fetchEventsForYear(2025),
+    ])
+
+    const events = useCalendarEventsStore.getState().eventsByDate.get(MARCH31_KEY) ?? []
+    expect(events).toHaveLength(1)
+  })
 })
 
 describe('calendarEventsStore — refreshYears', () => {


### PR DESCRIPTION
## Summary

#76의 후속. 이전 PR #78의 클램프 수정은 년도 경계 multi-day 케이스만 해결했고, 사용자가 다시 보고한 "그냥 두 개씩 나오는" 증상은 별개의 race condition이 원인이었음.

## Root cause

React StrictMode + `MainCalendar`의 `useEffect` 조합:

1. 컴포넌트 마운트 → StrictMode가 useEffect를 두 번 실행
2. 두 호출 모두 `fetchEventsForYear(2026)`을 거의 동시에 시작
3. 둘 다 `if (get().loadedYears.has(year)) return` 체크 시점에는 `loadedYears`가 아직 비어있음 → early return 발동 안 됨
4. 둘 다 API fetch → 각자 `merged = new Map(get().eventsByDate)` 스냅샷에 yearEvents 추가
5. 첫 호출의 `set()` 이후 두 번째 호출의 `set()`이 자기 스냅샷+yearEvents로 덮어쓰면서 동일 이벤트가 두 번 들어감

이 race는 항상 재현되지는 않고 timing에 따라 달라서 사용자가 경우에 따라 1x/2x를 다르게 보았을 가능성이 큼.

## Fix

- 모듈 레벨 `fetchInFlight: Map<number, Promise<void>>` 도입. 진행 중인 fetch가 있으면 후속 호출은 그 promise를 공유 await, 새 fetch는 시작하지 않음.
- `refreshYears`는 진행 중 fetch가 있으면 `Promise.allSettled`로 완료 대기 후 cleaned 단계 진입. 그렇지 않으면 cleaned 직후 in-flight fetch의 결과가 cleaned 상태를 덮어써 fresh 의미가 사라짐.

## Test plan

- [x] 동일 년도 `Promise.all([fetch, fetch])` 동시 호출 시 결과가 1개만 유지 (`tests/stores/calendarEventsStore.test.ts`)
- [x] 기존 13 + 신규 1 = 14 store tests + 19 utils tests = 33 GREEN

closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)