### PR TITLE
#81 이벤트 편집 화면 수정

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -50,6 +50,8 @@
   "settings.management": "Management",
   "settings.default_tag": "Default Tag",
   "settings.default_notification": "Default Notification",
+  "settings.event_notification": "Event Notification",
+  "settings.allday_event_notification": "All-day Event Notification",
   "settings.none": "None",
   "settings.notification": "Notifications",
   "settings.notification_granted": "Notifications are enabled",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -50,6 +50,8 @@
   "settings.management": "관리",
   "settings.default_tag": "기본 태그",
   "settings.default_notification": "기본 알림",
+  "settings.event_notification": "이벤트 알림",
+  "settings.allday_event_notification": "하루종일 이벤트 알림",
   "settings.none": "없음",
   "settings.notification": "알림",
   "settings.notification_granted": "알림이 허용되었습니다",

--- a/src/pages/ScheduleFormPage.tsx
+++ b/src/pages/ScheduleFormPage.tsx
@@ -13,6 +13,7 @@ import { EventFormHeader } from '../components/eventForm/EventFormHeader'
 import { EventTimeSection } from '../components/eventForm/EventTimeSection'
 import { EventDetailsSection } from '../components/eventForm/EventDetailsSection'
 import { useEventDefaultsStore } from '../stores/eventDefaultsStore'
+import { defaultNotificationsForEventTime } from '../stores/eventFormStore'
 import { useEventFormDirty, type EventFormSnapshot } from '../hooks/useEventFormDirty'
 import type { Schedule, EventTime, Repeating, NotificationOption } from '../models'
 
@@ -24,7 +25,7 @@ export function ScheduleFormPage() {
   const selectedDate = useUiStore(s => s.selectedDate)
 
   const { addEvent, removeEvent } = useCalendarEventsStore()
-  const { defaultTagId, defaultNotificationSeconds } = useEventDefaultsStore()
+  const { defaultTagId } = useEventDefaultsStore()
 
   const prefilled = (location.state as { prefilled?: Partial<EventFormSnapshot> } | null)?.prefilled
 
@@ -42,7 +43,9 @@ export function ScheduleFormPage() {
   const [repeating, setRepeating] = useState<Repeating | null>(() => (prefilled?.repeating as Repeating | null | undefined) ?? null)
   const [notifications, setNotifications] = useState<NotificationOption[]>(() => {
     if (prefilled?.notifications) return prefilled.notifications as NotificationOption[]
-    return !id && defaultNotificationSeconds != null ? [{ type: 'time' as const, seconds: defaultNotificationSeconds }] : []
+    if (id) return []
+    const initialTime = (prefilled?.eventTime as EventTime | undefined) ?? defaultEventTime()
+    return defaultNotificationsForEventTime(initialTime)
   })
   const [place, setPlace] = useState(() => prefilled?.place ?? '')
   const [url, setUrl] = useState(() => prefilled?.url ?? '')
@@ -95,7 +98,9 @@ export function ScheduleFormPage() {
     if (!newTime) return
     const prevIsAllDay = eventTime.time_type === 'allday'
     const nextIsAllDay = newTime.time_type === 'allday'
-    if (prevIsAllDay !== nextIsAllDay) setNotifications([])
+    if (prevIsAllDay !== nextIsAllDay) {
+      setNotifications(id ? [] : defaultNotificationsForEventTime(newTime))
+    }
     setEventTime(newTime)
   }
 

--- a/src/pages/TodoFormPage.tsx
+++ b/src/pages/TodoFormPage.tsx
@@ -15,6 +15,7 @@ import { EventFormHeader } from '../components/eventForm/EventFormHeader'
 import { EventTimeSection } from '../components/eventForm/EventTimeSection'
 import { EventDetailsSection } from '../components/eventForm/EventDetailsSection'
 import { useEventDefaultsStore } from '../stores/eventDefaultsStore'
+import { defaultNotificationsForEventTime } from '../stores/eventFormStore'
 import { useEventFormDirty, type EventFormSnapshot } from '../hooks/useEventFormDirty'
 import type { Todo, EventTime, Repeating, NotificationOption } from '../models'
 
@@ -27,7 +28,7 @@ export function TodoFormPage() {
 
   const { addEvent, removeEvent } = useCalendarEventsStore()
   const { addTodo, removeTodo, replaceTodo } = useCurrentTodosStore()
-  const { defaultTagId, defaultNotificationSeconds } = useEventDefaultsStore()
+  const { defaultTagId } = useEventDefaultsStore()
 
   const prefilled = (location.state as { prefilled?: Partial<EventFormSnapshot> } | null)?.prefilled
 
@@ -43,7 +44,11 @@ export function TodoFormPage() {
   const [repeating, setRepeating] = useState<Repeating | null>(() => (prefilled?.repeating as Repeating | null | undefined) ?? null)
   const [notifications, setNotifications] = useState<NotificationOption[]>(() => {
     if (prefilled?.notifications) return prefilled.notifications as NotificationOption[]
-    return !id && defaultNotificationSeconds != null ? [{ type: 'time' as const, seconds: defaultNotificationSeconds }] : []
+    if (id) return []
+    const initialTime = prefilled?.eventTime !== undefined
+      ? (prefilled.eventTime as EventTime | null)
+      : (selectedDate ? { time_type: 'at' as const, timestamp: Math.floor(selectedDate.getTime() / 1000) } : null)
+    return defaultNotificationsForEventTime(initialTime)
   })
   const [place, setPlace] = useState(() => prefilled?.place ?? '')
   const [url, setUrl] = useState(() => prefilled?.url ?? '')
@@ -58,7 +63,9 @@ export function TodoFormPage() {
   function handleEventTimeChange(newTime: EventTime | null) {
     const prevIsAllDay = eventTime?.time_type === 'allday'
     const nextIsAllDay = newTime?.time_type === 'allday'
-    if (prevIsAllDay !== nextIsAllDay) setNotifications([])
+    if (prevIsAllDay !== nextIsAllDay) {
+      setNotifications(id ? [] : defaultNotificationsForEventTime(newTime))
+    }
     setEventTime(newTime)
   }
 

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -19,6 +19,7 @@ import { NotificationSection } from './sections/NotificationSection'
 import { GoogleCalendarSection } from './sections/GoogleCalendarSection'
 import { AccountSection } from './sections/AccountSection'
 import { TagManagementPanel } from './tagManagement/TagManagementPanel'
+import { DefaultTagPickerPanel } from './sections/DefaultTagPickerPanel'
 
 function renderSection(id: SettingCategoryId) {
   switch (id) {
@@ -42,6 +43,8 @@ export function SettingsPage() {
   const selected: SettingCategoryId = hasExplicitCategory ? categoryId : DEFAULT_SETTING_CATEGORY
   const category = findSettingCategory(selected)
   const tagsPanelOpen = selected === 'editEvent' && subView === 'tags'
+  const defaultTagPanelOpen = selected === 'editEvent' && subView === 'defaultTag'
+  const subPanelOpen = tagsPanelOpen || defaultTagPanelOpen
 
   useEffect(() => {
     if (categoryId !== undefined && !isSettingCategoryId(categoryId)) {
@@ -57,7 +60,7 @@ export function SettingsPage() {
     navigate('/')
   }
 
-  const handleCloseTags = () => {
+  const handleCloseSubPanel = () => {
     navigate('/settings/editEvent')
   }
 
@@ -66,7 +69,7 @@ export function SettingsPage() {
       <div
         className={cn(
           'md:grid',
-          tagsPanelOpen
+          subPanelOpen
             ? 'md:grid-cols-[15rem_minmax(0,1fr)_minmax(0,1fr)] md:max-w-7xl'
             : 'md:grid-cols-[15rem_minmax(0,1fr)] md:max-w-5xl',
         )}
@@ -85,13 +88,13 @@ export function SettingsPage() {
         <main
           className={cn(
             'px-4 py-6 md:px-10 md:py-10',
-            tagsPanelOpen ? 'md:border-r md:border-gray-100' : '',
-            // mobile 표시 규칙: 카테고리 선택됨 AND tags 패널이 mobile에서 가리는 중이 아님
-            hasExplicitCategory && !tagsPanelOpen ? 'block' : 'hidden',
+            subPanelOpen ? 'md:border-r md:border-gray-100' : '',
+            // mobile 표시 규칙: 카테고리 선택됨 AND 서브 패널이 mobile에서 가리는 중이 아님
+            hasExplicitCategory && !subPanelOpen ? 'block' : 'hidden',
             'md:block',
           )}
         >
-          {hasExplicitCategory && !tagsPanelOpen && (
+          {hasExplicitCategory && !subPanelOpen && (
             <div className="md:hidden flex items-center gap-2 mb-8 -mx-4 px-4 pb-3 border-b border-gray-100">
               <button
                 type="button"
@@ -109,10 +112,15 @@ export function SettingsPage() {
           {renderSection(selected)}
         </main>
 
-        {/* 우측 TagManagement 패널 — editEvent/tags 서브뷰에서만 */}
+        {/* 우측 서브 패널 — editEvent의 tags / defaultTag 서브뷰 */}
         {tagsPanelOpen && (
           <aside className="px-4 py-6 md:px-10 md:py-10 block">
-            <TagManagementPanel onClose={handleCloseTags} />
+            <TagManagementPanel onClose={handleCloseSubPanel} />
+          </aside>
+        )}
+        {defaultTagPanelOpen && (
+          <aside className="px-4 py-6 md:px-10 md:py-10 block">
+            <DefaultTagPickerPanel onClose={handleCloseSubPanel} />
           </aside>
         )}
       </div>

--- a/src/pages/settings/sections/DefaultTagPickerPanel.tsx
+++ b/src/pages/settings/sections/DefaultTagPickerPanel.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ChevronLeft, Check } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useEventDefaultsStore } from '../../../stores/eventDefaultsStore'
+import { useEventTagStore } from '../../../stores/eventTagStore'
+import { APP_FALLBACK_DEFAULT_COLOR } from '../../../domain/tag/resolveEventTag'
+
+interface Props {
+  onClose: () => void
+}
+
+interface TagOption {
+  id: string | null
+  name: string
+  color: string
+}
+
+export function DefaultTagPickerPanel({ onClose }: Props) {
+  const { t } = useTranslation()
+  const tags = useEventTagStore(s => s.tags)
+  const defaultTagColors = useEventTagStore(s => s.defaultTagColors)
+  const defaultTagId = useEventDefaultsStore(s => s.defaultTagId)
+  const setDefaults = useEventDefaultsStore(s => s.setDefaults)
+
+  const baseDefaultColor =
+    defaultTagColors?.default && defaultTagColors.default.length > 0
+      ? defaultTagColors.default
+      : APP_FALLBACK_DEFAULT_COLOR
+
+  const options: TagOption[] = useMemo(() => [
+    { id: null, name: t('tag.default_name', '기본'), color: baseDefaultColor },
+    ...Array.from(tags.values()).map(tag => ({
+      id: tag.uuid,
+      name: tag.name,
+      color: tag.color_hex ?? APP_FALLBACK_DEFAULT_COLOR,
+    })),
+  ], [tags, baseDefaultColor, t])
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center gap-2 mb-6">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={t('settings.back')}
+          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+        >
+          <ChevronLeft className="h-5 w-5" />
+        </button>
+        <h2 className="flex-1 text-lg font-semibold text-[#1f1f1f]">
+          {t('settings.default_tag')}
+        </h2>
+      </div>
+
+      <ul className="divide-y divide-gray-100">
+        {options.map(opt => {
+          const isSelected = opt.id === defaultTagId
+          return (
+            <li key={opt.id ?? '__default__'}>
+              <button
+                type="button"
+                onClick={() => setDefaults({ defaultTagId: opt.id })}
+                className={cn(
+                  'w-full flex items-center gap-3 py-3 text-left transition-colors',
+                  isSelected ? 'text-[#1f1f1f] font-semibold' : 'text-[#1f1f1f] hover:bg-gray-50',
+                )}
+              >
+                <span
+                  className="inline-block h-5 w-5 shrink-0 rounded-full"
+                  style={{ backgroundColor: opt.color }}
+                  aria-hidden="true"
+                />
+                <span className="flex-1 truncate text-sm">{opt.name}</span>
+                {isSelected && <Check className="h-4 w-4 text-[#1f1f1f] shrink-0" strokeWidth={3} />}
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/src/pages/settings/sections/EditEventSection.tsx
+++ b/src/pages/settings/sections/EditEventSection.tsx
@@ -2,49 +2,128 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router-dom'
 import { ChevronRight } from 'lucide-react'
+import { cn } from '@/lib/utils'
 import { useEventDefaultsStore } from '../../../stores/eventDefaultsStore'
 import { useEventTagStore } from '../../../stores/eventTagStore'
+import { APP_FALLBACK_DEFAULT_COLOR } from '../../../domain/tag/resolveEventTag'
 import { SettingsSection, settingsInput, settingsLabel } from '../SettingsSection'
 
-export function EditEventSection() {
-  const { t } = useTranslation()
-  const navigate = useNavigate()
-  const { subView } = useParams<{ subView?: string }>()
-  const { defaultTagId, defaultNotificationSeconds, setDefaults } = useEventDefaultsStore()
-  const tags = useEventTagStore(s => s.tags)
+interface NotificationPreset {
+  label: string
+  value: number | null
+}
 
-  const notificationPresets = useMemo(() => [
+function useNotificationPresets(): NotificationPreset[] {
+  const { t } = useTranslation()
+  return useMemo(() => [
     { label: t('settings.none'), value: null },
     { label: t('settings.notif_5min'), value: -300 },
     { label: t('settings.notif_10min'), value: -600 },
     { label: t('settings.notif_30min'), value: -1800 },
     { label: t('settings.notif_1hour'), value: -3600 },
   ], [t])
+}
 
+interface TagChipProps {
+  name: string
+  color: string
+  selected: boolean
+  onClick: () => void
+}
+
+function TagChip({ name, color, selected, onClick }: TagChipProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      className={cn(
+        'inline-flex items-center gap-2 rounded-full px-3 h-8 text-sm font-medium transition-colors',
+        selected
+          ? 'bg-[#1f1f1f] text-white'
+          : 'bg-gray-100 text-[#1f1f1f] hover:bg-gray-200',
+      )}
+    >
+      <span
+        className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+        style={{ backgroundColor: color }}
+        aria-hidden="true"
+      />
+      <span className="truncate">{name}</span>
+    </button>
+  )
+}
+
+export function EditEventSection() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { subView } = useParams<{ subView?: string }>()
+  const {
+    defaultTagId,
+    defaultNotificationSeconds,
+    defaultAllDayNotificationSeconds,
+    setDefaults,
+  } = useEventDefaultsStore()
+  const tags = useEventTagStore(s => s.tags)
+  const defaultTagColors = useEventTagStore(s => s.defaultTagColors)
+
+  const notificationPresets = useNotificationPresets()
   const tagsOpen = subView === 'tags'
 
+  const baseDefaultColor =
+    (defaultTagColors?.default && defaultTagColors.default.length > 0
+      ? defaultTagColors.default
+      : APP_FALLBACK_DEFAULT_COLOR)
+
+  const tagList = Array.from(tags.values())
+
   return (
-    <div className="space-y-10">
+    <div className="space-y-14">
       <SettingsSection title={t('settings.defaults')}>
-        <div className="space-y-2">
-          <p className={settingsLabel}>{t('settings.default_tag')}</p>
+        <div className="flex items-start justify-between gap-4">
+          <p className={cn(settingsLabel, 'pt-1.5 shrink-0')}>{t('settings.default_tag')}</p>
+          <div className="flex flex-wrap justify-end gap-2 max-w-[70%]">
+            <TagChip
+              name={t('tag.default_name', '기본')}
+              color={baseDefaultColor}
+              selected={defaultTagId == null}
+              onClick={() => setDefaults({ defaultTagId: null })}
+            />
+            {tagList.map(tag => (
+              <TagChip
+                key={tag.uuid}
+                name={tag.name}
+                color={tag.color_hex ?? APP_FALLBACK_DEFAULT_COLOR}
+                selected={defaultTagId === tag.uuid}
+                onClick={() => setDefaults({ defaultTagId: tag.uuid })}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <p className={cn(settingsLabel, 'shrink-0')}>{t('settings.event_notification')}</p>
           <select
-            className={settingsInput}
-            value={defaultTagId ?? ''}
-            onChange={e => setDefaults({ defaultTagId: e.target.value || null })}
+            className={cn(settingsInput, 'max-w-[60%]')}
+            value={defaultNotificationSeconds ?? ''}
+            onChange={e => setDefaults({
+              defaultNotificationSeconds: e.target.value ? Number(e.target.value) : null,
+            })}
           >
-            <option value="">{t('settings.none')}</option>
-            {Array.from(tags.values()).map(tag => (
-              <option key={tag.uuid} value={tag.uuid}>{tag.name}</option>
+            {notificationPresets.map(p => (
+              <option key={p.label} value={p.value ?? ''}>{p.label}</option>
             ))}
           </select>
         </div>
-        <div className="space-y-2">
-          <p className={settingsLabel}>{t('settings.default_notification')}</p>
+
+        <div className="flex items-center justify-between gap-4">
+          <p className={cn(settingsLabel, 'shrink-0')}>{t('settings.allday_event_notification')}</p>
           <select
-            className={settingsInput}
-            value={defaultNotificationSeconds ?? ''}
-            onChange={e => setDefaults({ defaultNotificationSeconds: e.target.value ? Number(e.target.value) : null })}
+            className={cn(settingsInput, 'max-w-[60%]')}
+            value={defaultAllDayNotificationSeconds ?? ''}
+            onChange={e => setDefaults({
+              defaultAllDayNotificationSeconds: e.target.value ? Number(e.target.value) : null,
+            })}
           >
             {notificationPresets.map(p => (
               <option key={p.label} value={p.value ?? ''}>{p.label}</option>

--- a/src/pages/settings/sections/EditEventSection.tsx
+++ b/src/pages/settings/sections/EditEventSection.tsx
@@ -24,23 +24,23 @@ function useNotificationPresets(): NotificationPreset[] {
   ], [t])
 }
 
-interface TagChipProps {
+interface SelectedTagChipProps {
   name: string
   color: string
-  selected: boolean
+  active: boolean
   onClick: () => void
 }
 
-function TagChip({ name, color, selected, onClick }: TagChipProps) {
+function SelectedTagChip({ name, color, active, onClick }: SelectedTagChipProps) {
   return (
     <button
       type="button"
       onClick={onClick}
-      aria-pressed={selected}
+      aria-current={active ? 'page' : undefined}
       className={cn(
-        'inline-flex items-center gap-2 rounded-full px-3 h-8 text-sm font-medium transition-colors',
-        selected
-          ? 'bg-[#1f1f1f] text-white'
+        'inline-flex items-center gap-2 rounded-full px-3 h-8 text-sm font-medium transition-colors max-w-full',
+        active
+          ? 'bg-gray-100 text-[#1f1f1f]'
           : 'bg-gray-100 text-[#1f1f1f] hover:bg-gray-200',
       )}
     >
@@ -50,6 +50,7 @@ function TagChip({ name, color, selected, onClick }: TagChipProps) {
         aria-hidden="true"
       />
       <span className="truncate">{name}</span>
+      <ChevronRight className="h-3.5 w-3.5 text-gray-500 shrink-0" />
     </button>
   )
 }
@@ -69,36 +70,29 @@ export function EditEventSection() {
 
   const notificationPresets = useNotificationPresets()
   const tagsOpen = subView === 'tags'
+  const defaultTagOpen = subView === 'defaultTag'
 
   const baseDefaultColor =
     (defaultTagColors?.default && defaultTagColors.default.length > 0
       ? defaultTagColors.default
       : APP_FALLBACK_DEFAULT_COLOR)
 
-  const tagList = Array.from(tags.values())
+  const selectedTag = defaultTagId ? tags.get(defaultTagId) : undefined
+  const selectedName = selectedTag?.name ?? t('tag.default_name', '기본')
+  const selectedColor =
+    selectedTag?.color_hex ?? (defaultTagId ? APP_FALLBACK_DEFAULT_COLOR : baseDefaultColor)
 
   return (
     <div className="space-y-14">
       <SettingsSection title={t('settings.defaults')}>
-        <div className="flex items-start justify-between gap-4">
-          <p className={cn(settingsLabel, 'pt-1.5 shrink-0')}>{t('settings.default_tag')}</p>
-          <div className="flex flex-wrap justify-end gap-2 max-w-[70%]">
-            <TagChip
-              name={t('tag.default_name', '기본')}
-              color={baseDefaultColor}
-              selected={defaultTagId == null}
-              onClick={() => setDefaults({ defaultTagId: null })}
-            />
-            {tagList.map(tag => (
-              <TagChip
-                key={tag.uuid}
-                name={tag.name}
-                color={tag.color_hex ?? APP_FALLBACK_DEFAULT_COLOR}
-                selected={defaultTagId === tag.uuid}
-                onClick={() => setDefaults({ defaultTagId: tag.uuid })}
-              />
-            ))}
-          </div>
+        <div className="flex items-center justify-between gap-4">
+          <p className={cn(settingsLabel, 'shrink-0')}>{t('settings.default_tag')}</p>
+          <SelectedTagChip
+            name={selectedName}
+            color={selectedColor}
+            active={defaultTagOpen}
+            onClick={() => navigate('/settings/editEvent/defaultTag')}
+          />
         </div>
 
         <div className="flex items-center justify-between gap-4">

--- a/src/stores/eventDefaultsStore.ts
+++ b/src/stores/eventDefaultsStore.ts
@@ -5,9 +5,14 @@ const STORAGE_KEY = 'event_defaults'
 interface EventDefaults {
   defaultTagId: string | null
   defaultNotificationSeconds: number | null
+  defaultAllDayNotificationSeconds: number | null
 }
 
-const DEFAULT_VALUES: EventDefaults = { defaultTagId: null, defaultNotificationSeconds: null }
+const DEFAULT_VALUES: EventDefaults = {
+  defaultTagId: null,
+  defaultNotificationSeconds: null,
+  defaultAllDayNotificationSeconds: null,
+}
 
 function load(): EventDefaults {
   try {
@@ -24,7 +29,11 @@ export const useEventDefaultsStore = create<EventDefaultsState>((set, get) => ({
   ...load(),
   setDefaults: (updates) => {
     const next = { ...get(), ...updates }
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ defaultTagId: next.defaultTagId, defaultNotificationSeconds: next.defaultNotificationSeconds }))
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      defaultTagId: next.defaultTagId,
+      defaultNotificationSeconds: next.defaultNotificationSeconds,
+      defaultAllDayNotificationSeconds: next.defaultAllDayNotificationSeconds,
+    }))
     set(updates)
   },
 }))

--- a/src/stores/eventFormStore.ts
+++ b/src/stores/eventFormStore.ts
@@ -48,6 +48,12 @@ function isAllDay(time: EventTime | null): boolean {
   return time?.time_type === 'allday'
 }
 
+export function defaultNotificationsForEventTime(time: EventTime | null): NotificationOption[] {
+  const { defaultNotificationSeconds, defaultAllDayNotificationSeconds } = useEventDefaultsStore.getState()
+  const seconds = isAllDay(time) ? defaultAllDayNotificationSeconds : defaultNotificationSeconds
+  return seconds != null ? [{ type: 'time', seconds }] : []
+}
+
 export function canSave(state: EventFormState): boolean {
   if (!state.name.trim()) return false
   if (state.eventType === 'schedule' && !state.eventTime) return false
@@ -81,15 +87,13 @@ export const useEventFormStore = create<EventFormState>((set, get) => ({
 
   openForm: (anchorRect, eventType = 'todo') => {
     const selectedDate = useUiStore.getState().selectedDate
-    const { defaultTagId, defaultNotificationSeconds } = useEventDefaultsStore.getState()
+    const { defaultTagId } = useEventDefaultsStore.getState()
 
     const eventTime: EventTime | null = selectedDate
       ? { time_type: 'at', timestamp: Math.floor(selectedDate.getTime() / 1000) }
       : null
 
-    const notifications: NotificationOption[] = defaultNotificationSeconds != null
-      ? [{ type: 'time', seconds: defaultNotificationSeconds }]
-      : []
+    const notifications = defaultNotificationsForEventTime(eventTime)
 
     set({
       isOpen: true,
@@ -146,7 +150,7 @@ export const useEventFormStore = create<EventFormState>((set, get) => ({
     const prev = get().eventTime
     const alldayChanged = isAllDay(prev) !== isAllDay(time)
     if (alldayChanged) {
-      set({ eventTime: time, notifications: [] })
+      set({ eventTime: time, notifications: defaultNotificationsForEventTime(time) })
     } else {
       set({ eventTime: time })
     }


### PR DESCRIPTION
closes #81

## 요약

이슈 #81의 4개 요구사항을 충족하도록 이벤트 편집 설정 화면을 정돈했다.

1. **디자인 전반 정돈** — `AppearanceSection`과 동일한 SettingsSection + 라벨/컨트롤 row 레이아웃으로 통일.
2. **기본 태그 선택** — 드랍다운 제거. 현재 선택된 태그만 칩(색상+이름+chevron)으로 노출, 칩 클릭 시 우측 패널(`DefaultTagPickerPanel`)이 열려 선택. "이벤트 종류" 서브뷰와 동일한 라우팅 패턴(`/settings/editEvent/defaultTag`). 미설정 상태는 "없음" 대신 `tag.default_name`("기본")으로 노출.
3. **이벤트 알림** — `defaultNotificationSeconds` 드랍다운 (라벨 `settings.event_notification`).
4. **하루종일 이벤트 알림** — 신규 `defaultAllDayNotificationSeconds` 추가, 별도 드랍다운 (라벨 `settings.allday_event_notification`).

## 부수 변경

- `eventDefaultsStore` — `defaultAllDayNotificationSeconds` 필드 추가, localStorage 직렬화에 포함.
- `eventFormStore.defaultNotificationsForEventTime` — 시간 타입(allday 여부)에 맞는 기본 알림을 반환하는 헬퍼 export. `openForm` / `setEventTime`에서 사용.
- `TodoFormPage` / `ScheduleFormPage` — 신규 작성 시 동일 헬퍼로 정렬. allday 토글 시 빈 배열 대신 새 모드의 기본값으로 교체(편집 모드는 기존대로 서버 값 유지).

## Test plan

- [ ] 설정 → 이벤트 편집 진입 시 기본 태그 row가 현재 선택된 태그 칩만 노출하는지 확인
- [ ] 칩 클릭 시 우측 패널이 열리고, 첫 항목 "기본" + 등록 태그 목록이 색상과 함께 노출되는지
- [ ] 패널에서 항목 클릭 시 즉시 반영되어 좌측 row의 칩이 갱신되는지
- [ ] 이벤트 알림 / 하루종일 이벤트 알림 드랍다운이 각각 독립적으로 저장되는지
- [ ] 새 일정/할일 작성 시 일반 이벤트는 `defaultNotificationSeconds`, 하루종일 이벤트는 `defaultAllDayNotificationSeconds`가 적용되는지
- [ ] 폼에서 시간↔하루종일 토글 시 알림이 새 모드의 기본값으로 교체되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)