### PR TITLE
#75 컬러 토큰 워싱 — 의미 기반 디자인 토큰 도입 + 다크 정합

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ e2e/.auth/
 # Claude Code
 .claude/
 
+# Git worktrees
+.worktrees/
+
 # Superpowers docs (design specs, plans)
 docs/superpowers/
 .superpowers/

--- a/src/calendar/CalendarHeader.tsx
+++ b/src/calendar/CalendarHeader.tsx
@@ -12,15 +12,15 @@ export default function CalendarHeader({ year, month, onPrev, onNext }: Calendar
     <div className="mb-4 flex items-center justify-between">
       <button
         onClick={onPrev}
-        className="rounded px-3 py-1 hover:bg-gray-100 dark:hover:bg-gray-700 dark:text-gray-300"
+        className="rounded px-3 py-1 hover:bg-surface-sunken text-fg-tertiary"
         aria-label="Previous month"
       >
         ‹
       </button>
-      <h2 className="text-lg font-semibold dark:text-gray-100">{formatMonthTitle(year, month)}</h2>
+      <h2 className="text-lg font-semibold text-fg">{formatMonthTitle(year, month)}</h2>
       <button
         onClick={onNext}
-        className="rounded px-3 py-1 hover:bg-gray-100 dark:hover:bg-gray-700 dark:text-gray-300"
+        className="rounded px-3 py-1 hover:bg-surface-sunken text-fg-tertiary"
         aria-label="Next month"
       >
         ›

--- a/src/calendar/MainCalendar.tsx
+++ b/src/calendar/MainCalendar.tsx
@@ -35,7 +35,7 @@ export default function MainCalendar({
   const overflowClass = eventDisplayLevel === 'full' ? 'overflow-y-auto' : 'overflow-hidden'
 
   return (
-    <div className={`flex-1 flex flex-col bg-white px-2 pt-2 pb-4 ${overflowClass}`}>
+    <div className={`flex-1 flex flex-col bg-surface px-2 pt-2 pb-4 ${overflowClass}`}>
       <MainCalendarGrid days={days} onEventClick={onEventClick} />
     </div>
   )

--- a/src/calendar/MainCalendarGrid.tsx
+++ b/src/calendar/MainCalendarGrid.tsx
@@ -224,7 +224,7 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
 
                 const circleBg = day.isToday ? TODAY_BG : undefined
                 const ringClass = isSelected && !day.isToday
-                  ? 'ring-2 ring-action ring-offset-1 ring-offset-white'
+                  ? 'ring-2 ring-action ring-offset-1 ring-offset-surface'
                   : ''
 
                 const accent = (
@@ -238,7 +238,7 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
                   : !day.isCurrentMonth
                     ? 'text-fg-quaternary'
                     : accent
-                      ? 'text-red-400'
+                      ? 'text-danger'
                       : 'text-fg'
 
                 return (

--- a/src/calendar/MainCalendarGrid.tsx
+++ b/src/calendar/MainCalendarGrid.tsx
@@ -164,7 +164,7 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
 
   // 주 컨테이너 className/style 계산
   function getWeekClass(isLastWeek: boolean): string {
-    const base = `relative grid grid-cols-7${!isLastWeek ? ' border-b border-gray-100' : ''}`
+    const base = `relative grid grid-cols-7${!isLastWeek ? ' border-b border-line' : ''}`
     return isFull ? base : `flex-1 ${base}`
   }
 
@@ -234,9 +234,9 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
                 )
 
                 const dateTextColor = day.isToday
-                  ? 'text-white font-semibold'
+                  ? 'text-action-fg font-semibold'
                   : !day.isCurrentMonth
-                    ? 'text-gray-300'
+                    ? 'text-fg-quaternary'
                     : accent
                       ? 'text-red-400'
                       : 'text-fg'
@@ -244,7 +244,7 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
                 return (
                   <div
                     key={di}
-                    className="flex flex-col pt-1.5 px-1.5 pb-1 cursor-pointer transition-colors hover:bg-gray-50"
+                    className="flex flex-col pt-1.5 px-1.5 pb-1 cursor-pointer transition-colors hover:bg-surface-elevated"
                     data-testid="day-cell"
                     data-today={day.isToday || undefined}
                     data-selected={isSelected || undefined}

--- a/src/calendar/MainCalendarGrid.tsx
+++ b/src/calendar/MainCalendarGrid.tsx
@@ -21,7 +21,7 @@ const DATE_NUMBER_HEIGHT = 28
 // 날짜 숫자 아래 이벤트 바 시작 오프셋(px)
 const EVENT_AREA_TOP_OFFSET = 4
 
-const TODAY_BG = '#1f1f1f'
+const TODAY_BG = 'var(--color-action)'
 
 interface MainCalendarGridProps {
   days: CalendarDay[]
@@ -55,7 +55,7 @@ function EventBar({ ev, timeType, showEventNames, fontSizeWeight, onEventClick }
 
   return (
     <div
-      className="flex items-center h-5 rounded px-1.5 py-0.5 leading-tight cursor-pointer pointer-events-auto overflow-hidden text-[#1f1f1f]"
+      className="flex items-center h-5 rounded px-1.5 py-0.5 leading-tight cursor-pointer pointer-events-auto overflow-hidden text-fg"
       data-testid="event-bar"
       style={{
         gridColumn: `${ev.startCol} / ${ev.endCol + 1}`,
@@ -186,7 +186,7 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
           return (
             <div
               key={key}
-              className={`px-3 py-1.5 text-[11px] font-semibold uppercase tracking-widest ${accent ? 'text-[#e8a5a5]' : 'text-[#bbb]'}`}
+              className={`px-3 py-1.5 text-[11px] font-semibold uppercase tracking-widest ${accent ? 'text-[#e8a5a5]' : 'text-fg-quaternary'}`}
             >
               {t(`calendar.weekdays.${key}`, key.toUpperCase())}
             </div>
@@ -224,7 +224,7 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
 
                 const circleBg = day.isToday ? TODAY_BG : undefined
                 const ringClass = isSelected && !day.isToday
-                  ? 'ring-2 ring-[#1f1f1f] ring-offset-1 ring-offset-white'
+                  ? 'ring-2 ring-action ring-offset-1 ring-offset-white'
                   : ''
 
                 const accent = (
@@ -239,7 +239,7 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
                     ? 'text-gray-300'
                     : accent
                       ? 'text-red-400'
-                      : 'text-[#1f1f1f]'
+                      : 'text-fg'
 
                 return (
                   <div
@@ -306,7 +306,7 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
 
                   {hiddenCount > 0 && (
                     <div className="grid grid-cols-7">
-                      <div className="col-span-7 text-[10px] font-medium text-[#969696] px-2 pointer-events-auto">
+                      <div className="col-span-7 text-[10px] font-medium text-fg-tertiary px-2 pointer-events-auto">
                         +{hiddenCount} more
                       </div>
                     </div>

--- a/src/components/ArchivePanel.tsx
+++ b/src/components/ArchivePanel.tsx
@@ -27,11 +27,11 @@ function DoneTodoRow({ item, onRevert, onRequestDelete, onClick }: DoneTodoRowPr
 
   return (
     <li
-      className={`flex items-center gap-3 py-2.5 rounded-md px-2 -mx-2 transition-colors ${onClick ? 'cursor-pointer hover:bg-gray-50' : ''}`}
+      className={`flex items-center gap-3 py-2.5 rounded-md px-2 -mx-2 transition-colors ${onClick ? 'cursor-pointer hover:bg-surface-elevated' : ''}`}
       onClick={handleRowClick}
     >
       <span
-        className="h-2 w-2 shrink-0 rounded-full ring-2 ring-white"
+        className="h-2 w-2 shrink-0 rounded-full ring-2 ring-surface"
         style={{ backgroundColor: resolved.color }}
       />
       <p className="min-w-0 flex-1 truncate text-sm text-fg">{item.name}</p>
@@ -39,7 +39,7 @@ function DoneTodoRow({ item, onRevert, onRequestDelete, onClick }: DoneTodoRowPr
         type="button"
         aria-label={t('todo.revert')}
         onClick={(e) => { e.stopPropagation(); onRevert(item.uuid) }}
-        className="shrink-0 p-1.5 rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
+        className="shrink-0 p-1.5 rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors"
       >
         <RotateCcw className="h-4 w-4" />
       </button>
@@ -47,7 +47,7 @@ function DoneTodoRow({ item, onRevert, onRequestDelete, onClick }: DoneTodoRowPr
         type="button"
         aria-label={t('common.delete')}
         onClick={(e) => { e.stopPropagation(); onRequestDelete(item.uuid) }}
-        className="shrink-0 p-1.5 rounded-full text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors"
+        className="shrink-0 p-1.5 rounded-full text-fg-quaternary hover:text-red-500 hover:bg-red-50 transition-colors"
       >
         <Trash2 className="h-4 w-4" />
       </button>
@@ -59,7 +59,7 @@ function SectionHeader({ label }: { label: string }) {
   return (
     <div className="flex items-center gap-3 mb-3">
       <span className="text-[11px] font-semibold uppercase tracking-widest text-fg-quaternary shrink-0">{label}</span>
-      <div className="flex-1 h-px bg-gray-100" />
+      <div className="flex-1 h-px bg-line" />
     </div>
   )
 }
@@ -117,12 +117,12 @@ export function ArchivePanel({ onDoneTodoClick }: ArchivePanelProps = {}) {
   }
 
   return (
-    <div className="w-full h-full flex flex-col bg-white relative">
+    <div className="w-full h-full flex flex-col bg-surface relative">
       {/* 닫기(X) — 우측 상단 absolute, 아카이브 모드에서도 패널 전체 닫기 */}
       <button
         onClick={toggleRightPanel}
         aria-label={t('common.close')}
-        className="absolute top-2 right-3 z-10 p-1.5 rounded-full hover:bg-gray-100 transition-colors text-gray-400 hover:text-gray-600"
+        className="absolute top-2 right-3 z-10 p-1.5 rounded-full hover:bg-surface-sunken transition-colors text-fg-quaternary hover:text-fg-secondary"
       >
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
           <path d="M6 6l12 12M18 6L6 18" />
@@ -138,7 +138,7 @@ export function ArchivePanel({ onDoneTodoClick }: ArchivePanelProps = {}) {
               type="button"
               onClick={exitArchivePanel}
               aria-label={t('settings.back', '뒤로')}
-              className="shrink-0 -ml-2 flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
+              className="shrink-0 -ml-2 flex h-9 w-9 items-center justify-center rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors"
             >
               <ChevronLeft className="h-5 w-5" />
             </button>

--- a/src/components/ArchivePanel.tsx
+++ b/src/components/ArchivePanel.tsx
@@ -47,7 +47,7 @@ function DoneTodoRow({ item, onRevert, onRequestDelete, onClick }: DoneTodoRowPr
         type="button"
         aria-label={t('common.delete')}
         onClick={(e) => { e.stopPropagation(); onRequestDelete(item.uuid) }}
-        className="shrink-0 p-1.5 rounded-full text-fg-quaternary hover:text-red-500 hover:bg-red-50 transition-colors"
+        className="shrink-0 p-1.5 rounded-full text-fg-quaternary hover:text-danger hover:bg-danger/10 transition-colors"
       >
         <Trash2 className="h-4 w-4" />
       </button>

--- a/src/components/ArchivePanel.tsx
+++ b/src/components/ArchivePanel.tsx
@@ -34,12 +34,12 @@ function DoneTodoRow({ item, onRevert, onRequestDelete, onClick }: DoneTodoRowPr
         className="h-2 w-2 shrink-0 rounded-full ring-2 ring-white"
         style={{ backgroundColor: resolved.color }}
       />
-      <p className="min-w-0 flex-1 truncate text-sm text-[#1f1f1f]">{item.name}</p>
+      <p className="min-w-0 flex-1 truncate text-sm text-fg">{item.name}</p>
       <button
         type="button"
         aria-label={t('todo.revert')}
         onClick={(e) => { e.stopPropagation(); onRevert(item.uuid) }}
-        className="shrink-0 p-1.5 rounded-full text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+        className="shrink-0 p-1.5 rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
       >
         <RotateCcw className="h-4 w-4" />
       </button>
@@ -58,7 +58,7 @@ function DoneTodoRow({ item, onRevert, onRequestDelete, onClick }: DoneTodoRowPr
 function SectionHeader({ label }: { label: string }) {
   return (
     <div className="flex items-center gap-3 mb-3">
-      <span className="text-[11px] font-semibold uppercase tracking-widest text-[#bbb] shrink-0">{label}</span>
+      <span className="text-[11px] font-semibold uppercase tracking-widest text-fg-quaternary shrink-0">{label}</span>
       <div className="flex-1 h-px bg-gray-100" />
     </div>
   )
@@ -138,15 +138,15 @@ export function ArchivePanel({ onDoneTodoClick }: ArchivePanelProps = {}) {
               type="button"
               onClick={exitArchivePanel}
               aria-label={t('settings.back', '뒤로')}
-              className="shrink-0 -ml-2 flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+              className="shrink-0 -ml-2 flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
             >
               <ChevronLeft className="h-5 w-5" />
             </button>
-            <h1 className="text-2xl font-bold text-[#323232]">{t('todo.done_list')}</h1>
+            <h1 className="text-2xl font-bold text-fg">{t('todo.done_list')}</h1>
           </div>
 
           {items.length === 0 && hasMore === false && (
-            <p className="py-8 text-center text-sm text-[#969696]">{t('todo.done_empty')}</p>
+            <p className="py-8 text-center text-sm text-fg-tertiary">{t('todo.done_empty')}</p>
           )}
 
           {Array.from(groups.entries()).map(([dateKey, groupItems]) => (
@@ -166,7 +166,7 @@ export function ArchivePanel({ onDoneTodoClick }: ArchivePanelProps = {}) {
             </section>
           ))}
 
-          <div ref={sentinelRef} className="py-2 text-center text-xs text-[#bbb]">
+          <div ref={sentinelRef} className="py-2 text-center text-xs text-fg-quaternary">
             {!hasMore && items.length > 0 && t('todo.all_shown')}
           </div>
         </div>

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -36,7 +36,7 @@ export function AuthGuard({ children }: AuthGuardProps) {
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div data-testid="loading-spinner" className="w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
+        <div data-testid="loading-spinner" className="w-8 h-8 border-4 border-brand border-t-transparent rounded-full animate-spin" />
       </div>
     )
   }

--- a/src/components/CalendarList.tsx
+++ b/src/components/CalendarList.tsx
@@ -28,12 +28,12 @@ export default function CalendarList() {
   return (
     <div className="flex flex-col">
       <div className="flex items-center justify-between mb-2">
-        <p className="text-text-secondary text-[10px] font-semibold uppercase tracking-[0.08em]">
+        <p className="text-fg-secondary text-[10px] font-semibold uppercase tracking-[0.08em]">
           {t('main.event_types', '이벤트 종류')}
         </p>
         <button
           onClick={() => navigate('/settings/editEvent/tags')}
-          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-text-tertiary hover:text-text-secondary hover:bg-surface-sunken transition-colors"
+          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-fg-tertiary hover:text-fg-secondary hover:bg-surface-sunken transition-colors"
           aria-label={t('tag.manage', '태그 관리')}
         >
           <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -71,7 +71,7 @@ export default function CalendarList() {
                   </svg>
                 )}
               </span>
-              <span className={`flex-1 text-sm truncate ${hidden ? 'text-text-tertiary' : 'text-text-primary'}`}>
+              <span className={`flex-1 text-sm truncate ${hidden ? 'text-fg-tertiary' : 'text-fg'}`}>
                 {tag.name}
               </span>
             </button>

--- a/src/components/CellTimeLabel.tsx
+++ b/src/components/CellTimeLabel.tsx
@@ -81,15 +81,15 @@ function ScheduleTimeLabel({ eventTime }: { eventTime: EventTime }) {
 
 function SingleLine({ text }: { text: string }) {
   return (
-    <p className="text-xs text-[#323232] text-center truncate leading-tight">{text}</p>
+    <p className="text-xs text-fg text-center truncate leading-tight">{text}</p>
   )
 }
 
 function DoubleLine({ top, bottom }: { top: string; bottom: string }) {
   return (
     <div className="flex flex-col items-center">
-      <p className="text-xs text-[#323232] truncate leading-tight">{top}</p>
-      <p className="text-[10px] text-[#646464] truncate leading-tight">{bottom}</p>
+      <p className="text-xs text-fg truncate leading-tight">{top}</p>
+      <p className="text-[10px] text-fg-secondary truncate leading-tight">{bottom}</p>
     </div>
   )
 }

--- a/src/components/ColorPalette.tsx
+++ b/src/components/ColorPalette.tsx
@@ -24,7 +24,7 @@ export function ColorPalette({ colors = PRESET_COLORS, selected, onChange }: Col
           aria-pressed={selected === color}
           onClick={() => onChange(color)}
           className={`h-7 w-7 rounded-full border-2 transition-transform ${
-            selected === color ? 'border-gray-800 scale-110' : 'border-transparent'
+            selected === color ? 'border-action scale-110' : 'border-transparent'
           }`}
           style={{ backgroundColor: color }}
         />

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -50,17 +50,17 @@ export function ConfirmDialog({ title, message, confirmLabel, onConfirm, onCance
       aria-modal="true"
       aria-labelledby="confirm-dialog-message"
     >
-      <div ref={dialogRef} className="mx-4 w-full max-w-sm rounded-xl bg-white dark:bg-gray-800 p-6 shadow-lg">
-        {title && <h2 className="text-base font-semibold text-gray-900 dark:text-white">{title}</h2>}
+      <div ref={dialogRef} className="mx-4 w-full max-w-sm rounded-xl bg-surface-elevated p-6 shadow-lg">
+        {title && <h2 className="text-base font-semibold text-fg">{title}</h2>}
         <p
           id="confirm-dialog-message"
-          className={`text-sm text-gray-700 dark:text-gray-300${title ? ' mt-2' : ''}`}
+          className={`text-sm text-fg-secondary${title ? ' mt-2' : ''}`}
         >
           {message}
         </p>
         <div className="mt-5 flex justify-end gap-2">
           <button
-            className="rounded-lg px-4 py-2 text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+            className="rounded-lg px-4 py-2 text-sm text-fg-tertiary hover:bg-surface-sunken"
             onClick={onCancel}
           >
             {t('common.cancel')}

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -66,8 +66,9 @@ export function ConfirmDialog({ title, message, confirmLabel, onConfirm, onCance
             {t('common.cancel')}
           </button>
           <button
+            data-variant={danger ? 'danger' : 'primary'}
             className={`rounded-lg px-4 py-2 text-sm font-medium text-white ${
-              danger ? 'bg-red-500 hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700' : 'bg-blue-500 hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700'
+              danger ? 'bg-danger hover:bg-danger/90' : 'bg-brand hover:bg-brand/90'
             }`}
             onClick={onConfirm}
           >

--- a/src/components/CreateEventButton.tsx
+++ b/src/components/CreateEventButton.tsx
@@ -23,7 +23,7 @@ export function CreateEventButton() {
         aria-label={t('main.create_event', 'Create')}
         aria-haspopup="menu"
         aria-expanded={showMenu}
-        className="flex w-full items-center justify-between rounded-full bg-white border border-line px-4 py-2.5 shadow-sm hover:shadow transition-shadow"
+        className="flex w-full items-center justify-between rounded-full bg-surface border border-line px-4 py-2.5 shadow-sm hover:shadow transition-shadow"
         onClick={() => setShowMenu(!showMenu)}
       >
         <span className="flex items-center gap-2 text-fg">
@@ -46,11 +46,11 @@ export function CreateEventButton() {
           <div className="fixed inset-0 z-40" onClick={() => setShowMenu(false)} />
           <div
             role="menu"
-            className="absolute bottom-full left-0 mb-1.5 z-50 w-full overflow-hidden rounded-xl bg-white dark:bg-gray-800 border border-line shadow-lg"
+            className="absolute bottom-full left-0 mb-1.5 z-50 w-full overflow-hidden rounded-xl bg-surface-elevated border border-line shadow-lg"
           >
             <button
               role="menuitem"
-              className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken dark:hover:bg-gray-700 transition-colors"
+              className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken transition-colors"
               onClick={() => handleSelect('todo')}
             >
               <svg className="h-4 w-4 text-fg-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -58,10 +58,10 @@ export function CreateEventButton() {
               </svg>
               Todo
             </button>
-            <div className="border-t border-line dark:border-gray-700" />
+            <div className="border-t border-line" />
             <button
               role="menuitem"
-              className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken dark:hover:bg-gray-700 transition-colors"
+              className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken transition-colors"
               onClick={() => handleSelect('schedule')}
             >
               <svg className="h-4 w-4 text-fg-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/components/CreateEventButton.tsx
+++ b/src/components/CreateEventButton.tsx
@@ -23,17 +23,17 @@ export function CreateEventButton() {
         aria-label={t('main.create_event', 'Create')}
         aria-haspopup="menu"
         aria-expanded={showMenu}
-        className="flex w-full items-center justify-between rounded-full bg-white border border-border-light px-4 py-2.5 shadow-sm hover:shadow transition-shadow"
+        className="flex w-full items-center justify-between rounded-full bg-white border border-line px-4 py-2.5 shadow-sm hover:shadow transition-shadow"
         onClick={() => setShowMenu(!showMenu)}
       >
-        <span className="flex items-center gap-2 text-text-primary">
+        <span className="flex items-center gap-2 text-fg">
           <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
           </svg>
           <span className="text-sm font-medium">{t('main.create_event', 'Create')}</span>
         </span>
         <svg
-          className={cn('h-3.5 w-3.5 text-text-tertiary transition-transform', showMenu && 'rotate-180')}
+          className={cn('h-3.5 w-3.5 text-fg-tertiary transition-transform', showMenu && 'rotate-180')}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -46,25 +46,25 @@ export function CreateEventButton() {
           <div className="fixed inset-0 z-40" onClick={() => setShowMenu(false)} />
           <div
             role="menu"
-            className="absolute bottom-full left-0 mb-1.5 z-50 w-full overflow-hidden rounded-xl bg-white dark:bg-gray-800 border border-border-light shadow-lg"
+            className="absolute bottom-full left-0 mb-1.5 z-50 w-full overflow-hidden rounded-xl bg-white dark:bg-gray-800 border border-line shadow-lg"
           >
             <button
               role="menuitem"
-              className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-text-primary hover:bg-surface-sunken dark:hover:bg-gray-700 transition-colors"
+              className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken dark:hover:bg-gray-700 transition-colors"
               onClick={() => handleSelect('todo')}
             >
-              <svg className="h-4 w-4 text-text-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="h-4 w-4 text-fg-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               Todo
             </button>
-            <div className="border-t border-border-light dark:border-gray-700" />
+            <div className="border-t border-line dark:border-gray-700" />
             <button
               role="menuitem"
-              className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-text-primary hover:bg-surface-sunken dark:hover:bg-gray-700 transition-colors"
+              className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken dark:hover:bg-gray-700 transition-colors"
               onClick={() => handleSelect('schedule')}
             >
-              <svg className="h-4 w-4 text-text-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="h-4 w-4 text-fg-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
               </svg>
               Schedule

--- a/src/components/CurrentTodoList.tsx
+++ b/src/components/CurrentTodoList.tsx
@@ -47,11 +47,11 @@ function CurrentTodoRow({ todo, onEventClick, onComplete, isLast }: CurrentTodoR
       <div className="flex-1 min-w-0 py-0.5 flex items-start gap-2">
         <div className="flex-1 min-w-0">
           <p
-            className="truncate font-semibold text-[#1f1f1f] leading-snug group-hover:text-black transition-colors duration-150"
+            className="truncate font-semibold text-fg leading-snug group-hover:text-black transition-colors duration-150"
             style={{ fontSize: nameFontSize }}
           >{todo.name}</p>
           <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
-            <span className="text-xs text-[#aaa] leading-none">Todo</span>
+            <span className="text-xs text-fg-quaternary leading-none">Todo</span>
             {tagName && (
               <span
                 className="shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded-full leading-none"
@@ -64,7 +64,7 @@ function CurrentTodoRow({ todo, onEventClick, onComplete, isLast }: CurrentTodoR
         </div>
         <button
           aria-label={todo.name}
-          className="shrink-0 h-5 w-5 rounded-full border-2 border-[#ccd0dc] hover:border-[#323232] transition-colors mt-0.5"
+          className="shrink-0 h-5 w-5 rounded-full border-2 border-line-strong hover:border-fg transition-colors mt-0.5"
           onClick={(e) => { e.stopPropagation(); onComplete(todo) }}
         />
       </div>
@@ -132,7 +132,7 @@ export function CurrentTodoList({ todos, isTagHidden, onEventClick }: CurrentTod
   return (
     <section data-testid="current-todo-list" className="mb-6">
       <div className="flex items-center gap-3 mb-3">
-        <span className="text-[11px] font-semibold uppercase tracking-widest text-[#bbb] shrink-0">Current Todo</span>
+        <span className="text-[11px] font-semibold uppercase tracking-widest text-fg-quaternary shrink-0">Current Todo</span>
         <div className="flex-1 h-px bg-gray-100" />
       </div>
       <div className="flex flex-col">

--- a/src/components/CurrentTodoList.tsx
+++ b/src/components/CurrentTodoList.tsx
@@ -35,11 +35,11 @@ function CurrentTodoRow({ todo, onEventClick, onComplete, isLast }: CurrentTodoR
       {/* 타임라인: 도트 + 연결선 */}
       <div className="flex flex-col items-center shrink-0 w-3">
         <div
-          className="w-2 h-2 rounded-full shrink-0 mt-1.5 ring-2 ring-white group-hover:scale-125 transition-transform duration-150"
+          className="w-2 h-2 rounded-full shrink-0 mt-1.5 ring-2 ring-surface group-hover:scale-125 transition-transform duration-150"
           style={{ backgroundColor: color }}
         />
         {!isLast && (
-          <div className="flex-1 w-px bg-gray-200 mt-1.5" />
+          <div className="flex-1 w-px bg-line mt-1.5" />
         )}
       </div>
 
@@ -47,7 +47,7 @@ function CurrentTodoRow({ todo, onEventClick, onComplete, isLast }: CurrentTodoR
       <div className="flex-1 min-w-0 py-0.5 flex items-start gap-2">
         <div className="flex-1 min-w-0">
           <p
-            className="truncate font-semibold text-fg leading-snug group-hover:text-black transition-colors duration-150"
+            className="truncate font-semibold text-fg leading-snug group-hover:text-fg transition-colors duration-150"
             style={{ fontSize: nameFontSize }}
           >{todo.name}</p>
           <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
@@ -133,7 +133,7 @@ export function CurrentTodoList({ todos, isTagHidden, onEventClick }: CurrentTod
     <section data-testid="current-todo-list" className="mb-6">
       <div className="flex items-center gap-3 mb-3">
         <span className="text-[11px] font-semibold uppercase tracking-widest text-fg-quaternary shrink-0">Current Todo</span>
-        <div className="flex-1 h-px bg-gray-100" />
+        <div className="flex-1 h-px bg-line" />
       </div>
       <div className="flex flex-col">
         {visibleTodos.map((todo, i) => (

--- a/src/components/DayEventList.tsx
+++ b/src/components/DayEventList.tsx
@@ -40,11 +40,11 @@ function EventItem({ calEvent, onEventClick, onComplete, isLast }: {
       {/* 타임라인: 도트 + 연결선 */}
       <div className="flex flex-col items-center shrink-0 w-3">
         <div
-          className="w-2 h-2 rounded-full shrink-0 mt-1.5 ring-2 ring-white group-hover:scale-125 transition-transform duration-150"
+          className="w-2 h-2 rounded-full shrink-0 mt-1.5 ring-2 ring-surface group-hover:scale-125 transition-transform duration-150"
           style={{ backgroundColor: color }}
         />
         {!isLast && (
-          <div className="flex-1 w-px bg-gray-200 mt-1.5" />
+          <div className="flex-1 w-px bg-line mt-1.5" />
         )}
       </div>
 
@@ -52,7 +52,7 @@ function EventItem({ calEvent, onEventClick, onComplete, isLast }: {
       <div className="flex-1 min-w-0 py-0.5 flex items-start gap-2">
         <div className="flex-1 min-w-0">
           <p
-            className="truncate font-semibold text-fg leading-snug group-hover:text-black transition-colors duration-150"
+            className="truncate font-semibold text-fg leading-snug group-hover:text-fg transition-colors duration-150"
             style={{ fontSize: nameFontSize }}
           >{name}</p>
           <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">

--- a/src/components/DayEventList.tsx
+++ b/src/components/DayEventList.tsx
@@ -52,11 +52,11 @@ function EventItem({ calEvent, onEventClick, onComplete, isLast }: {
       <div className="flex-1 min-w-0 py-0.5 flex items-start gap-2">
         <div className="flex-1 min-w-0">
           <p
-            className="truncate font-semibold text-[#1f1f1f] leading-snug group-hover:text-black transition-colors duration-150"
+            className="truncate font-semibold text-fg leading-snug group-hover:text-black transition-colors duration-150"
             style={{ fontSize: nameFontSize }}
           >{name}</p>
           <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
-            <span className="text-xs text-[#aaa] leading-none">
+            <span className="text-xs text-fg-quaternary leading-none">
               <TimeDescription eventTime={event_time} />
             </span>
             {tagName && (
@@ -73,7 +73,7 @@ function EventItem({ calEvent, onEventClick, onComplete, isLast }: {
         {calEvent.type === 'todo' && (
           <button
             aria-label={name}
-            className="shrink-0 h-5 w-5 rounded-full border-2 border-[#ccd0dc] hover:border-[#323232] transition-colors mt-0.5"
+            className="shrink-0 h-5 w-5 rounded-full border-2 border-line-strong hover:border-fg transition-colors mt-0.5"
             onClick={(e) => { e.stopPropagation(); onComplete(calEvent.event) }}
           />
         )}
@@ -157,7 +157,7 @@ export function DayEventList({ selectedDate, eventsByDate, isTagHidden, onEventC
     <>
       <div className="flex flex-col">
         {sorted.length === 0 ? (
-          <div className="flex items-center justify-center py-8 text-sm text-[#969696]">
+          <div className="flex items-center justify-center py-8 text-sm text-fg-tertiary">
             {t('event.no_events')}
           </div>
         ) : (

--- a/src/components/DoneTodoDetail/DoneTodoDetailPopover.tsx
+++ b/src/components/DoneTodoDetail/DoneTodoDetailPopover.tsx
@@ -13,9 +13,9 @@ import { formatNotification } from '../../utils/formatNotification'
 const POPOVER_WIDTH = 320
 const THRESHOLD = 200
 
-const ACTION_BTN = 'p-1.5 rounded-full text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50'
-const INFO_ROW = 'flex items-start gap-2 text-[13px] text-[#6b6b6b] dark:text-gray-300 leading-snug'
-const INFO_ICON = 'h-4 w-4 text-[#bbb] mt-0.5 shrink-0'
+const ACTION_BTN = 'p-1.5 rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50'
+const INFO_ROW = 'flex items-start gap-2 text-[13px] text-fg-secondary dark:text-gray-300 leading-snug'
+const INFO_ICON = 'h-4 w-4 text-fg-quaternary mt-0.5 shrink-0'
 
 export interface DoneTodoDetailPopoverProps {
   doneTodo: DoneTodo
@@ -123,10 +123,10 @@ export function DoneTodoDetailPopover({
         </div>
 
         {/* 이름 + 태그 */}
-        <p className="pr-24 text-lg font-semibold text-[#1f1f1f] dark:text-gray-100">{doneTodo.name}</p>
+        <p className="pr-24 text-lg font-semibold text-fg dark:text-gray-100">{doneTodo.name}</p>
         <div className="mt-1 flex items-center gap-2">
           <span className="h-2 w-2 rounded-full" style={{ backgroundColor: tagColor }} />
-          <span className="text-xs text-[#6b6b6b] dark:text-gray-400">{tagName}</span>
+          <span className="text-xs text-fg-secondary dark:text-gray-400">{tagName}</span>
         </div>
 
         {/* 본문: 시간 / 알림 / url / memo / place */}
@@ -135,7 +135,7 @@ export function DoneTodoDetailPopover({
             <div className={INFO_ROW}>
               <Clock className={INFO_ICON} />
               <div>
-                <p className="text-[11px] uppercase tracking-wider text-[#bbb]">{t('todo.done_at_label', '완료 시각')}</p>
+                <p className="text-[11px] uppercase tracking-wider text-fg-quaternary">{t('todo.done_at_label', '완료 시각')}</p>
                 <p>{doneTimeText}</p>
               </div>
             </div>
@@ -144,7 +144,7 @@ export function DoneTodoDetailPopover({
             <div className={INFO_ROW}>
               <Clock className={INFO_ICON} />
               <div>
-                <p className="text-[11px] uppercase tracking-wider text-[#bbb]">{t('todo.original_time_label', '원래 시간')}</p>
+                <p className="text-[11px] uppercase tracking-wider text-fg-quaternary">{t('todo.original_time_label', '원래 시간')}</p>
                 <p><EventTimeDisplay eventTime={originEventTime} /></p>
               </div>
             </div>

--- a/src/components/DoneTodoDetail/DoneTodoDetailPopover.tsx
+++ b/src/components/DoneTodoDetail/DoneTodoDetailPopover.tsx
@@ -13,8 +13,8 @@ import { formatNotification } from '../../utils/formatNotification'
 const POPOVER_WIDTH = 320
 const THRESHOLD = 200
 
-const ACTION_BTN = 'p-1.5 rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50'
-const INFO_ROW = 'flex items-start gap-2 text-[13px] text-fg-secondary dark:text-gray-300 leading-snug'
+const ACTION_BTN = 'p-1.5 rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors disabled:opacity-50'
+const INFO_ROW = 'flex items-start gap-2 text-[13px] text-fg-secondary leading-snug'
 const INFO_ICON = 'h-4 w-4 text-fg-quaternary mt-0.5 shrink-0'
 
 export interface DoneTodoDetailPopoverProps {
@@ -82,7 +82,7 @@ export function DoneTodoDetailPopover({
       />
       {/* 카드 — EventDetailPopover 와 톤 정합 (rounded-xl, shadow-xl, gray-100 border, 폭 320) */}
       <div
-        className="fixed z-50 bg-white dark:bg-gray-800 rounded-xl shadow-xl border border-gray-100 dark:border-gray-700 p-5"
+        className="fixed z-50 bg-surface-elevated rounded-xl shadow-xl border border-line p-5"
         style={{ top, left, transform: `translateY(${translateY})`, width: POPOVER_WIDTH }}
         data-testid="done-todo-detail-popover"
       >
@@ -108,7 +108,7 @@ export function DoneTodoDetailPopover({
             aria-label={t('common.delete', '삭제')}
             disabled={vm.isDeleting}
             onClick={() => setShowDeleteConfirm(true)}
-            className={`${ACTION_BTN} hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30`}
+            className={`${ACTION_BTN} hover:text-red-500 hover:bg-red-50`}
           >
             <Trash2 className="h-4 w-4" />
           </button>
@@ -123,10 +123,10 @@ export function DoneTodoDetailPopover({
         </div>
 
         {/* 이름 + 태그 */}
-        <p className="pr-24 text-lg font-semibold text-fg dark:text-gray-100">{doneTodo.name}</p>
+        <p className="pr-24 text-lg font-semibold text-fg">{doneTodo.name}</p>
         <div className="mt-1 flex items-center gap-2">
           <span className="h-2 w-2 rounded-full" style={{ backgroundColor: tagColor }} />
-          <span className="text-xs text-fg-secondary dark:text-gray-400">{tagName}</span>
+          <span className="text-xs text-fg-secondary">{tagName}</span>
         </div>
 
         {/* 본문: 시간 / 알림 / url / memo / place */}

--- a/src/components/DoneTodoDetail/DoneTodoDetailPopover.tsx
+++ b/src/components/DoneTodoDetail/DoneTodoDetailPopover.tsx
@@ -108,7 +108,7 @@ export function DoneTodoDetailPopover({
             aria-label={t('common.delete', '삭제')}
             disabled={vm.isDeleting}
             onClick={() => setShowDeleteConfirm(true)}
-            className={`${ACTION_BTN} hover:text-red-500 hover:bg-red-50`}
+            className={`${ACTION_BTN} hover:text-danger hover:bg-danger/10`}
           >
             <Trash2 className="h-4 w-4" />
           </button>
@@ -162,7 +162,7 @@ export function DoneTodoDetailPopover({
                 href={vm.detail.url}
                 target="_blank"
                 rel="noreferrer"
-                className="text-blue-600 dark:text-blue-400 hover:underline truncate"
+                className="text-fg underline underline-offset-2 hover:opacity-60 transition-opacity truncate"
               >
                 {vm.detail.url}
               </a>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -18,10 +18,10 @@ export class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.hasError) {
       return (
-        <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-gray-50 dark:bg-gray-900">
-          <p className="text-lg font-semibold text-gray-800 dark:text-gray-200">{i18n.t('error.something_wrong')}</p>
+        <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-surface">
+          <p className="text-lg font-semibold text-fg">{i18n.t('error.something_wrong')}</p>
           <button
-            className="rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
             onClick={() => window.location.reload()}
           >
             {i18n.t('error.refresh')}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -21,7 +21,7 @@ export class ErrorBoundary extends Component<Props, State> {
         <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-surface">
           <p className="text-lg font-semibold text-fg">{i18n.t('error.something_wrong')}</p>
           <button
-            className="rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+            className="rounded-lg bg-brand px-4 py-2 text-sm text-white hover:bg-brand/90"
             onClick={() => window.location.reload()}
           >
             {i18n.t('error.refresh')}

--- a/src/components/EventDetail/EventDetailPopover.tsx
+++ b/src/components/EventDetail/EventDetailPopover.tsx
@@ -23,7 +23,7 @@ function repeatingLabel(repeating: Repeating, t: TFunction): string {
   }
 }
 
-const ACTION_BTN = 'p-1.5 rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors'
+const ACTION_BTN = 'p-1.5 rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors'
 const INFO_ROW = 'flex items-start gap-2 text-[13px] text-fg-secondary leading-snug'
 const INFO_ICON = 'h-4 w-4 text-fg-quaternary mt-0.5 shrink-0'
 
@@ -78,15 +78,15 @@ export function EventDetailPopover({
         onClick={onClose}
       />
       <div
-        className="fixed z-40 rounded-xl shadow-xl bg-white border border-gray-100 overflow-hidden min-w-[280px] max-w-[320px] animate-in fade-in-0 duration-150"
+        className="fixed z-40 rounded-xl shadow-xl bg-surface-elevated border border-line overflow-hidden min-w-[280px] max-w-[320px] animate-in fade-in-0 duration-150"
         style={{ top, left, transform: `translateY(${translateY})` }}
         data-testid="event-detail-popover"
       >
         {/* 헤더 — 이벤트 이름 + 액션 3버튼 */}
-        <div className="flex items-start gap-2 px-4 pt-3.5 pb-3 border-b border-gray-100">
+        <div className="flex items-start gap-2 px-4 pt-3.5 pb-3 border-b border-line">
           <div className="flex items-center gap-2 flex-1 min-w-0">
             <span
-              className="h-2 w-2 shrink-0 rounded-full ring-2 ring-white"
+              className="h-2 w-2 shrink-0 rounded-full ring-2 ring-surface-elevated"
               style={{ backgroundColor: tagColor }}
               data-testid="tag-color-dot"
             />

--- a/src/components/EventDetail/EventDetailPopover.tsx
+++ b/src/components/EventDetail/EventDetailPopover.tsx
@@ -23,9 +23,9 @@ function repeatingLabel(repeating: Repeating, t: TFunction): string {
   }
 }
 
-const ACTION_BTN = 'p-1.5 rounded-full text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors'
-const INFO_ROW = 'flex items-start gap-2 text-[13px] text-[#6b6b6b] leading-snug'
-const INFO_ICON = 'h-4 w-4 text-[#bbb] mt-0.5 shrink-0'
+const ACTION_BTN = 'p-1.5 rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors'
+const INFO_ROW = 'flex items-start gap-2 text-[13px] text-fg-secondary leading-snug'
+const INFO_ICON = 'h-4 w-4 text-fg-quaternary mt-0.5 shrink-0'
 
 export interface EventDetailPopoverProps {
   calEvent: CalendarEvent
@@ -90,7 +90,7 @@ export function EventDetailPopover({
               style={{ backgroundColor: tagColor }}
               data-testid="tag-color-dot"
             />
-            <h3 className="text-[15px] font-semibold text-[#1f1f1f] leading-snug break-words min-w-0">
+            <h3 className="text-[15px] font-semibold text-fg leading-snug break-words min-w-0">
               {event.name}
             </h3>
           </div>
@@ -174,7 +174,7 @@ export function EventDetailPopover({
                 href={vm.eventDetail.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="min-w-0 text-[#1f1f1f] underline underline-offset-2 hover:opacity-60 transition-opacity break-all"
+                className="min-w-0 text-fg underline underline-offset-2 hover:opacity-60 transition-opacity break-all"
               >
                 {vm.eventDetail.url}
               </a>

--- a/src/components/EventTimePicker.tsx
+++ b/src/components/EventTimePicker.tsx
@@ -67,7 +67,7 @@ function formatTimezoneLabel(): string {
 }
 
 const pillInput =
-  'rounded-md border border-transparent bg-gray-100 hover:bg-gray-200 focus:bg-white focus:border-gray-300 px-3 py-1.5 text-sm dark:bg-gray-700 dark:hover:bg-gray-600 dark:focus:bg-gray-800 dark:focus:border-gray-500 outline-none'
+  'rounded-md border border-transparent bg-surface-sunken hover:bg-surface-sunken focus:bg-surface focus:border-line-strong px-3 py-1.5 text-sm outline-none'
 
 interface EventTimePickerProps {
   value: EventTime | null
@@ -197,7 +197,7 @@ export function EventTimePicker({ value, onChange, required = false }: EventTime
             />
           </div>
 
-          <span className="px-3 text-sm font-medium text-gray-500 dark:text-gray-400">{t('eventTime.to')}</span>
+          <span className="px-3 text-sm font-medium text-fg-tertiary">{t('eventTime.to')}</span>
 
           {/* 종료 그룹 — 종료 시간을 시작 시간에 가까운 쪽으로, 종료 날짜는 맨 오른쪽 */}
           <div className="flex flex-wrap items-center gap-2">
@@ -246,7 +246,7 @@ export function EventTimePicker({ value, onChange, required = false }: EventTime
               handleValueChange({ ...internal, period_start: ts - internal.seconds_from_gmt })
             }}
           />
-          <span className="px-3 text-sm font-medium text-gray-500 dark:text-gray-400">{t('eventTime.to')}</span>
+          <span className="px-3 text-sm font-medium text-fg-tertiary">{t('eventTime.to')}</span>
           <input
             aria-label={t('eventTime.end_date')}
             type="date"
@@ -264,7 +264,7 @@ export function EventTimePicker({ value, onChange, required = false }: EventTime
       )}
 
       {type !== 'none' && (
-        <div className="text-xs text-gray-500 dark:text-gray-400">
+        <div className="text-xs text-fg-tertiary">
           {formatTimezoneLabel()}
         </div>
       )}

--- a/src/components/ForemostEventBanner.tsx
+++ b/src/components/ForemostEventBanner.tsx
@@ -46,11 +46,11 @@ export function ForemostEventBanner({ foremostEvent, onEventClick }: ForemostEve
         </div>
         <div className="flex-1 min-w-0 py-0.5">
           <p
-            className="truncate font-semibold text-[#1f1f1f] leading-snug group-hover:text-black transition-colors duration-150"
+            className="truncate font-semibold text-fg leading-snug group-hover:text-black transition-colors duration-150"
             style={{ fontSize: nameFontSize }}
           >{event.name}</p>
           <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
-            <span className="text-xs text-[#aaa] leading-none">
+            <span className="text-xs text-fg-quaternary leading-none">
               <TimeDescription eventTime={eventTime} />
             </span>
             {tagName && (

--- a/src/components/ForemostEventBanner.tsx
+++ b/src/components/ForemostEventBanner.tsx
@@ -40,13 +40,13 @@ export function ForemostEventBanner({ foremostEvent, onEventClick }: ForemostEve
       >
         <div className="flex flex-col items-center shrink-0 w-3">
           <div
-            className="w-2 h-2 rounded-full shrink-0 mt-1.5 ring-2 ring-white group-hover:scale-125 transition-transform duration-150"
+            className="w-2 h-2 rounded-full shrink-0 mt-1.5 ring-2 ring-surface group-hover:scale-125 transition-transform duration-150"
             style={{ backgroundColor: resolved.color }}
           />
         </div>
         <div className="flex-1 min-w-0 py-0.5">
           <p
-            className="truncate font-semibold text-fg leading-snug group-hover:text-black transition-colors duration-150"
+            className="truncate font-semibold text-fg leading-snug group-hover:text-fg transition-colors duration-150"
             style={{ fontSize: nameFontSize }}
           >{event.name}</p>
           <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,12 +5,12 @@ export function Header() {
   const { t } = useTranslation()
   const linkClass = ({ isActive }: { isActive: boolean }) =>
     `rounded-md px-3 py-2 text-xs md:text-sm font-medium transition-colors ${
-      isActive ? 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
+      isActive ? 'bg-surface-sunken text-fg' : 'text-fg-tertiary hover:text-fg-secondary'
     }`
 
   return (
-    <header className="sticky top-0 z-10 flex h-12 items-center justify-between border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-4">
-      <span className="text-sm font-bold text-gray-900 dark:text-gray-100">TodoCalendar</span>
+    <header className="sticky top-0 z-10 flex h-12 items-center justify-between border-b border-line bg-surface px-4">
+      <span className="text-sm font-bold text-fg">TodoCalendar</span>
       <nav className="flex gap-1">
         <NavLink to="/" end className={linkClass}>{t('nav.calendar')}</NavLink>
         <NavLink to="/settings" className={linkClass}>{t('nav.settings')}</NavLink>

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -46,7 +46,7 @@ function MiniCalendarDayButton({
       : 'hover:bg-surface-sunken hover:rounded-full'
 
   const textColor = isSelected
-    ? 'text-white font-semibold'
+    ? 'text-action-fg font-semibold'
     : isOutside
       ? 'text-fg-tertiary'
       : isSunday || isHoliday
@@ -97,7 +97,7 @@ export default function LeftSidebar({
   return (
     <div
       className={cn(
-        'hidden md:flex flex-col transition-[width] duration-200 bg-slate-50 overflow-hidden shrink-0',
+        'hidden md:flex flex-col transition-[width] duration-200 bg-surface-elevated overflow-hidden shrink-0',
         sidebarOpen ? SIDEBAR_WIDTH_CLASS : 'w-0'
       )}
     >
@@ -114,7 +114,7 @@ export default function LeftSidebar({
             data-testid="sidebar-create-event"
             aria-haspopup="menu"
             aria-expanded={showCreateMenu}
-            className="flex w-full items-center justify-between rounded-full bg-white border border-line px-4 py-2.5 shadow-sm hover:shadow transition-shadow"
+            className="flex w-full items-center justify-between rounded-full bg-surface border border-line px-4 py-2.5 shadow-sm hover:shadow transition-shadow"
             onClick={() => setShowCreateMenu(!showCreateMenu)}
           >
             <span className="flex items-center gap-2 text-fg">
@@ -137,11 +137,11 @@ export default function LeftSidebar({
               <div className="fixed inset-0 z-40" onClick={() => setShowCreateMenu(false)} />
               <div
                 role="menu"
-                className="absolute top-full left-0 mt-1.5 z-50 w-full overflow-hidden rounded-xl bg-white dark:bg-gray-800 border border-line shadow-lg"
+                className="absolute top-full left-0 mt-1.5 z-50 w-full overflow-hidden rounded-xl bg-surface-elevated border border-line shadow-lg"
               >
                 <button
                   role="menuitem"
-                  className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken dark:hover:bg-gray-700 transition-colors"
+                  className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken transition-colors"
                   onClick={() => {
                     setShowCreateMenu(false)
                     const rect = createButtonRef.current?.getBoundingClientRect() ?? null
@@ -153,10 +153,10 @@ export default function LeftSidebar({
                   </svg>
                   Todo
                 </button>
-                <div className="border-t border-line dark:border-gray-700" />
+                <div className="border-t border-line" />
                 <button
                   role="menuitem"
-                  className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken dark:hover:bg-gray-700 transition-colors"
+                  className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken transition-colors"
                   onClick={() => {
                     setShowCreateMenu(false)
                     const rect = createButtonRef.current?.getBoundingClientRect() ?? null

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -40,7 +40,7 @@ function MiniCalendarDayButton({
   const isSelected = modifiers.selected
 
   const bgStyle = isSelected
-    ? 'bg-text-primary rounded-full'
+    ? 'bg-fg rounded-full'
     : isToday
       ? 'bg-surface-sunken rounded-full'
       : 'hover:bg-surface-sunken hover:rounded-full'
@@ -48,10 +48,10 @@ function MiniCalendarDayButton({
   const textColor = isSelected
     ? 'text-white font-semibold'
     : isOutside
-      ? 'text-text-tertiary'
+      ? 'text-fg-tertiary'
       : isSunday || isHoliday
-        ? 'text-danger-soft'
-        : 'text-text-primary'
+        ? 'text-danger'
+        : 'text-fg'
 
   return (
     <button
@@ -114,17 +114,17 @@ export default function LeftSidebar({
             data-testid="sidebar-create-event"
             aria-haspopup="menu"
             aria-expanded={showCreateMenu}
-            className="flex w-full items-center justify-between rounded-full bg-white border border-border-light px-4 py-2.5 shadow-sm hover:shadow transition-shadow"
+            className="flex w-full items-center justify-between rounded-full bg-white border border-line px-4 py-2.5 shadow-sm hover:shadow transition-shadow"
             onClick={() => setShowCreateMenu(!showCreateMenu)}
           >
-            <span className="flex items-center gap-2 text-text-primary">
+            <span className="flex items-center gap-2 text-fg">
               <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
               </svg>
               <span className="text-sm font-medium">{t('main.create_event', 'Create')}</span>
             </span>
             <svg
-              className={cn('h-3.5 w-3.5 text-text-tertiary transition-transform', showCreateMenu && 'rotate-180')}
+              className={cn('h-3.5 w-3.5 text-fg-tertiary transition-transform', showCreateMenu && 'rotate-180')}
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -137,33 +137,33 @@ export default function LeftSidebar({
               <div className="fixed inset-0 z-40" onClick={() => setShowCreateMenu(false)} />
               <div
                 role="menu"
-                className="absolute top-full left-0 mt-1.5 z-50 w-full overflow-hidden rounded-xl bg-white dark:bg-gray-800 border border-border-light shadow-lg"
+                className="absolute top-full left-0 mt-1.5 z-50 w-full overflow-hidden rounded-xl bg-white dark:bg-gray-800 border border-line shadow-lg"
               >
                 <button
                   role="menuitem"
-                  className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-text-primary hover:bg-surface-sunken dark:hover:bg-gray-700 transition-colors"
+                  className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken dark:hover:bg-gray-700 transition-colors"
                   onClick={() => {
                     setShowCreateMenu(false)
                     const rect = createButtonRef.current?.getBoundingClientRect() ?? null
                     onOpenEventForm(rect, 'todo')
                   }}
                 >
-                  <svg className="h-4 w-4 text-text-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="h-4 w-4 text-fg-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                   Todo
                 </button>
-                <div className="border-t border-border-light dark:border-gray-700" />
+                <div className="border-t border-line dark:border-gray-700" />
                 <button
                   role="menuitem"
-                  className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-text-primary hover:bg-surface-sunken dark:hover:bg-gray-700 transition-colors"
+                  className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken dark:hover:bg-gray-700 transition-colors"
                   onClick={() => {
                     setShowCreateMenu(false)
                     const rect = createButtonRef.current?.getBoundingClientRect() ?? null
                     onOpenEventForm(rect, 'schedule')
                   }}
                 >
-                  <svg className="h-4 w-4 text-text-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="h-4 w-4 text-fg-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                   </svg>
                   Schedule
@@ -188,12 +188,12 @@ export default function LeftSidebar({
               months: 'relative flex flex-col gap-0',
               month: 'flex w-full flex-col gap-2',
               month_caption: 'flex h-7 w-full items-center justify-center px-7',
-              caption_label: 'text-sm font-semibold text-text-primary select-none',
+              caption_label: 'text-sm font-semibold text-fg select-none',
               nav: 'absolute inset-x-0 top-0 flex w-full items-center justify-between',
-              button_previous: 'rounded p-0.5 hover:bg-surface-sunken text-text-secondary h-7 w-7 flex items-center justify-center transition-colors',
-              button_next: 'rounded p-0.5 hover:bg-surface-sunken text-text-secondary h-7 w-7 flex items-center justify-center transition-colors',
+              button_previous: 'rounded p-0.5 hover:bg-surface-sunken text-fg-secondary h-7 w-7 flex items-center justify-center transition-colors',
+              button_next: 'rounded p-0.5 hover:bg-surface-sunken text-fg-secondary h-7 w-7 flex items-center justify-center transition-colors',
               weekdays: 'flex',
-              weekday: 'flex-1 text-center text-[10px] font-normal uppercase tracking-wide text-text-tertiary py-1',
+              weekday: 'flex-1 text-center text-[10px] font-normal uppercase tracking-wide text-fg-tertiary py-1',
               week: 'mt-0.5 flex w-full',
               day: 'flex-1 flex items-center justify-center py-0.5',
               today: '',

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -40,7 +40,7 @@ function MiniCalendarDayButton({
   const isSelected = modifiers.selected
 
   const bgStyle = isSelected
-    ? 'bg-fg rounded-full'
+    ? 'bg-action rounded-full'
     : isToday
       ? 'bg-surface-sunken rounded-full'
       : 'hover:bg-surface-sunken hover:rounded-full'

--- a/src/components/LoadingSkeleton.tsx
+++ b/src/components/LoadingSkeleton.tsx
@@ -4,7 +4,7 @@ export function LoadingSkeleton({ lines = 3, className = '' }: Props) {
   return (
     <div className={`animate-pulse space-y-3 ${className}`}>
       {Array.from({ length: lines }, (_, i) => (
-        <div key={i} className="h-4 rounded bg-gray-200" style={{ width: `${Math.max(30, 85 - i * 10)}%` }} />
+        <div key={i} className="h-4 rounded bg-surface-sunken" style={{ width: `${Math.max(30, 85 - i * 10)}%` }} />
       ))}
     </div>
   )

--- a/src/components/NotificationPicker.tsx
+++ b/src/components/NotificationPicker.tsx
@@ -97,14 +97,14 @@ export function NotificationPicker({ value, onChange, isAllDay }: NotificationPi
           {value.map((opt, i) => (
             <span
               key={i}
-              className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+              className="inline-flex items-center gap-1 rounded-full bg-surface-sunken px-3 py-1 text-sm text-fg-secondary"
             >
               {optionLabel(opt)}
               <button
                 type="button"
                 onClick={() => removeAt(i)}
                 aria-label={t('notif.remove')}
-                className="ml-1 rounded-full p-0.5 hover:bg-gray-200 dark:hover:bg-gray-600"
+                className="ml-1 rounded-full p-0.5 hover:bg-surface-sunken"
               >
                 <X size={12} />
               </button>
@@ -119,7 +119,7 @@ export function NotificationPicker({ value, onChange, isAllDay }: NotificationPi
           onClick={() => setOpen(v => !v)}
           aria-haspopup="listbox"
           aria-expanded={open}
-          className="inline-flex items-center gap-1 rounded-md border border-dashed border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+          className="inline-flex items-center gap-1 rounded-md border border-dashed border-line-strong bg-surface px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-elevated"
         >
           <Plus size={14} aria-hidden="true" />
           {t('notif.add_button')}
@@ -128,10 +128,10 @@ export function NotificationPicker({ value, onChange, isAllDay }: NotificationPi
         {open && (
           <div
             role="listbox"
-            className="absolute left-0 z-10 mt-1 min-w-[220px] max-h-64 overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-md dark:bg-gray-800 dark:border-gray-700"
+            className="absolute left-0 z-10 mt-1 min-w-[220px] max-h-64 overflow-auto rounded-md border border-line bg-surface-elevated py-1 shadow-md"
           >
             {!hasAvailable && (
-              <div className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">{t('notif.no_more_options')}</div>
+              <div className="px-3 py-2 text-sm text-fg-tertiary">{t('notif.no_more_options')}</div>
             )}
             {isAllDay
               ? availableAllDay.map(p => (
@@ -140,7 +140,7 @@ export function NotificationPicker({ value, onChange, isAllDay }: NotificationPi
                     type="button"
                     role="option"
                     onClick={() => addAllDayPreset(p)}
-                    className="block w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
+                    className="block w-full px-3 py-2 text-left text-sm text-fg-secondary hover:bg-surface-sunken"
                   >
                     {t(p.key)}
                   </button>
@@ -151,7 +151,7 @@ export function NotificationPicker({ value, onChange, isAllDay }: NotificationPi
                     type="button"
                     role="option"
                     onClick={() => addTimePreset(p)}
-                    className="block w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
+                    className="block w-full px-3 py-2 text-left text-sm text-fg-secondary hover:bg-surface-sunken"
                   >
                     {t(p.key)}
                   </button>

--- a/src/components/QuickTodoInput.tsx
+++ b/src/components/QuickTodoInput.tsx
@@ -40,7 +40,7 @@ export function QuickTodoInput() {
         style={{ backgroundColor: tagColor }}
       />
       <input
-        className="flex-1 bg-transparent text-sm text-[#1f1f1f] placeholder:text-[#ccc] outline-none"
+        className="flex-1 bg-transparent text-sm text-fg placeholder:text-fg-quaternary outline-none"
         placeholder={t('main.quick_todo_placeholder', 'Add a new task...')}
         value={value}
         onChange={e => setValue(e.target.value)}

--- a/src/components/QuickTodoInput.tsx
+++ b/src/components/QuickTodoInput.tsx
@@ -34,7 +34,7 @@ export function QuickTodoInput() {
   }
 
   return (
-    <div className="flex items-center gap-3 rounded-lg bg-white border border-gray-200 px-3 py-2.5 focus-within:border-gray-300 focus-within:shadow-sm transition-all duration-150">
+    <div className="flex items-center gap-3 rounded-lg bg-surface border border-line px-3 py-2.5 focus-within:border-line-strong focus-within:shadow-sm transition-all duration-150">
       <div
         className="shrink-0 w-2 h-2 rounded-full"
         style={{ backgroundColor: tagColor }}

--- a/src/components/RepeatingPicker.tsx
+++ b/src/components/RepeatingPicker.tsx
@@ -274,7 +274,7 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
               role="menuitem"
               onClick={() => handleSelectPreset(null)}
               className={`block w-full px-3 py-2 text-left text-sm hover:bg-surface-sunken ${
-                !value ? 'font-medium text-blue-600' : 'text-fg-secondary'
+                !value ? 'font-medium text-brand' : 'text-fg-secondary'
               }`}
             >
               {t('repeating.not_repeat')}
@@ -289,7 +289,7 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
                   role="menuitem"
                   onClick={() => handleSelectPreset(p)}
                   className={`block w-full px-3 py-2 text-left text-sm hover:bg-surface-sunken ${
-                    isSelected ? 'font-medium text-blue-600' : 'text-fg-secondary'
+                    isSelected ? 'font-medium text-brand' : 'text-fg-secondary'
                   }`}
                 >
                   {p.text}

--- a/src/components/RepeatingPicker.tsx
+++ b/src/components/RepeatingPicker.tsx
@@ -258,7 +258,7 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
           aria-haspopup="menu"
           aria-expanded={open}
           onClick={() => setOpen(v => !v)}
-          className="inline-flex items-center gap-1 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+          className="inline-flex items-center gap-1 rounded-md border border-line-strong bg-surface px-3 py-1.5 text-sm text-fg-secondary hover:bg-surface-elevated"
         >
           {buttonLabel}
           <ChevronDown size={14} aria-hidden="true" />
@@ -267,19 +267,19 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
         {open && (
           <div
             role="menu"
-            className="absolute left-0 z-10 mt-1 max-h-80 min-w-[220px] overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-md dark:bg-gray-800 dark:border-gray-700"
+            className="absolute left-0 z-10 mt-1 max-h-80 min-w-[220px] overflow-auto rounded-md border border-line bg-surface-elevated py-1 shadow-md"
           >
             <button
               type="button"
               role="menuitem"
               onClick={() => handleSelectPreset(null)}
-              className={`block w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 ${
-                !value ? 'font-medium text-blue-600 dark:text-blue-400' : 'text-gray-700 dark:text-gray-200'
+              className={`block w-full px-3 py-2 text-left text-sm hover:bg-surface-sunken ${
+                !value ? 'font-medium text-blue-600' : 'text-fg-secondary'
               }`}
             >
               {t('repeating.not_repeat')}
             </button>
-            <div className="my-1 border-t border-gray-200 dark:border-gray-700" />
+            <div className="my-1 border-t border-line" />
             {presets.map(p => {
               const isSelected = value && optionsEqual(p.option, value.option)
               return (
@@ -288,8 +288,8 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
                   type="button"
                   role="menuitem"
                   onClick={() => handleSelectPreset(p)}
-                  className={`block w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 ${
-                    isSelected ? 'font-medium text-blue-600 dark:text-blue-400' : 'text-gray-700 dark:text-gray-200'
+                  className={`block w-full px-3 py-2 text-left text-sm hover:bg-surface-sunken ${
+                    isSelected ? 'font-medium text-blue-600' : 'text-fg-secondary'
                   }`}
                 >
                   {p.text}
@@ -302,10 +302,10 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
 
       {/* 종료 조건: 반복이 설정된 경우에만 노출 */}
       {value && (
-        <div className="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200">
+        <div className="inline-flex items-center gap-2 text-sm text-fg-secondary">
           <select
             aria-label={t('repeating.end_condition')}
-            className="rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
+            className="rounded-md border border-line-strong bg-surface px-2 py-1.5 text-sm"
             value={endType}
             onChange={e => handleEndTypeChange(e.target.value as EndType)}
           >
@@ -317,7 +317,7 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
             <input
               type="date"
               aria-label={t('repeating.end_on_date')}
-              className="rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
+              className="rounded-md border border-line-strong bg-surface px-2 py-1.5 text-sm"
               value={endDate}
               onChange={e => handleEndDateChange(e.target.value)}
             />
@@ -327,7 +327,7 @@ export function RepeatingPicker({ value, onChange, startTimestamp }: RepeatingPi
               type="number"
               min={1}
               aria-label={t('repeating.end_after_count', { n: endCount })}
-              className="w-20 rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
+              className="w-20 rounded-md border border-line-strong bg-surface px-2 py-1.5 text-sm"
               value={endCount}
               onChange={e => handleEndCountChange(Math.max(1, Number(e.target.value) || 1))}
             />

--- a/src/components/RepeatingScopeDialog.tsx
+++ b/src/components/RepeatingScopeDialog.tsx
@@ -25,32 +25,32 @@ export function RepeatingScopeDialog({ mode, eventType = 'schedule', onSelect, o
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
-        <h2 className="text-base font-semibold text-gray-900">
+      <div className="w-full max-w-sm rounded-xl bg-surface-elevated p-6 shadow-xl">
+        <h2 className="text-base font-semibold text-fg">
           {dialogTitle()}
         </h2>
-        <div className="mt-4 flex flex-col divide-y divide-gray-100">
+        <div className="mt-4 flex flex-col divide-y divide-line">
           <button
-            className="px-4 py-3 text-left text-sm text-gray-800 hover:bg-gray-50"
+            className="px-4 py-3 text-left text-sm text-fg hover:bg-surface-sunken"
             onClick={() => onSelect('this')}
           >
             {t('repeat.this_only')}
           </button>
           <button
-            className="px-4 py-3 text-left text-sm text-gray-800 hover:bg-gray-50"
+            className="px-4 py-3 text-left text-sm text-fg hover:bg-surface-sunken"
             onClick={() => onSelect('future')}
           >
             {t('repeat.future')}
           </button>
           <button
-            className="px-4 py-3 text-left text-sm text-gray-800 hover:bg-gray-50"
+            className="px-4 py-3 text-left text-sm text-fg hover:bg-surface-sunken"
             onClick={() => onSelect('all')}
           >
             {t('repeat.all')}
           </button>
         </div>
         <button
-          className="mt-4 w-full rounded-lg px-4 py-2 text-sm text-gray-500 hover:bg-gray-100"
+          className="mt-4 w-full rounded-lg px-4 py-2 text-sm text-fg-tertiary hover:bg-surface-sunken"
           onClick={onCancel}
         >
           {t('common.cancel')}

--- a/src/components/RightEventPanel.tsx
+++ b/src/components/RightEventPanel.tsx
@@ -26,7 +26,7 @@ function SectionHeader({ label }: { label: string }) {
   return (
     <div className="flex items-center gap-3 mb-3">
       <span className="text-[11px] font-semibold uppercase tracking-widest text-fg-quaternary shrink-0">{label}</span>
-      <div className="flex-1 h-px bg-gray-100" />
+      <div className="flex-1 h-px bg-line" />
     </div>
   )
 }
@@ -85,20 +85,20 @@ export function RightEventPanel({
   const lunarText = selectedDate && showLunarCalendar ? formatLunarDate(selectedDate, dateLocale) : null
 
   return (
-    <div className="w-full h-full flex flex-col bg-white relative">
+    <div className="w-full h-full flex flex-col bg-surface relative">
       {/* 우상단 액션 — 아카이브 진입 + 패널 닫기 */}
       <div className="absolute top-2 right-3 z-10 flex items-center gap-0.5">
         <button
           onClick={onOpenArchivePanel}
           aria-label={t('todo.done_list', '완료된 할 일')}
-          className="p-1.5 rounded-full hover:bg-gray-100 transition-colors text-gray-400 hover:text-gray-600"
+          className="p-1.5 rounded-full hover:bg-surface-sunken transition-colors text-fg-quaternary hover:text-fg-secondary"
         >
           <CheckCircle2 className="h-4 w-4" />
         </button>
         <button
           onClick={onToggleRightPanel}
           aria-label={t('common.close', '패널 닫기')}
-          className="p-1.5 rounded-full hover:bg-gray-100 transition-colors text-gray-400 hover:text-gray-600"
+          className="p-1.5 rounded-full hover:bg-surface-sunken transition-colors text-fg-quaternary hover:text-fg-secondary"
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
             <path d="M6 6l12 12M18 6L6 18" />

--- a/src/components/RightEventPanel.tsx
+++ b/src/components/RightEventPanel.tsx
@@ -120,7 +120,7 @@ export function RightEventPanel({
                 )}
               </div>
               {showHolidayInEventList && holidayNames.length > 0 && (
-                <p className="mt-1 text-sm text-red-400 font-medium">{holidayNames.join(', ')}</p>
+                <p className="mt-1 text-sm text-danger font-medium">{holidayNames.join(', ')}</p>
               )}
             </div>
           )}

--- a/src/components/RightEventPanel.tsx
+++ b/src/components/RightEventPanel.tsx
@@ -25,7 +25,7 @@ function formatLunarDate(date: Date, locale: string): string | null {
 function SectionHeader({ label }: { label: string }) {
   return (
     <div className="flex items-center gap-3 mb-3">
-      <span className="text-[11px] font-semibold uppercase tracking-widest text-[#bbb] shrink-0">{label}</span>
+      <span className="text-[11px] font-semibold uppercase tracking-widest text-fg-quaternary shrink-0">{label}</span>
       <div className="flex-1 h-px bg-gray-100" />
     </div>
   )
@@ -112,11 +112,11 @@ export function RightEventPanel({
           {/* 날짜 헤더 — 우측 padding으로 X 버튼 영역 회피 */}
           {selectedDate && (
             <div className="mb-6 pr-20">
-              <h1 className="text-2xl font-bold text-[#323232]">{dateTitle}</h1>
+              <h1 className="text-2xl font-bold text-fg">{dateTitle}</h1>
               <div className="flex flex-wrap items-center gap-x-2 mt-0.5">
-                <p className="text-sm text-[#969696]">{weekdayText}</p>
+                <p className="text-sm text-fg-tertiary">{weekdayText}</p>
                 {lunarText && (
-                  <p className="text-sm text-[#969696]">· {t('settings.lunar_prefix', '음력')} {lunarText}</p>
+                  <p className="text-sm text-fg-tertiary">· {t('settings.lunar_prefix', '음력')} {lunarText}</p>
                 )}
               </div>
               {showHolidayInEventList && holidayNames.length > 0 && (

--- a/src/components/RightEventPanel.tsx
+++ b/src/components/RightEventPanel.tsx
@@ -163,7 +163,7 @@ export function RightEventPanel({
       </div>
 
       {/* 하단 고정 */}
-      <div className="shrink-0 border-t border-border-calendar p-4 flex flex-col gap-2">
+      <div className="shrink-0 border-t border-line p-4 flex flex-col gap-2">
         <QuickTodoInput />
         <CreateEventButton />
       </div>

--- a/src/components/TagDropdown.tsx
+++ b/src/components/TagDropdown.tsx
@@ -75,7 +75,7 @@ export function TagDropdown({ value, onChange, showManageLink = false }: TagDrop
       {showManageLink && (
         <button
           type="button"
-          className="text-xs text-[#1f1f1f] underline underline-offset-2 hover:opacity-60 transition-opacity"
+          className="text-xs text-fg underline underline-offset-2 hover:opacity-60 transition-opacity"
           onClick={() => navigate('/settings/editEvent/tags')}
         >
           {t('tag.manage')} &gt;

--- a/src/components/TagFilter.tsx
+++ b/src/components/TagFilter.tsx
@@ -11,8 +11,8 @@ export function TagFilter() {
   if (tags.size === 0) return null
 
   return (
-    <div className="px-3 py-2 border-t border-gray-100">
-      <p className="text-xs font-medium text-gray-400 uppercase tracking-wide mb-2">{t('tag.filter')}</p>
+    <div className="px-3 py-2 border-t border-line">
+      <p className="text-xs font-medium text-fg-quaternary uppercase tracking-wide mb-2">{t('tag.filter')}</p>
       <div className="flex flex-wrap gap-2">
         {Array.from(tags.values()).map(tag => {
           const isHidden = hiddenTagIds.has(tag.uuid)
@@ -21,7 +21,7 @@ export function TagFilter() {
               key={tag.uuid}
               onClick={() => toggleTag(tag.uuid)}
               className={`flex items-center gap-1 rounded-full px-2.5 py-1 text-xs transition ${
-                isHidden ? 'bg-gray-100 text-gray-400 line-through' : 'bg-gray-50 text-gray-700'
+                isHidden ? 'bg-surface-sunken text-fg-quaternary line-through' : 'bg-surface-elevated text-fg-secondary'
               }`}
             >
               <span

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,7 +1,8 @@
 import { useTranslation } from 'react-i18next'
 import { useToastStore } from '../stores/toastStore'
 
-const bgColor = { success: 'bg-green-600', error: 'bg-red-600', info: 'bg-gray-800' }
+const bgColor = { success: 'bg-green-600', error: 'bg-red-600', info: 'bg-action' }
+const fgColor = { success: 'text-white', error: 'text-white', info: 'text-action-fg' }
 
 export function ToastContainer() {
   const { t } = useTranslation()
@@ -15,7 +16,7 @@ export function ToastContainer() {
         <div
           key={toast.id}
           role="alert"
-          className={`${bgColor[toast.type]} rounded-lg px-4 py-2 text-sm text-white shadow-lg`}
+          className={`${bgColor[toast.type]} ${fgColor[toast.type]} rounded-lg px-4 py-2 text-sm shadow-lg`}
           onClick={() => dismiss(toast.id)}
         >
           {t(toast.key, toast.params as Record<string, string> | undefined)}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useToastStore } from '../stores/toastStore'
 
-const bgColor = { success: 'bg-green-600', error: 'bg-red-600', info: 'bg-action' }
+const bgColor = { success: 'bg-success', error: 'bg-danger', info: 'bg-action' }
 const fgColor = { success: 'text-white', error: 'text-white', info: 'text-action-fg' }
 
 export function ToastContainer() {
@@ -16,6 +16,7 @@ export function ToastContainer() {
         <div
           key={toast.id}
           role="alert"
+          data-toast-type={toast.type}
           className={`${bgColor[toast.type]} ${fgColor[toast.type]} rounded-lg px-4 py-2 text-sm shadow-lg`}
           onClick={() => dismiss(toast.id)}
         >

--- a/src/components/TopToolbar.tsx
+++ b/src/components/TopToolbar.tsx
@@ -32,11 +32,11 @@ export default function TopToolbar({
   const dateLocale = i18n.language === 'en' ? 'en-US' : 'ko-KR'
   const monthLabel = currentMonth.toLocaleDateString(dateLocale, { month: 'long' })
 
-  const iconBtn = 'rounded-full p-2 text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors'
-  const navBtn = 'rounded-full p-2 text-gray-300 hover:text-fg hover:bg-gray-50 transition-colors'
+  const iconBtn = 'rounded-full p-2 text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors'
+  const navBtn = 'rounded-full p-2 text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors'
 
   return (
-    <div className="flex h-16 items-center bg-white border-b border-gray-100 shrink-0">
+    <div className="flex h-16 items-center bg-surface border-b border-line shrink-0">
       {/* 좌측: 햄버거 + 로고 (사이드바 너비와 동기화) */}
       <div
         className={cn(
@@ -47,7 +47,7 @@ export default function TopToolbar({
         <button
           onClick={onToggleSidebar}
           aria-label={t('main.toggle_sidebar', '사이드바 토글')}
-          className="shrink-0 rounded-full p-2 mx-2 text-gray-500 hover:text-fg hover:bg-gray-50 transition-colors"
+          className="shrink-0 rounded-full p-2 mx-2 text-fg-tertiary hover:text-fg hover:bg-surface-elevated transition-colors"
         >
           <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
@@ -95,7 +95,7 @@ export default function TopToolbar({
         <button
           onClick={onGoToToday}
           aria-label={t('main.today', '오늘')}
-          className="rounded-full px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.15em] text-fg hover:bg-gray-50 transition-colors"
+          className="rounded-full px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.15em] text-fg hover:bg-surface-elevated transition-colors"
         >
           {t('main.today', '오늘')}
         </button>

--- a/src/components/TopToolbar.tsx
+++ b/src/components/TopToolbar.tsx
@@ -32,8 +32,8 @@ export default function TopToolbar({
   const dateLocale = i18n.language === 'en' ? 'en-US' : 'ko-KR'
   const monthLabel = currentMonth.toLocaleDateString(dateLocale, { month: 'long' })
 
-  const iconBtn = 'rounded-full p-2 text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors'
-  const navBtn = 'rounded-full p-2 text-gray-300 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors'
+  const iconBtn = 'rounded-full p-2 text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors'
+  const navBtn = 'rounded-full p-2 text-gray-300 hover:text-fg hover:bg-gray-50 transition-colors'
 
   return (
     <div className="flex h-16 items-center bg-white border-b border-gray-100 shrink-0">
@@ -47,7 +47,7 @@ export default function TopToolbar({
         <button
           onClick={onToggleSidebar}
           aria-label={t('main.toggle_sidebar', '사이드바 토글')}
-          className="shrink-0 rounded-full p-2 mx-2 text-gray-500 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+          className="shrink-0 rounded-full p-2 mx-2 text-gray-500 hover:text-fg hover:bg-gray-50 transition-colors"
         >
           <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
@@ -60,7 +60,7 @@ export default function TopToolbar({
           )}
         >
           <img src="/logo-light.png" alt="To-do Calendar" className="h-7 shrink-0" />
-          <span className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#1f1f1f] whitespace-nowrap">
+          <span className="text-[12px] font-semibold uppercase tracking-[0.18em] text-fg whitespace-nowrap">
             To-do Calendar
           </span>
         </div>
@@ -77,10 +77,10 @@ export default function TopToolbar({
 
           {/* 월 타이틀 — 연도는 캡션, 월은 히어로 */}
           <div data-testid="toolbar-month-title" className="flex flex-col items-center leading-none min-w-[7rem] py-1">
-            <span data-testid="toolbar-year" className="text-[10px] font-semibold uppercase tracking-[0.25em] text-[#bbb]">
+            <span data-testid="toolbar-year" className="text-[10px] font-semibold uppercase tracking-[0.25em] text-fg-quaternary">
               {year}
             </span>
-            <span data-testid="toolbar-month" className="mt-1 text-[18px] font-semibold text-[#1f1f1f] tracking-tight">
+            <span data-testid="toolbar-month" className="mt-1 text-[18px] font-semibold text-fg tracking-tight">
               {monthLabel}
             </span>
           </div>
@@ -95,7 +95,7 @@ export default function TopToolbar({
         <button
           onClick={onGoToToday}
           aria-label={t('main.today', '오늘')}
-          className="rounded-full px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.15em] text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+          className="rounded-full px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.15em] text-fg hover:bg-gray-50 transition-colors"
         >
           {t('main.today', '오늘')}
         </button>

--- a/src/components/UncompletedTodoList.tsx
+++ b/src/components/UncompletedTodoList.tsx
@@ -35,11 +35,11 @@ function UncompletedTodoRow({ todo, onEventClick, onComplete, isLast }: Uncomple
       {/* 타임라인: 도트 + 연결선 */}
       <div className="flex flex-col items-center shrink-0 w-3">
         <div
-          className="w-2 h-2 rounded-full shrink-0 mt-1.5 ring-2 ring-white group-hover:scale-125 transition-transform duration-150"
+          className="w-2 h-2 rounded-full shrink-0 mt-1.5 ring-2 ring-surface group-hover:scale-125 transition-transform duration-150"
           style={{ backgroundColor: color }}
         />
         {!isLast && (
-          <div className="flex-1 w-px bg-gray-200 mt-1.5" />
+          <div className="flex-1 w-px bg-line mt-1.5" />
         )}
       </div>
 
@@ -137,7 +137,7 @@ export function UncompletedTodoList({ todos, isTagHidden, onReload, onEventClick
         <span className="text-[11px] font-semibold uppercase tracking-widest text-fg-quaternary shrink-0">
           {t('todo.uncompleted')}
         </span>
-        <div className="flex-1 h-px bg-gray-100" />
+        <div className="flex-1 h-px bg-line" />
         <button
           onClick={onReload}
           className="shrink-0 text-fg-quaternary hover:text-fg-tertiary transition-colors"

--- a/src/components/UncompletedTodoList.tsx
+++ b/src/components/UncompletedTodoList.tsx
@@ -47,11 +47,11 @@ function UncompletedTodoRow({ todo, onEventClick, onComplete, isLast }: Uncomple
       <div className="flex-1 min-w-0 py-0.5 flex items-start gap-2">
         <div className="flex-1 min-w-0">
           <p
-            className="truncate font-semibold text-[#ea4444] leading-snug"
+            className="truncate font-semibold text-danger leading-snug"
             style={{ fontSize: nameFontSize }}
           >{todo.name}</p>
           <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
-            <span className="text-xs text-[#aaa] leading-none">Todo</span>
+            <span className="text-xs text-fg-quaternary leading-none">Todo</span>
             {tagName && (
               <span
                 className="shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded-full leading-none"
@@ -64,7 +64,7 @@ function UncompletedTodoRow({ todo, onEventClick, onComplete, isLast }: Uncomple
         </div>
         <button
           aria-label={todo.name}
-          className="shrink-0 h-5 w-5 rounded-full border-2 border-[#ccd0dc] hover:border-[#323232] transition-colors mt-0.5"
+          className="shrink-0 h-5 w-5 rounded-full border-2 border-line-strong hover:border-fg transition-colors mt-0.5"
           onClick={(e) => { e.stopPropagation(); onComplete(todo) }}
         />
       </div>
@@ -134,13 +134,13 @@ export function UncompletedTodoList({ todos, isTagHidden, onReload, onEventClick
   return (
     <section className="mb-6">
       <div className="flex items-center gap-3 mb-3">
-        <span className="text-[11px] font-semibold uppercase tracking-widest text-[#bbb] shrink-0">
+        <span className="text-[11px] font-semibold uppercase tracking-widest text-fg-quaternary shrink-0">
           {t('todo.uncompleted')}
         </span>
         <div className="flex-1 h-px bg-gray-100" />
         <button
           onClick={onReload}
-          className="shrink-0 text-[#ccc] hover:text-[#999] transition-colors"
+          className="shrink-0 text-fg-quaternary hover:text-fg-tertiary transition-colors"
           aria-label="refresh"
         >
           <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/components/dev/TestDataSeederButton.tsx
+++ b/src/components/dev/TestDataSeederButton.tsx
@@ -63,7 +63,7 @@ export default function TestDataSeederButton() {
       disabled={running}
       aria-label="테스트 데이터 주입"
       title="테스트 데이터 주입 (개발환경 전용)"
-      className="rounded-full p-2 hover:bg-gray-100 text-gray-500 disabled:opacity-50"
+      className="rounded-full p-2 hover:bg-surface-sunken text-fg-tertiary disabled:opacity-50"
     >
       <span className={`inline-block text-base leading-none ${running ? 'animate-pulse' : ''}`}>
         🧪

--- a/src/components/eventForm/EventDetailsSection.tsx
+++ b/src/components/eventForm/EventDetailsSection.tsx
@@ -20,7 +20,7 @@ interface EventDetailsSectionProps {
 }
 
 const inputClass =
-  'w-full rounded-md border border-border-light bg-transparent px-3 py-2 text-sm text-text-primary outline-none placeholder:text-text-tertiary focus:border-text-primary transition-colors'
+  'w-full rounded-md border border-line bg-transparent px-3 py-2 text-sm text-fg outline-none placeholder:text-fg-tertiary focus:border-fg transition-colors'
 
 interface RowProps {
   icon: React.ReactNode
@@ -31,7 +31,7 @@ interface RowProps {
 function Row({ icon, children, align = 'center' }: RowProps) {
   return (
     <div className={`flex gap-3 ${align === 'start' ? 'items-start' : 'items-center'}`}>
-      <div className={`flex h-6 w-6 shrink-0 items-center justify-center text-text-tertiary ${align === 'start' ? 'mt-2' : ''}`} aria-hidden="true">
+      <div className={`flex h-6 w-6 shrink-0 items-center justify-center text-fg-tertiary ${align === 'start' ? 'mt-2' : ''}`} aria-hidden="true">
         {icon}
       </div>
       <div className="flex-1 min-w-0">{children}</div>
@@ -59,7 +59,7 @@ export function EventDetailsSection({
   const memoId = `${fieldPrefix}-memo`
 
   return (
-    <section className="space-y-4 rounded-xl border border-border-light bg-background p-5 shadow-sm">
+    <section className="space-y-4 rounded-xl border border-line bg-background p-5 shadow-sm">
       {/* Tag */}
       <Row icon={<TagIcon className="h-4 w-4" />}>
         <TagDropdown value={tagId} onChange={onTagChange} showManageLink />

--- a/src/components/eventForm/EventFormHeader.tsx
+++ b/src/components/eventForm/EventFormHeader.tsx
@@ -30,12 +30,12 @@ export function EventFormHeader({
   const nameInputId = `${idPrefix}-event-name`
 
   return (
-    <div className="sticky top-0 z-10 flex items-center gap-4 border-b border-border-light bg-background px-4 py-4">
+    <div className="sticky top-0 z-10 flex items-center gap-4 border-b border-line bg-background px-4 py-4">
       <button
         type="button"
         aria-label={t('common.cancel')}
         onClick={onClose}
-        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-text-secondary hover:text-text-primary hover:bg-surface-sunken transition-colors"
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-fg-secondary hover:text-fg hover:bg-surface-sunken transition-colors"
       >
         <X size={20} />
       </button>
@@ -46,7 +46,7 @@ export function EventFormHeader({
           id={nameInputId}
           aria-label={t('event.name')}
           placeholder={t('event.namePlaceholder', '이벤트 이름 추가')}
-          className="w-full border-b border-transparent bg-transparent pr-6 text-2xl font-normal tracking-tight text-text-primary outline-none focus:border-text-primary placeholder:text-text-tertiary transition-colors"
+          className="w-full border-b border-transparent bg-transparent pr-6 text-2xl font-normal tracking-tight text-fg outline-none focus:border-fg placeholder:text-fg-tertiary transition-colors"
           value={name}
           onChange={e => onNameChange(e.target.value)}
         />

--- a/src/components/eventForm/EventFormPopover.tsx
+++ b/src/components/eventForm/EventFormPopover.tsx
@@ -179,14 +179,14 @@ export function EventFormPopover() {
           {/* Header: drag handle + title + close */}
           <div
             onMouseDown={handleDragMouseDown}
-            className="shrink-0 flex items-center gap-2 px-5 py-3 border-b border-border-light bg-surface-sunken/60 cursor-move"
+            className="shrink-0 flex items-center gap-2 px-5 py-3 border-b border-line bg-surface-sunken/60 cursor-move"
           >
             <GripHorizontal
-              className="h-4 w-4 text-text-tertiary shrink-0"
+              className="h-4 w-4 text-fg-tertiary shrink-0"
               aria-label={t('eventForm.drag_handle', '드래그하여 이동')}
               data-focus-skip
             />
-            <h2 id={TITLE_ID} className="flex-1 text-sm font-semibold text-text-primary select-none">
+            <h2 id={TITLE_ID} className="flex-1 text-sm font-semibold text-fg select-none">
               {t('eventForm.title_new', '새 이벤트 추가')}
             </h2>
             <button
@@ -194,7 +194,7 @@ export function EventFormPopover() {
               aria-label={t('common.close')}
               data-testid="event-form-close-btn"
               disabled={closeDisabled}
-              className="shrink-0 p-1 rounded text-text-tertiary hover:text-text-primary hover:bg-surface-sunken disabled:opacity-40 transition-colors"
+              className="shrink-0 p-1 rounded text-fg-tertiary hover:text-fg hover:bg-surface-sunken disabled:opacity-40 transition-colors"
               onClick={handleCloseRequest}
             >
               <X size={16} />
@@ -212,7 +212,7 @@ export function EventFormPopover() {
             </CardContent>
           </div>
 
-          <CardFooter className="px-5 py-3 border-t border-border-light bg-card shrink-0 flex-col items-stretch gap-2">
+          <CardFooter className="px-5 py-3 border-t border-line bg-card shrink-0 flex-col items-stretch gap-2">
             {error && (
               <p className="text-xs text-destructive text-center" role="alert">
                 {error}

--- a/src/components/eventForm/EventFormTopSection.tsx
+++ b/src/components/eventForm/EventFormTopSection.tsx
@@ -20,14 +20,14 @@ export function EventFormTopSection() {
   return (
     <div className="space-y-4">
       {/* Name input + DDay inline chip */}
-      <div className="flex items-center gap-3 pb-2 border-b border-border-light focus-within:border-text-primary transition-colors">
+      <div className="flex items-center gap-3 pb-2 border-b border-line focus-within:border-fg transition-colors">
         <div
           className="w-3 h-3 rounded-full shrink-0"
           style={{ backgroundColor: tagColor }}
           data-testid="event-form-tag-swatch"
         />
         <input
-          className="flex-1 min-w-0 text-lg font-semibold bg-transparent outline-none placeholder:text-text-tertiary placeholder:font-normal"
+          className="flex-1 min-w-0 text-lg font-semibold bg-transparent outline-none placeholder:text-fg-tertiary placeholder:font-normal"
           placeholder={t('event.namePlaceholder', '이벤트 이름')}
           value={name}
           onChange={e => setName(e.target.value)}

--- a/src/components/eventForm/EventTimeSection.tsx
+++ b/src/components/eventForm/EventTimeSection.tsx
@@ -18,7 +18,7 @@ export function EventTimeSection({
   required,
 }: EventTimeSectionProps) {
   return (
-    <section className="rounded-xl border border-border-light bg-background p-5 shadow-sm space-y-4">
+    <section className="rounded-xl border border-line bg-background p-5 shadow-sm space-y-4">
       <EventTimePickerCore
         value={eventTime}
         onChange={onEventTimeChange}

--- a/src/components/eventForm/EventTypeToggle.tsx
+++ b/src/components/eventForm/EventTypeToggle.tsx
@@ -21,14 +21,14 @@ export function EventTypeToggle() {
     >
       <ToggleGroupItem
         value="todo"
-        className="flex-1 h-8 gap-1.5 rounded-full text-xs font-medium text-fg-secondary aria-pressed:bg-white aria-pressed:text-fg aria-pressed:shadow-sm transition-all"
+        className="flex-1 h-8 gap-1.5 rounded-full text-xs font-medium text-fg-secondary aria-pressed:bg-surface aria-pressed:text-fg aria-pressed:shadow-sm transition-all"
       >
         <CheckCircle2 className="h-3.5 w-3.5" />
         {t('eventType.todo', 'Todo')}
       </ToggleGroupItem>
       <ToggleGroupItem
         value="schedule"
-        className="flex-1 h-8 gap-1.5 rounded-full text-xs font-medium text-fg-secondary aria-pressed:bg-white aria-pressed:text-fg aria-pressed:shadow-sm transition-all"
+        className="flex-1 h-8 gap-1.5 rounded-full text-xs font-medium text-fg-secondary aria-pressed:bg-surface aria-pressed:text-fg aria-pressed:shadow-sm transition-all"
       >
         <CalendarDays className="h-3.5 w-3.5" />
         {t('eventType.schedule', 'Schedule')}

--- a/src/components/eventForm/EventTypeToggle.tsx
+++ b/src/components/eventForm/EventTypeToggle.tsx
@@ -21,14 +21,14 @@ export function EventTypeToggle() {
     >
       <ToggleGroupItem
         value="todo"
-        className="flex-1 h-8 gap-1.5 rounded-full text-xs font-medium text-text-secondary aria-pressed:bg-white aria-pressed:text-text-primary aria-pressed:shadow-sm transition-all"
+        className="flex-1 h-8 gap-1.5 rounded-full text-xs font-medium text-fg-secondary aria-pressed:bg-white aria-pressed:text-fg aria-pressed:shadow-sm transition-all"
       >
         <CheckCircle2 className="h-3.5 w-3.5" />
         {t('eventType.todo', 'Todo')}
       </ToggleGroupItem>
       <ToggleGroupItem
         value="schedule"
-        className="flex-1 h-8 gap-1.5 rounded-full text-xs font-medium text-text-secondary aria-pressed:bg-white aria-pressed:text-text-primary aria-pressed:shadow-sm transition-all"
+        className="flex-1 h-8 gap-1.5 rounded-full text-xs font-medium text-fg-secondary aria-pressed:bg-white aria-pressed:text-fg aria-pressed:shadow-sm transition-all"
       >
         <CalendarDays className="h-3.5 w-3.5" />
         {t('eventType.schedule', 'Schedule')}

--- a/src/components/eventForm/MoreActionsMenu.tsx
+++ b/src/components/eventForm/MoreActionsMenu.tsx
@@ -37,7 +37,7 @@ export function MoreActionsMenu({ onCopy, onDelete }: MoreActionsMenuProps) {
         aria-label={t('eventForm.more_actions')}
         aria-haspopup="menu"
         aria-expanded={open}
-        className="flex h-9 w-9 items-center justify-center rounded-full text-text-secondary hover:text-text-primary hover:bg-surface-sunken transition-colors"
+        className="flex h-9 w-9 items-center justify-center rounded-full text-fg-secondary hover:text-fg hover:bg-surface-sunken transition-colors"
         onClick={() => setOpen(v => !v)}
       >
         <MoreHorizontal size={18} aria-hidden="true" />
@@ -47,20 +47,20 @@ export function MoreActionsMenu({ onCopy, onDelete }: MoreActionsMenuProps) {
           <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
           <div
             role="menu"
-            className="absolute right-0 z-50 mt-1.5 min-w-[10rem] overflow-hidden rounded-xl border border-border-light bg-background shadow-lg"
+            className="absolute right-0 z-50 mt-1.5 min-w-[10rem] overflow-hidden rounded-xl border border-line bg-background shadow-lg"
           >
             <button
               type="button"
               role="menuitem"
-              className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-text-primary hover:bg-surface-sunken transition-colors"
+              className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken transition-colors"
               onClick={() => { setOpen(false); onCopy() }}
             >
-              <Copy className="h-4 w-4 text-text-secondary" />
+              <Copy className="h-4 w-4 text-fg-secondary" />
               {t('eventForm.copy')}
             </button>
             {onDelete && (
               <>
-                <div className="border-t border-border-light" />
+                <div className="border-t border-line" />
                 <button
                   type="button"
                   role="menuitem"

--- a/src/components/eventForm/RepeatingSection.tsx
+++ b/src/components/eventForm/RepeatingSection.tsx
@@ -29,10 +29,10 @@ export function RepeatingSection({ eventTime, repeating, onRepeatingChange }: Re
         <PopoverTrigger
           className="flex-1 flex items-center justify-between rounded-md border border-input bg-transparent px-2.5 py-1.5 text-sm hover:bg-surface-sunken focus-visible:ring-2 focus-visible:ring-ring/50 outline-none transition-colors"
         >
-          <span className={isOn ? 'text-text-primary font-medium' : 'text-text-tertiary'}>
+          <span className={isOn ? 'text-fg font-medium' : 'text-fg-tertiary'}>
             {summary}
           </span>
-          <span className="text-xs text-text-tertiary">
+          <span className="text-xs text-fg-tertiary">
             {t('repeating.edit', '수정')}
           </span>
         </PopoverTrigger>

--- a/src/dev/testDataSeeder.ts
+++ b/src/dev/testDataSeeder.ts
@@ -4,6 +4,7 @@ import { scheduleApi } from '../api/scheduleApi'
 import { foremostApi } from '../api/foremostApi'
 import { doneTodoApi } from '../api/doneTodoApi'
 import type { EventTag, Todo, EventTime, Repeating, NotificationOption } from '../models'
+import { PRESET_COLORS } from '../components/ColorPalette'
 
 export const TEST_PREFIX = '[TEST] '
 
@@ -95,11 +96,11 @@ interface SeederTag {
 }
 
 const TAGS: SeederTag[] = [
-  { key: 'work', name: `${TEST_PREFIX}Work`, color_hex: '#F44336' },
-  { key: 'personal', name: `${TEST_PREFIX}Personal`, color_hex: '#2196F3' },
-  { key: 'study', name: `${TEST_PREFIX}Study`, color_hex: '#9C27B0' },
-  { key: 'health', name: `${TEST_PREFIX}Health`, color_hex: '#4CAF50' },
-  { key: 'travel', name: `${TEST_PREFIX}Travel`, color_hex: '#FF9800' },
+  { key: 'work', name: `${TEST_PREFIX}Work`, color_hex: PRESET_COLORS[0] },     // red
+  { key: 'personal', name: `${TEST_PREFIX}Personal`, color_hex: PRESET_COLORS[4] }, // blue
+  { key: 'study', name: `${TEST_PREFIX}Study`, color_hex: PRESET_COLORS[5] },   // purple
+  { key: 'health', name: `${TEST_PREFIX}Health`, color_hex: PRESET_COLORS[3] }, // green
+  { key: 'travel', name: `${TEST_PREFIX}Travel`, color_hex: PRESET_COLORS[1] }, // orange
 ]
 
 interface SeedResult {

--- a/src/index.css
+++ b/src/index.css
@@ -5,20 +5,39 @@
 
 @theme {
   --font-sans: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+
+  /* 사이드바 — 유지 (별도 카테고리, 본 PR 비스코프) */
   --color-sidebar-bg: #1e293b;
   --color-sidebar-text: #cbd5e1;
   --color-sidebar-text-dim: #64748b;
-  --color-surface: #f8f9fa;
-  --color-surface-alt: #f1f4f5;
-  --color-brand: #1d4ed8;
-  --color-brand-dark: #005bc1;
-  --color-border-light: #e2e8f0;
-  --color-border-calendar: #e5e7eb;
-  --color-text-primary: #334155;
-  --color-text-secondary: #64748b;
-  --color-text-tertiary: #94a3b8;
+
+  /* === 신규 의미 토큰 (이슈 #75) === */
+  /* Text (4) */
+  --color-fg: #1f1f1f;
+  --color-fg-secondary: #6b6b6b;
+  --color-fg-tertiary: #969696;
+  --color-fg-quaternary: #bbb;
+
+  /* Surface (3) */
+  --color-surface: #ffffff;
+  --color-surface-elevated: #f8f9fa;
   --color-surface-sunken: #f1f5f9;
-  --color-danger-soft: #e11d48;
+
+  /* Border (2) */
+  --color-line: #e2e8f0;
+  --color-line-strong: #cbd5e1;
+
+  /* Action (2) */
+  --color-action: #1f1f1f;
+  --color-action-fg: #ffffff;
+
+  /* Brand (1) */
+  --color-brand: #1d4ed8;
+
+  /* State (3) */
+  --color-danger: #e11d48;
+  --color-warning: #f59e0b;
+  --color-success: #16a34a;
 }
 
 html {
@@ -135,6 +154,28 @@ html {
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+
+  /* === 신규 의미 토큰 다크값 (이슈 #75) === */
+  --color-fg: #fbfbfb;
+  --color-fg-secondary: #c4c4c4;
+  --color-fg-tertiary: #969696;
+  --color-fg-quaternary: #6e6e6e;
+
+  --color-surface: #252525;
+  --color-surface-elevated: #353535;
+  --color-surface-sunken: #444444;
+
+  --color-line: rgba(255, 255, 255, 0.10);
+  --color-line-strong: rgba(255, 255, 255, 0.20);
+
+  --color-action: #fbfbfb;
+  --color-action-fg: #1f1f1f;
+
+  --color-brand: #60a5fa;
+
+  --color-danger: #fb7185;
+  --color-warning: #fbbf24;
+  --color-success: #4ade80;
 }
 
 @layer base {

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -23,7 +23,7 @@ export function LoginPage() {
         <p className="text-sm text-center text-fg-tertiary mb-8">{t('login.subtitle')}</p>
 
         {vm.errorKey && (
-          <div role="alert" className="mb-4 p-3 text-sm text-red-700 bg-red-50 rounded-lg">
+          <div role="alert" className="mb-4 p-3 text-sm text-danger bg-danger/10 rounded-lg">
             {t(vm.errorKey)}
           </div>
         )}

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -17,10 +17,10 @@ export function LoginPage() {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-50 dark:bg-gray-900">
-      <div className="w-full max-w-sm p-8 bg-white dark:bg-gray-800 rounded-2xl shadow-md">
-        <h1 className="text-2xl font-bold text-center text-gray-800 dark:text-gray-100 mb-2">{t('login.title')}</h1>
-        <p className="text-sm text-center text-gray-500 dark:text-gray-400 mb-8">{t('login.subtitle')}</p>
+    <div className="flex flex-col items-center justify-center min-h-screen bg-surface">
+      <div className="w-full max-w-sm p-8 bg-surface-elevated rounded-2xl shadow-md">
+        <h1 className="text-2xl font-bold text-center text-fg mb-2">{t('login.title')}</h1>
+        <p className="text-sm text-center text-fg-tertiary mb-8">{t('login.subtitle')}</p>
 
         {vm.errorKey && (
           <div role="alert" className="mb-4 p-3 text-sm text-red-700 bg-red-50 rounded-lg">
@@ -32,7 +32,7 @@ export function LoginPage() {
           <button
             onClick={vm.signInWithGoogle}
             disabled={vm.loading}
-            className="flex items-center justify-center gap-2 w-full py-3 px-4 border border-gray-300 dark:border-gray-600 rounded-xl text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="flex items-center justify-center gap-2 w-full py-3 px-4 border border-line rounded-xl text-sm font-medium text-fg-secondary bg-surface hover:bg-surface-sunken disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
               <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
@@ -46,7 +46,7 @@ export function LoginPage() {
           <button
             onClick={vm.signInWithApple}
             disabled={vm.loading}
-            className="flex items-center justify-center gap-2 w-full py-3 px-4 border border-gray-300 dark:border-gray-600 rounded-xl text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="flex items-center justify-center gap-2 w-full py-3 px-4 border border-line rounded-xl text-sm font-medium text-fg-secondary bg-surface hover:bg-surface-sunken disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>

--- a/src/pages/Main/MainPage.tsx
+++ b/src/pages/Main/MainPage.tsx
@@ -90,7 +90,7 @@ export function MainPage() {
   }
 
   return (
-    <div className="h-screen bg-slate-50">
+    <div className="h-screen bg-surface-elevated">
       <div className="flex h-full flex-col overflow-hidden">
         <TopToolbar
           currentMonth={vm.currentMonth}
@@ -126,7 +126,7 @@ export function MainPage() {
             }`}
           >
             <div className="w-[408px] h-full py-4 pr-4">
-              <div className="h-full rounded-lg border border-line bg-white shadow-sm overflow-hidden">
+              <div className="h-full rounded-lg border border-line bg-surface shadow-sm overflow-hidden">
                 <RightEventPanel
                   selectedDate={vm.selectedDate}
                   rightPanelMode={vm.rightPanelMode}

--- a/src/pages/Main/MainPage.tsx
+++ b/src/pages/Main/MainPage.tsx
@@ -90,7 +90,7 @@ export function MainPage() {
   }
 
   return (
-    <div className="h-screen bg-surface-elevated">
+    <div className="h-screen bg-surface">
       <div className="flex h-full flex-col overflow-hidden">
         <TopToolbar
           currentMonth={vm.currentMonth}

--- a/src/pages/Main/MainPage.tsx
+++ b/src/pages/Main/MainPage.tsx
@@ -126,7 +126,7 @@ export function MainPage() {
             }`}
           >
             <div className="w-[408px] h-full py-4 pr-4">
-              <div className="h-full rounded-lg border border-border-calendar bg-white shadow-sm overflow-hidden">
+              <div className="h-full rounded-lg border border-line bg-white shadow-sm overflow-hidden">
                 <RightEventPanel
                   selectedDate={vm.selectedDate}
                   rightPanelMode={vm.rightPanelMode}

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -9,7 +9,7 @@ export function NotFoundPage() {
       <p className="mt-4 text-lg text-fg-secondary">{t('error.page_not_found')}</p>
       <Link
         to="/"
-        className="mt-6 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        className="mt-6 rounded-lg bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand/90"
       >
         {t('error.go_home')}
       </Link>

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -5,8 +5,8 @@ export function NotFoundPage() {
   const { t } = useTranslation()
   return (
     <div className="flex min-h-screen flex-col items-center justify-center px-4 text-center">
-      <h1 className="text-6xl font-bold text-gray-300 dark:text-gray-600">404</h1>
-      <p className="mt-4 text-lg text-gray-600 dark:text-gray-400">{t('error.page_not_found')}</p>
+      <h1 className="text-6xl font-bold text-fg-quaternary">404</h1>
+      <p className="mt-4 text-lg text-fg-secondary">{t('error.page_not_found')}</p>
       <Link
         to="/"
         className="mt-6 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"

--- a/src/pages/settings/SettingsMenu.tsx
+++ b/src/pages/settings/SettingsMenu.tsx
@@ -14,12 +14,12 @@ export function SettingsMenu({ selected, onSelect, onBack }: Props) {
 
   return (
     <nav className="flex flex-col" aria-label={t('settings.title')}>
-      <div className="flex items-center gap-2 px-4 py-4 border-b border-gray-100">
+      <div className="flex items-center gap-2 px-4 py-4 border-b border-line">
         <button
           type="button"
           onClick={onBack}
           aria-label={t('settings.back')}
-          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
+          className="flex h-9 w-9 items-center justify-center rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors"
         >
           <ChevronLeft className="h-5 w-5" />
         </button>
@@ -39,7 +39,7 @@ export function SettingsMenu({ selected, onSelect, onBack }: Props) {
                   'relative flex w-full items-center px-6 py-2.5 text-left text-sm transition-colors',
                   isSelected
                     ? 'font-semibold text-fg'
-                    : 'font-medium text-fg-secondary hover:text-fg hover:bg-gray-50',
+                    : 'font-medium text-fg-secondary hover:text-fg hover:bg-surface-elevated',
                 )}
               >
                 {isSelected && (

--- a/src/pages/settings/SettingsMenu.tsx
+++ b/src/pages/settings/SettingsMenu.tsx
@@ -19,11 +19,11 @@ export function SettingsMenu({ selected, onSelect, onBack }: Props) {
           type="button"
           onClick={onBack}
           aria-label={t('settings.back')}
-          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
         >
           <ChevronLeft className="h-5 w-5" />
         </button>
-        <h1 className="text-lg font-semibold text-[#1f1f1f]">{t('settings.title')}</h1>
+        <h1 className="text-lg font-semibold text-fg">{t('settings.title')}</h1>
       </div>
 
       <ul className="flex flex-col py-3">
@@ -38,12 +38,12 @@ export function SettingsMenu({ selected, onSelect, onBack }: Props) {
                 className={cn(
                   'relative flex w-full items-center px-6 py-2.5 text-left text-sm transition-colors',
                   isSelected
-                    ? 'font-semibold text-[#1f1f1f]'
-                    : 'font-medium text-[#6b6b6b] hover:text-[#1f1f1f] hover:bg-gray-50',
+                    ? 'font-semibold text-fg'
+                    : 'font-medium text-fg-secondary hover:text-fg hover:bg-gray-50',
                 )}
               >
                 {isSelected && (
-                  <span className="absolute left-0 top-1 bottom-1 w-0.5 rounded-full bg-[#1f1f1f]" aria-hidden="true" />
+                  <span className="absolute left-0 top-1 bottom-1 w-0.5 rounded-full bg-action" aria-hidden="true" />
                 )}
                 {t(cat.labelKey)}
               </button>

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -105,7 +105,7 @@ export function SettingsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-surface">
       <div
         className={cn(
           'md:grid',
@@ -117,7 +117,7 @@ export function SettingsPage() {
         {/* 좌측 메뉴 */}
         <aside
           className={cn(
-            'border-r border-gray-100',
+            'border-r border-line',
             !hasExplicitCategory ? 'block' : 'hidden md:block',
           )}
         >
@@ -128,19 +128,19 @@ export function SettingsPage() {
         <main
           className={cn(
             'px-4 py-6 md:px-10 md:py-10',
-            subPanelOpen ? 'md:border-r md:border-gray-100' : '',
+            subPanelOpen ? 'md:border-r md:border-line' : '',
             // mobile 표시 규칙: 카테고리 선택됨 AND 서브 패널이 mobile에서 가리는 중이 아님
             hasExplicitCategory && !subPanelOpen ? 'block' : 'hidden',
             'md:block',
           )}
         >
           {hasExplicitCategory && !subPanelOpen && (
-            <div className="md:hidden flex items-center gap-2 mb-8 -mx-4 px-4 pb-3 border-b border-gray-100">
+            <div className="md:hidden flex items-center gap-2 mb-8 -mx-4 px-4 pb-3 border-b border-line">
               <button
                 type="button"
                 onClick={() => navigate('/settings')}
                 aria-label={t('settings.back')}
-                className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
+                className="flex h-9 w-9 items-center justify-center rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors"
               >
                 <ChevronLeft className="h-5 w-5" />
               </button>

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -140,11 +140,11 @@ export function SettingsPage() {
                 type="button"
                 onClick={() => navigate('/settings')}
                 aria-label={t('settings.back')}
-                className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+                className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
               >
                 <ChevronLeft className="h-5 w-5" />
               </button>
-              <h2 className="text-base font-semibold text-[#1f1f1f]">
+              <h2 className="text-base font-semibold text-fg">
                 {category && t(category.labelKey)}
               </h2>
             </div>

--- a/src/pages/settings/SettingsSection.tsx
+++ b/src/pages/settings/SettingsSection.tsx
@@ -7,8 +7,8 @@ interface SettingsSectionProps {
 }
 
 export function SettingsSection({ title, children, tone = 'default' }: SettingsSectionProps) {
-  const titleColor = tone === 'danger' ? 'text-red-400' : 'text-fg-quaternary'
-  const ruleColor = tone === 'danger' ? 'bg-red-100' : 'bg-line'
+  const titleColor = tone === 'danger' ? 'text-danger' : 'text-fg-quaternary'
+  const ruleColor = tone === 'danger' ? 'bg-danger/10' : 'bg-line'
   return (
     <section className="space-y-6">
       <div className="flex items-center gap-3">
@@ -27,7 +27,7 @@ export const settingsBtnPrimary =
 export const settingsBtnSecondary =
   'inline-flex items-center rounded-full border border-line text-fg px-4 h-9 text-sm font-medium hover:bg-surface-elevated transition-colors'
 export const settingsBtnDanger =
-  'inline-flex items-center rounded-full border border-red-200 text-red-500 px-4 h-9 text-sm font-medium hover:bg-red-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
+  'inline-flex items-center rounded-full border border-danger/30 text-danger px-4 h-9 text-sm font-medium hover:bg-danger/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
 export const settingsInput =
   'w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-fg outline-none focus:border-action transition-colors'
 export const settingsLabel = 'text-xs font-medium text-fg-secondary'

--- a/src/pages/settings/SettingsSection.tsx
+++ b/src/pages/settings/SettingsSection.tsx
@@ -7,7 +7,7 @@ interface SettingsSectionProps {
 }
 
 export function SettingsSection({ title, children, tone = 'default' }: SettingsSectionProps) {
-  const titleColor = tone === 'danger' ? 'text-red-400' : 'text-[#bbb]'
+  const titleColor = tone === 'danger' ? 'text-red-400' : 'text-fg-quaternary'
   const ruleColor = tone === 'danger' ? 'bg-red-100' : 'bg-gray-100'
   return (
     <section className="space-y-6">
@@ -23,11 +23,11 @@ export function SettingsSection({ title, children, tone = 'default' }: SettingsS
 }
 
 export const settingsBtnPrimary =
-  'inline-flex items-center rounded-full bg-[#1f1f1f] text-white px-4 h-9 text-sm font-semibold hover:bg-[#323232] transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
+  'inline-flex items-center rounded-full bg-action text-action-fg px-4 h-9 text-sm font-semibold hover:bg-action/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
 export const settingsBtnSecondary =
-  'inline-flex items-center rounded-full border border-gray-200 text-[#1f1f1f] px-4 h-9 text-sm font-medium hover:bg-gray-50 transition-colors'
+  'inline-flex items-center rounded-full border border-gray-200 text-fg px-4 h-9 text-sm font-medium hover:bg-gray-50 transition-colors'
 export const settingsBtnDanger =
   'inline-flex items-center rounded-full border border-red-200 text-red-500 px-4 h-9 text-sm font-medium hover:bg-red-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
 export const settingsInput =
-  'w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-[#1f1f1f] outline-none focus:border-[#1f1f1f] transition-colors'
-export const settingsLabel = 'text-xs font-medium text-[#6b6b6b]'
+  'w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-fg outline-none focus:border-action transition-colors'
+export const settingsLabel = 'text-xs font-medium text-fg-secondary'

--- a/src/pages/settings/SettingsSection.tsx
+++ b/src/pages/settings/SettingsSection.tsx
@@ -8,7 +8,7 @@ interface SettingsSectionProps {
 
 export function SettingsSection({ title, children, tone = 'default' }: SettingsSectionProps) {
   const titleColor = tone === 'danger' ? 'text-red-400' : 'text-fg-quaternary'
-  const ruleColor = tone === 'danger' ? 'bg-red-100' : 'bg-gray-100'
+  const ruleColor = tone === 'danger' ? 'bg-red-100' : 'bg-line'
   return (
     <section className="space-y-6">
       <div className="flex items-center gap-3">
@@ -25,9 +25,9 @@ export function SettingsSection({ title, children, tone = 'default' }: SettingsS
 export const settingsBtnPrimary =
   'inline-flex items-center rounded-full bg-action text-action-fg px-4 h-9 text-sm font-semibold hover:bg-action/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
 export const settingsBtnSecondary =
-  'inline-flex items-center rounded-full border border-gray-200 text-fg px-4 h-9 text-sm font-medium hover:bg-gray-50 transition-colors'
+  'inline-flex items-center rounded-full border border-line text-fg px-4 h-9 text-sm font-medium hover:bg-surface-elevated transition-colors'
 export const settingsBtnDanger =
   'inline-flex items-center rounded-full border border-red-200 text-red-500 px-4 h-9 text-sm font-medium hover:bg-red-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
 export const settingsInput =
-  'w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-fg outline-none focus:border-action transition-colors'
+  'w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-fg outline-none focus:border-action transition-colors'
 export const settingsLabel = 'text-xs font-medium text-fg-secondary'

--- a/src/pages/settings/sections/AccountSection.tsx
+++ b/src/pages/settings/sections/AccountSection.tsx
@@ -35,7 +35,7 @@ export function AccountSection({ account, signOut }: Props) {
     <div className="space-y-10">
       <SettingsSection title={t('settings.account')}>
         {account && (
-          <p className="text-sm text-[#6b6b6b]">{account.email ?? account.uid}</p>
+          <p className="text-sm text-fg-secondary">{account.email ?? account.uid}</p>
         )}
         <div>
           <button className={settingsBtnSecondary} onClick={() => signOut()}>

--- a/src/pages/settings/sections/AppearanceSection.tsx
+++ b/src/pages/settings/sections/AppearanceSection.tsx
@@ -115,7 +115,7 @@ export function AppearanceSection({
                   'rounded-full px-3 h-8 text-sm font-medium transition-colors',
                   weekStartDay === opt.value
                     ? 'bg-action text-action-fg'
-                    : 'bg-surface-sunken text-fg hover:bg-surface-sunken',
+                    : 'bg-surface-sunken text-fg hover:bg-surface-elevated',
                 )}
               >
                 {t(`calendar.weekdays.${opt.key}`, opt.key.toUpperCase())}
@@ -149,7 +149,7 @@ export function AppearanceSection({
                   'rounded-full px-4 h-9 text-sm font-medium transition-colors',
                   theme === opt.id
                     ? 'bg-action text-action-fg'
-                    : 'bg-surface-sunken text-fg hover:bg-surface-sunken',
+                    : 'bg-surface-sunken text-fg hover:bg-surface-elevated',
                 )}
               >
                 {opt.label}
@@ -178,7 +178,7 @@ export function AppearanceSection({
                   'rounded-full px-4 h-9 text-sm font-medium transition-colors',
                   eventDisplayLevel === opt.value
                     ? 'bg-action text-action-fg'
-                    : 'bg-surface-sunken text-fg hover:bg-surface-sunken',
+                    : 'bg-surface-sunken text-fg hover:bg-surface-elevated',
                 )}
               >
                 {t(`settings.event_display_${opt.key}`, opt.key)}

--- a/src/pages/settings/sections/AppearanceSection.tsx
+++ b/src/pages/settings/sections/AppearanceSection.tsx
@@ -35,7 +35,7 @@ function ToggleSwitch({ on, onChange, ariaLabel }: { on: boolean; onChange: () =
       aria-label={ariaLabel}
       className={cn(
         'relative inline-flex h-6 w-11 items-center rounded-full transition-colors shrink-0',
-        on ? 'bg-[#1f1f1f]' : 'bg-gray-300',
+        on ? 'bg-action' : 'bg-gray-300',
       )}
     >
       <span
@@ -114,8 +114,8 @@ export function AppearanceSection({
                 className={cn(
                   'rounded-full px-3 h-8 text-sm font-medium transition-colors',
                   weekStartDay === opt.value
-                    ? 'bg-[#1f1f1f] text-white'
-                    : 'bg-gray-100 text-[#1f1f1f] hover:bg-gray-200',
+                    ? 'bg-action text-action-fg'
+                    : 'bg-gray-100 text-fg hover:bg-gray-200',
                 )}
               >
                 {t(`calendar.weekdays.${opt.key}`, opt.key.toUpperCase())}
@@ -128,7 +128,7 @@ export function AppearanceSection({
           <div className="space-y-3">
             {(['holiday', 'sunday', 'saturday'] as const).map(key => (
               <div key={key} className="flex items-center justify-between">
-                <span className="text-sm text-[#1f1f1f]">{t(`settings.accent_${key}`, key)}</span>
+                <span className="text-sm text-fg">{t(`settings.accent_${key}`, key)}</span>
                 <ToggleSwitch
                   on={accentDays[key]}
                   onChange={() => setAppearance({ accentDays: { ...accentDays, [key]: !accentDays[key] } })}
@@ -148,8 +148,8 @@ export function AppearanceSection({
                 className={cn(
                   'rounded-full px-4 h-9 text-sm font-medium transition-colors',
                   theme === opt.id
-                    ? 'bg-[#1f1f1f] text-white'
-                    : 'bg-gray-100 text-[#1f1f1f] hover:bg-gray-200',
+                    ? 'bg-action text-action-fg'
+                    : 'bg-gray-100 text-fg hover:bg-gray-200',
                 )}
               >
                 {opt.label}
@@ -177,8 +177,8 @@ export function AppearanceSection({
                 className={cn(
                   'rounded-full px-4 h-9 text-sm font-medium transition-colors',
                   eventDisplayLevel === opt.value
-                    ? 'bg-[#1f1f1f] text-white'
-                    : 'bg-gray-100 text-[#1f1f1f] hover:bg-gray-200',
+                    ? 'bg-action text-action-fg'
+                    : 'bg-gray-100 text-fg hover:bg-gray-200',
                 )}
               >
                 {t(`settings.event_display_${opt.key}`, opt.key)}
@@ -198,12 +198,12 @@ export function AppearanceSection({
             max={7}
             value={eventFontSizeWeight}
             onChange={e => setAppearance({ eventFontSizeWeight: Number(e.target.value) })}
-            className="w-full accent-[#1f1f1f]"
+            className="w-full accent-action"
           />
         </div>
 
         <div className="flex items-center justify-between">
-          <span className="text-sm text-[#1f1f1f]">{t('settings.show_event_names', '이벤트 이름 표시')}</span>
+          <span className="text-sm text-fg">{t('settings.show_event_names', '이벤트 이름 표시')}</span>
           <ToggleSwitch
             on={showEventNames}
             onChange={() => setAppearance({ showEventNames: !showEventNames })}
@@ -232,7 +232,7 @@ export function AppearanceSection({
             max={7}
             value={eventListFontSizeWeight}
             onChange={e => setAppearance({ eventListFontSizeWeight: Number(e.target.value) })}
-            className="w-full accent-[#1f1f1f]"
+            className="w-full accent-action"
           />
         </div>
 
@@ -243,7 +243,7 @@ export function AppearanceSection({
             { key: 'showUncompletedTodos', label: t('settings.show_uncompleted_todos', '미완료 할 일 표시'), value: showUncompletedTodos },
           ].map(opt => (
             <div key={opt.key} className="flex items-center justify-between">
-              <span className="text-sm text-[#1f1f1f]">{opt.label}</span>
+              <span className="text-sm text-fg">{opt.label}</span>
               <ToggleSwitch
                 on={opt.value}
                 onChange={() => setAppearance({ [opt.key]: !opt.value } as never)}

--- a/src/pages/settings/sections/AppearanceSection.tsx
+++ b/src/pages/settings/sections/AppearanceSection.tsx
@@ -35,12 +35,12 @@ function ToggleSwitch({ on, onChange, ariaLabel }: { on: boolean; onChange: () =
       aria-label={ariaLabel}
       className={cn(
         'relative inline-flex h-6 w-11 items-center rounded-full transition-colors shrink-0',
-        on ? 'bg-action' : 'bg-gray-300',
+        on ? 'bg-action' : 'bg-line-strong',
       )}
     >
       <span
         className={cn(
-          'inline-block h-4 w-4 rounded-full bg-white shadow transition-transform',
+          'inline-block h-4 w-4 rounded-full bg-action-fg shadow transition-transform',
           on ? 'translate-x-6' : 'translate-x-1',
         )}
       />
@@ -115,7 +115,7 @@ export function AppearanceSection({
                   'rounded-full px-3 h-8 text-sm font-medium transition-colors',
                   weekStartDay === opt.value
                     ? 'bg-action text-action-fg'
-                    : 'bg-gray-100 text-fg hover:bg-gray-200',
+                    : 'bg-surface-sunken text-fg hover:bg-surface-sunken',
                 )}
               >
                 {t(`calendar.weekdays.${opt.key}`, opt.key.toUpperCase())}
@@ -149,7 +149,7 @@ export function AppearanceSection({
                   'rounded-full px-4 h-9 text-sm font-medium transition-colors',
                   theme === opt.id
                     ? 'bg-action text-action-fg'
-                    : 'bg-gray-100 text-fg hover:bg-gray-200',
+                    : 'bg-surface-sunken text-fg hover:bg-surface-sunken',
                 )}
               >
                 {opt.label}
@@ -178,7 +178,7 @@ export function AppearanceSection({
                   'rounded-full px-4 h-9 text-sm font-medium transition-colors',
                   eventDisplayLevel === opt.value
                     ? 'bg-action text-action-fg'
-                    : 'bg-gray-100 text-fg hover:bg-gray-200',
+                    : 'bg-surface-sunken text-fg hover:bg-surface-sunken',
                 )}
               >
                 {t(`settings.event_display_${opt.key}`, opt.key)}

--- a/src/pages/settings/sections/DefaultTagPickerPanel.tsx
+++ b/src/pages/settings/sections/DefaultTagPickerPanel.tsx
@@ -43,11 +43,11 @@ export function DefaultTagPickerPanel({ onClose, tags, defaultTagColors, default
           type="button"
           onClick={onClose}
           aria-label={t('settings.back')}
-          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
         >
           <ChevronLeft className="h-5 w-5" />
         </button>
-        <h2 className="flex-1 text-lg font-semibold text-[#1f1f1f]">
+        <h2 className="flex-1 text-lg font-semibold text-fg">
           {t('settings.default_tag')}
         </h2>
       </div>
@@ -62,7 +62,7 @@ export function DefaultTagPickerPanel({ onClose, tags, defaultTagColors, default
                 onClick={() => setDefaultTagId(opt.id)}
                 className={cn(
                   'w-full flex items-center gap-3 py-3 text-left transition-colors',
-                  isSelected ? 'text-[#1f1f1f] font-semibold' : 'text-[#1f1f1f] hover:bg-gray-50',
+                  isSelected ? 'text-fg font-semibold' : 'text-fg hover:bg-gray-50',
                 )}
               >
                 <span
@@ -71,7 +71,7 @@ export function DefaultTagPickerPanel({ onClose, tags, defaultTagColors, default
                   aria-hidden="true"
                 />
                 <span className="flex-1 truncate text-sm">{opt.name}</span>
-                {isSelected && <Check className="h-4 w-4 text-[#1f1f1f] shrink-0" strokeWidth={3} />}
+                {isSelected && <Check className="h-4 w-4 text-fg shrink-0" strokeWidth={3} />}
               </button>
             </li>
           )

--- a/src/pages/settings/sections/DefaultTagPickerPanel.tsx
+++ b/src/pages/settings/sections/DefaultTagPickerPanel.tsx
@@ -43,7 +43,7 @@ export function DefaultTagPickerPanel({ onClose, tags, defaultTagColors, default
           type="button"
           onClick={onClose}
           aria-label={t('settings.back')}
-          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
+          className="flex h-9 w-9 items-center justify-center rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors"
         >
           <ChevronLeft className="h-5 w-5" />
         </button>
@@ -52,7 +52,7 @@ export function DefaultTagPickerPanel({ onClose, tags, defaultTagColors, default
         </h2>
       </div>
 
-      <ul className="divide-y divide-gray-100">
+      <ul className="divide-y divide-line">
         {options.map(opt => {
           const isSelected = opt.id === defaultTagId
           return (
@@ -62,7 +62,7 @@ export function DefaultTagPickerPanel({ onClose, tags, defaultTagColors, default
                 onClick={() => setDefaultTagId(opt.id)}
                 className={cn(
                   'w-full flex items-center gap-3 py-3 text-left transition-colors',
-                  isSelected ? 'text-fg font-semibold' : 'text-fg hover:bg-gray-50',
+                  isSelected ? 'text-fg font-semibold' : 'text-fg hover:bg-surface-elevated',
                 )}
               >
                 <span

--- a/src/pages/settings/sections/EditEventSection.tsx
+++ b/src/pages/settings/sections/EditEventSection.tsx
@@ -41,7 +41,7 @@ function SelectedTagChip({ name, color, active, onClick }: SelectedTagChipProps)
         'inline-flex items-center gap-2 rounded-full px-3 h-8 text-sm font-medium transition-colors max-w-full',
         active
           ? 'bg-surface-sunken text-fg'
-          : 'bg-surface-sunken text-fg hover:bg-surface-sunken',
+          : 'bg-surface-sunken text-fg hover:bg-surface-elevated',
       )}
     >
       <span

--- a/src/pages/settings/sections/EditEventSection.tsx
+++ b/src/pages/settings/sections/EditEventSection.tsx
@@ -40,8 +40,8 @@ function SelectedTagChip({ name, color, active, onClick }: SelectedTagChipProps)
       className={cn(
         'inline-flex items-center gap-2 rounded-full px-3 h-8 text-sm font-medium transition-colors max-w-full',
         active
-          ? 'bg-gray-100 text-[#1f1f1f]'
-          : 'bg-gray-100 text-[#1f1f1f] hover:bg-gray-200',
+          ? 'bg-gray-100 text-fg'
+          : 'bg-gray-100 text-fg hover:bg-gray-200',
       )}
     >
       <span
@@ -143,8 +143,8 @@ export function EditEventSection({
           aria-current={tagsOpen ? 'page' : undefined}
           className={`w-full flex items-center justify-between px-3 py-3 rounded-lg text-sm transition-colors ${
             tagsOpen
-              ? 'bg-gray-50 text-[#1f1f1f] font-semibold'
-              : 'text-[#1f1f1f] hover:bg-gray-50 font-medium'
+              ? 'bg-gray-50 text-fg font-semibold'
+              : 'text-fg hover:bg-gray-50 font-medium'
           }`}
         >
           <span>{t('tag.event_types', '이벤트 종류')}</span>

--- a/src/pages/settings/sections/EditEventSection.tsx
+++ b/src/pages/settings/sections/EditEventSection.tsx
@@ -40,8 +40,8 @@ function SelectedTagChip({ name, color, active, onClick }: SelectedTagChipProps)
       className={cn(
         'inline-flex items-center gap-2 rounded-full px-3 h-8 text-sm font-medium transition-colors max-w-full',
         active
-          ? 'bg-gray-100 text-fg'
-          : 'bg-gray-100 text-fg hover:bg-gray-200',
+          ? 'bg-surface-sunken text-fg'
+          : 'bg-surface-sunken text-fg hover:bg-surface-sunken',
       )}
     >
       <span
@@ -50,7 +50,7 @@ function SelectedTagChip({ name, color, active, onClick }: SelectedTagChipProps)
         aria-hidden="true"
       />
       <span className="truncate">{name}</span>
-      <ChevronRight className="h-3.5 w-3.5 text-gray-500 shrink-0" />
+      <ChevronRight className="h-3.5 w-3.5 text-fg-tertiary shrink-0" />
     </button>
   )
 }
@@ -143,12 +143,12 @@ export function EditEventSection({
           aria-current={tagsOpen ? 'page' : undefined}
           className={`w-full flex items-center justify-between px-3 py-3 rounded-lg text-sm transition-colors ${
             tagsOpen
-              ? 'bg-gray-50 text-fg font-semibold'
-              : 'text-fg hover:bg-gray-50 font-medium'
+              ? 'bg-surface-elevated text-fg font-semibold'
+              : 'text-fg hover:bg-surface-elevated font-medium'
           }`}
         >
           <span>{t('tag.event_types', '이벤트 종류')}</span>
-          <ChevronRight className="h-4 w-4 text-gray-400" />
+          <ChevronRight className="h-4 w-4 text-fg-quaternary" />
         </button>
       </SettingsSection>
     </div>

--- a/src/pages/settings/sections/HolidaySection.tsx
+++ b/src/pages/settings/sections/HolidaySection.tsx
@@ -19,11 +19,11 @@ function CountryRow({ country, selected, onClick }: CountryRowProps) {
       aria-pressed={selected}
       className={cn(
         'w-full flex items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors',
-        selected ? 'text-fg font-semibold bg-gray-50' : 'text-fg hover:bg-gray-50',
+        selected ? 'text-fg font-semibold bg-surface-elevated' : 'text-fg hover:bg-surface-elevated',
       )}
     >
       <span className="flex-1 truncate">{country.name}</span>
-      <span className="shrink-0 text-xs uppercase tracking-wider text-gray-400">{country.regionCode}</span>
+      <span className="shrink-0 text-xs uppercase tracking-wider text-fg-quaternary">{country.regionCode}</span>
       {selected && <Check className="h-4 w-4 text-fg shrink-0" strokeWidth={3} />}
     </button>
   )
@@ -74,13 +74,13 @@ export function HolidaySection({
     <SettingsSection title={t('settings.holiday_country')}>
       <div className="space-y-2">
         <p className={settingsLabel}>{t('settings.country_current', '현재 선택')}</p>
-        <div className="rounded-lg border border-gray-100 overflow-hidden">
+        <div className="rounded-lg border border-line overflow-hidden">
           <CountryRow country={pinnedCountry} selected onClick={() => { /* already selected */ }} />
         </div>
       </div>
 
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-fg-quaternary pointer-events-none" />
         <input
           type="text"
           value={query}
@@ -90,14 +90,14 @@ export function HolidaySection({
         />
       </div>
 
-      <ul className="max-h-[60vh] overflow-y-auto divide-y divide-gray-100 rounded-lg border border-gray-100">
+      <ul className="max-h-[60vh] overflow-y-auto divide-y divide-line rounded-lg border border-line">
         {!availableCountriesLoaded && availableCountries.length === 0 && (
-          <li className="px-3 py-4 text-sm text-gray-400 text-center">
+          <li className="px-3 py-4 text-sm text-fg-quaternary text-center">
             {t('common.loading', '불러오는 중...')}
           </li>
         )}
         {availableCountriesLoaded && filtered.length === 0 && (
-          <li className="px-3 py-4 text-sm text-gray-400 text-center">
+          <li className="px-3 py-4 text-sm text-fg-quaternary text-center">
             {t('settings.country_no_results', '검색 결과 없음')}
           </li>
         )}

--- a/src/pages/settings/sections/HolidaySection.tsx
+++ b/src/pages/settings/sections/HolidaySection.tsx
@@ -19,12 +19,12 @@ function CountryRow({ country, selected, onClick }: CountryRowProps) {
       aria-pressed={selected}
       className={cn(
         'w-full flex items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors',
-        selected ? 'text-[#1f1f1f] font-semibold bg-gray-50' : 'text-[#1f1f1f] hover:bg-gray-50',
+        selected ? 'text-fg font-semibold bg-gray-50' : 'text-fg hover:bg-gray-50',
       )}
     >
       <span className="flex-1 truncate">{country.name}</span>
       <span className="shrink-0 text-xs uppercase tracking-wider text-gray-400">{country.regionCode}</span>
-      {selected && <Check className="h-4 w-4 text-[#1f1f1f] shrink-0" strokeWidth={3} />}
+      {selected && <Check className="h-4 w-4 text-fg shrink-0" strokeWidth={3} />}
     </button>
   )
 }

--- a/src/pages/settings/sections/NotificationSection.tsx
+++ b/src/pages/settings/sections/NotificationSection.tsx
@@ -14,7 +14,7 @@ export function NotificationSection({ notification, requestNotificationPermissio
   return (
     <SettingsSection title={t('settings.notification')}>
       {permission === 'granted' ? (
-        <p className="text-sm text-[#1f1f1f]">{t('settings.notification_granted')}</p>
+        <p className="text-sm text-fg">{t('settings.notification_granted')}</p>
       ) : permission === 'denied' ? (
         <p className="text-sm text-red-500">{t('settings.notification_denied')}</p>
       ) : (

--- a/src/pages/settings/sections/NotificationSection.tsx
+++ b/src/pages/settings/sections/NotificationSection.tsx
@@ -16,7 +16,7 @@ export function NotificationSection({ notification, requestNotificationPermissio
       {permission === 'granted' ? (
         <p className="text-sm text-fg">{t('settings.notification_granted')}</p>
       ) : permission === 'denied' ? (
-        <p className="text-sm text-red-500">{t('settings.notification_denied')}</p>
+        <p className="text-sm text-danger">{t('settings.notification_denied')}</p>
       ) : (
         <div>
           <button className={settingsBtnSecondary} onClick={requestNotificationPermission}>

--- a/src/pages/settings/sections/TimezoneSection.tsx
+++ b/src/pages/settings/sections/TimezoneSection.tsx
@@ -26,7 +26,7 @@ function TimezoneRow({ info, selected, systemBadgeLabel, onClick }: TimezoneRowP
       aria-pressed={selected}
       className={cn(
         'w-full flex items-start gap-3 px-3 py-2.5 text-left transition-colors',
-        selected ? 'text-[#1f1f1f] bg-gray-50' : 'text-[#1f1f1f] hover:bg-gray-50',
+        selected ? 'text-fg bg-gray-50' : 'text-fg hover:bg-gray-50',
       )}
     >
       <div className="flex-1 min-w-0">
@@ -45,7 +45,7 @@ function TimezoneRow({ info, selected, systemBadgeLabel, onClick }: TimezoneRowP
           )}
         </div>
       </div>
-      {selected && <Check className="h-4 w-4 mt-1 text-[#1f1f1f] shrink-0" strokeWidth={3} />}
+      {selected && <Check className="h-4 w-4 mt-1 text-fg shrink-0" strokeWidth={3} />}
     </button>
   )
 }

--- a/src/pages/settings/sections/TimezoneSection.tsx
+++ b/src/pages/settings/sections/TimezoneSection.tsx
@@ -26,22 +26,22 @@ function TimezoneRow({ info, selected, systemBadgeLabel, onClick }: TimezoneRowP
       aria-pressed={selected}
       className={cn(
         'w-full flex items-start gap-3 px-3 py-2.5 text-left transition-colors',
-        selected ? 'text-fg bg-gray-50' : 'text-fg hover:bg-gray-50',
+        selected ? 'text-fg bg-surface-elevated' : 'text-fg hover:bg-surface-elevated',
       )}
     >
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           <span className={cn('truncate text-sm', selected && 'font-semibold')}>{info.title}</span>
           {systemBadgeLabel && (
-            <span className="shrink-0 rounded-full border border-gray-200 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-gray-500">
+            <span className="shrink-0 rounded-full border border-line px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-fg-tertiary">
               {systemBadgeLabel}
             </span>
           )}
         </div>
-        <div className="mt-0.5 flex items-center gap-2 text-xs text-gray-500">
+        <div className="mt-0.5 flex items-center gap-2 text-xs text-fg-tertiary">
           <span className="truncate">{info.identifier}</span>
           {info.abbreviation && (
-            <span className="shrink-0 text-gray-400">· {info.abbreviation}</span>
+            <span className="shrink-0 text-fg-quaternary">· {info.abbreviation}</span>
           )}
         </div>
       </div>
@@ -96,7 +96,7 @@ export function TimezoneSection({ timezone, setTimezone }: Props) {
     <SettingsSection title={t('settings.timezone')}>
       <div className="space-y-2">
         <p className={settingsLabel}>{t('settings.timezone_current', '현재 선택')}</p>
-        <div className="rounded-lg border border-gray-100 overflow-hidden">
+        <div className="rounded-lg border border-line overflow-hidden">
           <TimezoneRow
             info={pinnedInfo}
             selected
@@ -107,7 +107,7 @@ export function TimezoneSection({ timezone, setTimezone }: Props) {
       </div>
 
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-fg-quaternary pointer-events-none" />
         <input
           type="text"
           value={query}
@@ -117,7 +117,7 @@ export function TimezoneSection({ timezone, setTimezone }: Props) {
         />
       </div>
 
-      <ul className="max-h-[60vh] overflow-y-auto divide-y divide-gray-100 rounded-lg border border-gray-100">
+      <ul className="max-h-[60vh] overflow-y-auto divide-y divide-line rounded-lg border border-line">
         {systemMatchesQuery && (
           <li>
             <TimezoneRow
@@ -129,7 +129,7 @@ export function TimezoneSection({ timezone, setTimezone }: Props) {
           </li>
         )}
         {filteredOthers.length === 0 && !systemMatchesQuery && (
-          <li className="px-3 py-4 text-sm text-gray-400 text-center">
+          <li className="px-3 py-4 text-sm text-fg-quaternary text-center">
             {t('settings.timezone_no_results', '검색 결과 없음')}
           </li>
         )}

--- a/src/pages/settings/sections/appearance/CalendarAppearancePreview.tsx
+++ b/src/pages/settings/sections/appearance/CalendarAppearancePreview.tsx
@@ -45,7 +45,7 @@ export function CalendarAppearancePreview({ weekStartDay, accentDays }: Props) {
   )
 
   return (
-    <div className="rounded-lg border border-gray-100 bg-white p-4">
+    <div className="rounded-lg border border-line bg-surface p-4">
       <div className="grid grid-cols-7 mb-1">
         {weekdayKeys.map((k, i) => {
           const dow = (weekStartDay + i) % 7

--- a/src/pages/settings/sections/appearance/CalendarAppearancePreview.tsx
+++ b/src/pages/settings/sections/appearance/CalendarAppearancePreview.tsx
@@ -53,7 +53,7 @@ export function CalendarAppearancePreview({ weekStartDay, accentDays }: Props) {
           return (
             <div
               key={k}
-              className={`text-center text-[10px] font-semibold uppercase tracking-widest ${isAccent ? 'text-[#e8a5a5]' : 'text-[#bbb]'}`}
+              className={`text-center text-[10px] font-semibold uppercase tracking-widest ${isAccent ? 'text-[#e8a5a5]' : 'text-fg-quaternary'}`}
             >
               {t(`calendar.weekdays.${k}`, k)}
             </div>
@@ -66,7 +66,7 @@ export function CalendarAppearancePreview({ weekStartDay, accentDays }: Props) {
             {week.map(cell => (
               <div
                 key={`${wi}-${cell.num}`}
-                className={`text-center py-1 text-xs ${accent(cell.dow, cell.isHoliday) ? 'text-red-400' : 'text-[#1f1f1f]'}`}
+                className={`text-center py-1 text-xs ${accent(cell.dow, cell.isHoliday) ? 'text-red-400' : 'text-fg'}`}
               >
                 {cell.num}
               </div>

--- a/src/pages/settings/sections/appearance/CalendarAppearancePreview.tsx
+++ b/src/pages/settings/sections/appearance/CalendarAppearancePreview.tsx
@@ -66,7 +66,7 @@ export function CalendarAppearancePreview({ weekStartDay, accentDays }: Props) {
             {week.map(cell => (
               <div
                 key={`${wi}-${cell.num}`}
-                className={`text-center py-1 text-xs ${accent(cell.dow, cell.isHoliday) ? 'text-red-400' : 'text-fg'}`}
+                className={`text-center py-1 text-xs ${accent(cell.dow, cell.isHoliday) ? 'text-danger' : 'text-fg'}`}
               >
                 {cell.num}
               </div>

--- a/src/pages/settings/sections/appearance/EventDisplayPreview.tsx
+++ b/src/pages/settings/sections/appearance/EventDisplayPreview.tsx
@@ -65,10 +65,10 @@ export function EventDisplayPreview({ eventDisplayLevel, eventFontSizeWeight, sh
   }
 
   return (
-    <div className="rounded-lg border border-gray-100 bg-white p-4">
+    <div className="rounded-lg border border-line bg-surface p-4">
       <div className="grid grid-cols-7 gap-1">
         {SAMPLE_EVENTS_BY_DAY.map((events, i) => (
-          <div key={i} className="min-h-[60px] p-1 border-r border-gray-50 last:border-r-0">
+          <div key={i} className="min-h-[60px] p-1 border-r border-line last:border-r-0">
             {renderCell(i, events)}
           </div>
         ))}

--- a/src/pages/settings/sections/appearance/EventDisplayPreview.tsx
+++ b/src/pages/settings/sections/appearance/EventDisplayPreview.tsx
@@ -1,16 +1,17 @@
+import { PRESET_COLORS } from '../../../../components/ColorPalette'
 import type { EventDisplayLevel } from '../../../../repositories/caches/settingsCache'
 
 const SAMPLE_EVENTS_BY_DAY: { day: number; name: string; color: string }[][] = [
-  [{ day: 1, name: '회의', color: '#5096FF' }],
-  [{ day: 2, name: '커피챗', color: '#FF8A65' }, { day: 2, name: '리뷰 PR', color: '#7CB342' }],
+  [{ day: 1, name: '회의', color: PRESET_COLORS[4] }],          // blue
+  [{ day: 2, name: '커피챗', color: PRESET_COLORS[1] }, { day: 2, name: '리뷰 PR', color: PRESET_COLORS[3] }],  // orange, green
   [
-    { day: 3, name: '디자인 리뷰', color: '#AB47BC' },
-    { day: 3, name: '점심 약속', color: '#FFA726' },
-    { day: 3, name: '운동', color: '#26A69A' },
+    { day: 3, name: '디자인 리뷰', color: PRESET_COLORS[5] },   // purple
+    { day: 3, name: '점심 약속', color: PRESET_COLORS[2] },     // yellow
+    { day: 3, name: '운동', color: PRESET_COLORS[3] },           // green
   ],
-  [{ day: 4, name: '주간 리포트', color: '#5096FF' }],
+  [{ day: 4, name: '주간 리포트', color: PRESET_COLORS[4] }],   // blue
   [],
-  [{ day: 6, name: '생일 🎂', color: '#EC407A' }],
+  [{ day: 6, name: '생일 🎂', color: PRESET_COLORS[6] }],      // pink
   [],
 ]
 
@@ -30,7 +31,7 @@ export function EventDisplayPreview({ eventDisplayLevel, eventFontSizeWeight, sh
     if (eventDisplayLevel === 'minimal') {
       return (
         <div className="flex flex-col items-stretch">
-          <div className="text-xs text-[#1f1f1f] mb-1">{idx + 1}</div>
+          <div className="text-xs text-fg mb-1">{idx + 1}</div>
           <div className="flex gap-0.5">
             {events.slice(0, 3).map((e, i) => (
               <span key={i} className="h-1 w-1 rounded-full" style={{ backgroundColor: e.color }} />
@@ -43,7 +44,7 @@ export function EventDisplayPreview({ eventDisplayLevel, eventFontSizeWeight, sh
     const hidden = events.length - visible.length
     return (
       <div className="flex flex-col items-stretch gap-0.5">
-        <div className="text-xs text-[#1f1f1f] mb-0.5">{idx + 1}</div>
+        <div className="text-xs text-fg mb-0.5">{idx + 1}</div>
         {visible.map((e, i) => (
           <div
             key={i}
@@ -51,13 +52,13 @@ export function EventDisplayPreview({ eventDisplayLevel, eventFontSizeWeight, sh
             style={{ backgroundColor: `${e.color}22`, fontSize }}
           >
             <span className="inline-block h-[5px] w-[5px] rounded-full mr-1 shrink-0" style={{ backgroundColor: e.color }} />
-            <span className="truncate font-medium text-[#1f1f1f]">
+            <span className="truncate font-medium text-fg">
               {showEventNames ? e.name : ' '}
             </span>
           </div>
         ))}
         {hidden > 0 && (
-          <span className="text-[9px] font-medium text-[#969696] px-1">+{hidden}</span>
+          <span className="text-[9px] font-medium text-fg-tertiary px-1">+{hidden}</span>
         )}
       </div>
     )

--- a/src/pages/settings/sections/appearance/EventListPreview.tsx
+++ b/src/pages/settings/sections/appearance/EventListPreview.tsx
@@ -1,9 +1,10 @@
 import { useTranslation } from 'react-i18next'
+import { PRESET_COLORS } from '../../../../components/ColorPalette'
 
 const SAMPLE_EVENTS = [
-  { name: '디자인 리뷰', time: '10:00 — 11:00', color: '#AB47BC' },
-  { name: '점심 약속', time: '12:30', color: '#FFA726' },
-  { name: '주간 리포트 작성', time: '15:00 — 16:30', color: '#5096FF' },
+  { name: '디자인 리뷰', time: '10:00 — 11:00', color: PRESET_COLORS[5] },      // purple
+  { name: '점심 약속', time: '12:30', color: PRESET_COLORS[2] },                 // yellow
+  { name: '주간 리포트 작성', time: '15:00 — 16:30', color: PRESET_COLORS[4] }, // blue
 ]
 
 const SAMPLE_UNCOMPLETED = [
@@ -29,11 +30,11 @@ export function EventListPreview({ eventListFontSizeWeight, showHolidayInEventLi
     <div className="rounded-lg border border-gray-100 bg-white p-4 space-y-4">
       {/* 날짜 헤더 */}
       <div>
-        <h3 className="text-base font-bold text-[#323232]">2026년 4월 27일</h3>
+        <h3 className="text-base font-bold text-fg">2026년 4월 27일</h3>
         <div className="flex flex-wrap items-center gap-x-2 mt-0.5">
-          <p className="text-xs text-[#969696]">월요일</p>
+          <p className="text-xs text-fg-tertiary">월요일</p>
           {showLunarCalendar && (
-            <p className="text-xs text-[#969696]">· {t('settings.lunar_prefix', '음력')} 3월 9일</p>
+            <p className="text-xs text-fg-tertiary">· {t('settings.lunar_prefix', '음력')} 3월 9일</p>
           )}
         </div>
         {showHolidayInEventList && (
@@ -45,15 +46,15 @@ export function EventListPreview({ eventListFontSizeWeight, showHolidayInEventLi
       {showUncompletedTodos && (
         <div>
           <div className="flex items-center gap-3 mb-2">
-            <span className="text-[10px] font-semibold uppercase tracking-widest text-[#bbb]">
+            <span className="text-[10px] font-semibold uppercase tracking-widest text-fg-quaternary">
               {t('todo.uncompleted', '미완료')}
             </span>
             <div className="flex-1 h-px bg-gray-100" />
           </div>
           {SAMPLE_UNCOMPLETED.map(t2 => (
             <div key={t2.name} className="flex items-center gap-2 py-1">
-              <span className="h-2 w-2 rounded-full ring-2 ring-white shrink-0" style={{ backgroundColor: '#EC407A' }} />
-              <span className="font-semibold text-[#ea4444]" style={{ fontSize: nameFontSize }}>{t2.name}</span>
+              <span className="h-2 w-2 rounded-full ring-2 ring-white shrink-0" style={{ backgroundColor: PRESET_COLORS[6] }} />
+              <span className="font-semibold text-danger" style={{ fontSize: nameFontSize }}>{t2.name}</span>
             </div>
           ))}
         </div>
@@ -62,7 +63,7 @@ export function EventListPreview({ eventListFontSizeWeight, showHolidayInEventLi
       {/* 이벤트 */}
       <div>
         <div className="flex items-center gap-3 mb-2">
-          <span className="text-[10px] font-semibold uppercase tracking-widest text-[#bbb]">
+          <span className="text-[10px] font-semibold uppercase tracking-widest text-fg-quaternary">
             {t('main.events_title', 'Events')}
           </span>
           <div className="flex-1 h-px bg-gray-100" />
@@ -71,8 +72,8 @@ export function EventListPreview({ eventListFontSizeWeight, showHolidayInEventLi
           <div key={e.name} className="flex items-start gap-2 py-1">
             <span className="h-2 w-2 mt-1.5 rounded-full ring-2 ring-white shrink-0" style={{ backgroundColor: e.color }} />
             <div className="min-w-0">
-              <p className="font-semibold text-[#1f1f1f]" style={{ fontSize: nameFontSize }}>{e.name}</p>
-              <p className="text-[11px] text-[#aaa]">{e.time}</p>
+              <p className="font-semibold text-fg" style={{ fontSize: nameFontSize }}>{e.name}</p>
+              <p className="text-[11px] text-fg-quaternary">{e.time}</p>
             </div>
           </div>
         ))}

--- a/src/pages/settings/sections/appearance/EventListPreview.tsx
+++ b/src/pages/settings/sections/appearance/EventListPreview.tsx
@@ -38,7 +38,7 @@ export function EventListPreview({ eventListFontSizeWeight, showHolidayInEventLi
           )}
         </div>
         {showHolidayInEventList && (
-          <p className="mt-1 text-xs text-red-400 font-medium">{t('settings.preview_holiday_sample', '식목일')}</p>
+          <p className="mt-1 text-xs text-danger font-medium">{t('settings.preview_holiday_sample', '식목일')}</p>
         )}
       </div>
 

--- a/src/pages/settings/sections/appearance/EventListPreview.tsx
+++ b/src/pages/settings/sections/appearance/EventListPreview.tsx
@@ -27,7 +27,7 @@ export function EventListPreview({ eventListFontSizeWeight, showHolidayInEventLi
   const nameFontSize = `${14 + eventListFontSizeWeight}px`
 
   return (
-    <div className="rounded-lg border border-gray-100 bg-white p-4 space-y-4">
+    <div className="rounded-lg border border-line bg-surface p-4 space-y-4">
       {/* 날짜 헤더 */}
       <div>
         <h3 className="text-base font-bold text-fg">2026년 4월 27일</h3>
@@ -49,11 +49,11 @@ export function EventListPreview({ eventListFontSizeWeight, showHolidayInEventLi
             <span className="text-[10px] font-semibold uppercase tracking-widest text-fg-quaternary">
               {t('todo.uncompleted', '미완료')}
             </span>
-            <div className="flex-1 h-px bg-gray-100" />
+            <div className="flex-1 h-px bg-line" />
           </div>
           {SAMPLE_UNCOMPLETED.map(t2 => (
             <div key={t2.name} className="flex items-center gap-2 py-1">
-              <span className="h-2 w-2 rounded-full ring-2 ring-white shrink-0" style={{ backgroundColor: PRESET_COLORS[6] }} />
+              <span className="h-2 w-2 rounded-full ring-2 ring-surface shrink-0" style={{ backgroundColor: PRESET_COLORS[6] }} />
               <span className="font-semibold text-danger" style={{ fontSize: nameFontSize }}>{t2.name}</span>
             </div>
           ))}
@@ -66,11 +66,11 @@ export function EventListPreview({ eventListFontSizeWeight, showHolidayInEventLi
           <span className="text-[10px] font-semibold uppercase tracking-widest text-fg-quaternary">
             {t('main.events_title', 'Events')}
           </span>
-          <div className="flex-1 h-px bg-gray-100" />
+          <div className="flex-1 h-px bg-line" />
         </div>
         {SAMPLE_EVENTS.map(e => (
           <div key={e.name} className="flex items-start gap-2 py-1">
-            <span className="h-2 w-2 mt-1.5 rounded-full ring-2 ring-white shrink-0" style={{ backgroundColor: e.color }} />
+            <span className="h-2 w-2 mt-1.5 rounded-full ring-2 ring-surface shrink-0" style={{ backgroundColor: e.color }} />
             <div className="min-w-0">
               <p className="font-semibold text-fg" style={{ fontSize: nameFontSize }}>{e.name}</p>
               <p className="text-[11px] text-fg-quaternary">{e.time}</p>

--- a/src/pages/settings/tagManagement/DeleteTagDialog.tsx
+++ b/src/pages/settings/tagManagement/DeleteTagDialog.tsx
@@ -12,14 +12,14 @@ export function DeleteTagDialog({ tagName, onDeleteTagOnly, onDeleteTagAndEvents
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
       <div className="w-full max-w-sm rounded-xl bg-white border border-gray-100 p-6 shadow-xl">
-        <h2 className="text-base font-semibold text-[#1f1f1f]">{t('tag.delete_title')}</h2>
-        <p className="mt-2 text-sm text-[#6b6b6b]">
+        <h2 className="text-base font-semibold text-fg">{t('tag.delete_title')}</h2>
+        <p className="mt-2 text-sm text-fg-secondary">
           {t('tag.delete_message', { name: tagName })}
         </p>
         <div className="mt-4 flex flex-col divide-y divide-gray-100">
           <button
             type="button"
-            className="px-4 py-3 text-left text-sm text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+            className="px-4 py-3 text-left text-sm text-fg hover:bg-gray-50 transition-colors"
             onClick={onDeleteTagOnly}
           >
             {t('tag.delete_tag_only')}
@@ -34,7 +34,7 @@ export function DeleteTagDialog({ tagName, onDeleteTagOnly, onDeleteTagAndEvents
         </div>
         <button
           type="button"
-          className="mt-4 w-full rounded-lg px-4 py-2 text-sm text-[#6b6b6b] hover:bg-gray-50 transition-colors"
+          className="mt-4 w-full rounded-lg px-4 py-2 text-sm text-fg-secondary hover:bg-gray-50 transition-colors"
           onClick={onCancel}
         >
           {t('common.cancel')}

--- a/src/pages/settings/tagManagement/DeleteTagDialog.tsx
+++ b/src/pages/settings/tagManagement/DeleteTagDialog.tsx
@@ -26,7 +26,7 @@ export function DeleteTagDialog({ tagName, onDeleteTagOnly, onDeleteTagAndEvents
           </button>
           <button
             type="button"
-            className="px-4 py-3 text-left text-sm text-red-500 hover:bg-red-50 transition-colors"
+            className="px-4 py-3 text-left text-sm text-danger hover:bg-danger/10 transition-colors"
             onClick={onDeleteTagAndEvents}
           >
             {t('tag.delete_tag_and_events')}

--- a/src/pages/settings/tagManagement/DeleteTagDialog.tsx
+++ b/src/pages/settings/tagManagement/DeleteTagDialog.tsx
@@ -11,15 +11,15 @@ export function DeleteTagDialog({ tagName, onDeleteTagOnly, onDeleteTagAndEvents
   const { t } = useTranslation()
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-      <div className="w-full max-w-sm rounded-xl bg-white border border-gray-100 p-6 shadow-xl">
+      <div className="w-full max-w-sm rounded-xl bg-surface-elevated border border-line p-6 shadow-xl">
         <h2 className="text-base font-semibold text-fg">{t('tag.delete_title')}</h2>
         <p className="mt-2 text-sm text-fg-secondary">
           {t('tag.delete_message', { name: tagName })}
         </p>
-        <div className="mt-4 flex flex-col divide-y divide-gray-100">
+        <div className="mt-4 flex flex-col divide-y divide-line">
           <button
             type="button"
-            className="px-4 py-3 text-left text-sm text-fg hover:bg-gray-50 transition-colors"
+            className="px-4 py-3 text-left text-sm text-fg hover:bg-surface-sunken transition-colors"
             onClick={onDeleteTagOnly}
           >
             {t('tag.delete_tag_only')}
@@ -34,7 +34,7 @@ export function DeleteTagDialog({ tagName, onDeleteTagOnly, onDeleteTagAndEvents
         </div>
         <button
           type="button"
-          className="mt-4 w-full rounded-lg px-4 py-2 text-sm text-fg-secondary hover:bg-gray-50 transition-colors"
+          className="mt-4 w-full rounded-lg px-4 py-2 text-sm text-fg-secondary hover:bg-surface-sunken transition-colors"
           onClick={onCancel}
         >
           {t('common.cancel')}

--- a/src/pages/settings/tagManagement/TagEditPanel.tsx
+++ b/src/pages/settings/tagManagement/TagEditPanel.tsx
@@ -104,7 +104,7 @@ export function TagEditPanel({ mode, onBack }: TagEditPanelProps) {
           type="button"
           onClick={onBack}
           aria-label={t('tag.close_panel', 'Close panel')}
-          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
+          className="flex h-9 w-9 items-center justify-center rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors"
         >
           <ChevronLeft className="h-5 w-5" />
         </button>
@@ -117,7 +117,7 @@ export function TagEditPanel({ mode, onBack }: TagEditPanelProps) {
         </label>
         <input
           id="tag-edit-name"
-          className={`${settingsInput} read-only:bg-gray-50 read-only:text-fg-secondary`}
+          className={`${settingsInput} read-only:bg-surface-elevated read-only:text-fg-secondary`}
           value={name}
           onChange={e => setName(e.target.value)}
           readOnly={isReadonlyName}

--- a/src/pages/settings/tagManagement/TagEditPanel.tsx
+++ b/src/pages/settings/tagManagement/TagEditPanel.tsx
@@ -104,11 +104,11 @@ export function TagEditPanel({ mode, onBack }: TagEditPanelProps) {
           type="button"
           onClick={onBack}
           aria-label={t('tag.close_panel', 'Close panel')}
-          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
         >
           <ChevronLeft className="h-5 w-5" />
         </button>
-        <h2 className="flex-1 text-lg font-semibold text-[#1f1f1f]">{title}</h2>
+        <h2 className="flex-1 text-lg font-semibold text-fg">{title}</h2>
       </div>
 
       <div className="space-y-2">
@@ -117,14 +117,14 @@ export function TagEditPanel({ mode, onBack }: TagEditPanelProps) {
         </label>
         <input
           id="tag-edit-name"
-          className={`${settingsInput} read-only:bg-gray-50 read-only:text-[#6b6b6b]`}
+          className={`${settingsInput} read-only:bg-gray-50 read-only:text-fg-secondary`}
           value={name}
           onChange={e => setName(e.target.value)}
           readOnly={isReadonlyName}
           placeholder={t('tag.new_placeholder', '새 태그 이름')}
         />
         {isReadonlyName && (
-          <p className="text-xs text-[#969696]">
+          <p className="text-xs text-fg-tertiary">
             {t('tag.readonly_name_notice', '기본 태그 이름은 변경할 수 없습니다')}
           </p>
         )}

--- a/src/pages/settings/tagManagement/TagManagementPanel.tsx
+++ b/src/pages/settings/tagManagement/TagManagementPanel.tsx
@@ -54,18 +54,18 @@ export function TagManagementPanel({ onClose }: Props) {
           type="button"
           onClick={onClose}
           aria-label={t('tag.close_page', '태그 관리 닫기')}
-          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
         >
           <ChevronLeft className="h-5 w-5" />
         </button>
-        <h2 className="flex-1 text-lg font-semibold text-[#1f1f1f]">
+        <h2 className="flex-1 text-lg font-semibold text-fg">
           {t('tag.event_types', '이벤트 종류')}
         </h2>
         <button
           type="button"
           onClick={() => setPanel({ kind: 'create' })}
           aria-label={t('tag.add_new', '새 태그 추가')}
-          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
         >
           <Plus className="h-5 w-5" />
         </button>

--- a/src/pages/settings/tagManagement/TagManagementPanel.tsx
+++ b/src/pages/settings/tagManagement/TagManagementPanel.tsx
@@ -54,7 +54,7 @@ export function TagManagementPanel({ onClose }: Props) {
           type="button"
           onClick={onClose}
           aria-label={t('tag.close_page', '태그 관리 닫기')}
-          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
+          className="flex h-9 w-9 items-center justify-center rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors"
         >
           <ChevronLeft className="h-5 w-5" />
         </button>
@@ -65,14 +65,14 @@ export function TagManagementPanel({ onClose }: Props) {
           type="button"
           onClick={() => setPanel({ kind: 'create' })}
           aria-label={t('tag.add_new', '새 태그 추가')}
-          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
+          className="flex h-9 w-9 items-center justify-center rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors"
         >
           <Plus className="h-5 w-5" />
         </button>
       </div>
 
       {/* 리스트 — 얇은 row divider */}
-      <ul data-testid="tag-row-list" className="divide-y divide-gray-100">
+      <ul data-testid="tag-row-list" className="divide-y divide-line">
         {rows.map(row => (
           <li key={row.id}>
             <TagRow row={row} onEdit={() => setPanel({ kind: 'edit', row })} />

--- a/src/pages/settings/tagManagement/TagRow.tsx
+++ b/src/pages/settings/tagManagement/TagRow.tsx
@@ -35,13 +35,13 @@ export function TagRow({ row, onEdit }: TagRowProps) {
         )}
       </button>
 
-      <span className="flex-1 truncate text-sm text-[#1f1f1f]">{row.name}</span>
+      <span className="flex-1 truncate text-sm text-fg">{row.name}</span>
 
       <button
         type="button"
         aria-label={t('tag.open_detail', 'Open tag detail')}
         onClick={onEdit}
-        className="shrink-0 p-1.5 rounded-full text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+        className="shrink-0 p-1.5 rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
       >
         <Pencil className="h-4 w-4" />
       </button>

--- a/src/pages/settings/tagManagement/TagRow.tsx
+++ b/src/pages/settings/tagManagement/TagRow.tsx
@@ -41,7 +41,7 @@ export function TagRow({ row, onEdit }: TagRowProps) {
         type="button"
         aria-label={t('tag.open_detail', 'Open tag detail')}
         onClick={onEdit}
-        className="shrink-0 p-1.5 rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
+        className="shrink-0 p-1.5 rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors"
       >
         <Pencil className="h-4 w-4" />
       </button>

--- a/src/pages/tagManagement/components/DeleteTagDialog.tsx
+++ b/src/pages/tagManagement/components/DeleteTagDialog.tsx
@@ -12,14 +12,14 @@ export function DeleteTagDialog({ tagName, onDeleteTagOnly, onDeleteTagAndEvents
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
       <div className="w-full max-w-sm rounded-xl bg-white border border-gray-100 p-6 shadow-xl">
-        <h2 className="text-base font-semibold text-[#1f1f1f]">{t('tag.delete_title')}</h2>
-        <p className="mt-2 text-sm text-[#6b6b6b]">
+        <h2 className="text-base font-semibold text-fg">{t('tag.delete_title')}</h2>
+        <p className="mt-2 text-sm text-fg-secondary">
           {t('tag.delete_message', { name: tagName })}
         </p>
         <div className="mt-4 flex flex-col divide-y divide-gray-100">
           <button
             type="button"
-            className="px-4 py-3 text-left text-sm text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+            className="px-4 py-3 text-left text-sm text-fg hover:bg-gray-50 transition-colors"
             onClick={onDeleteTagOnly}
           >
             {t('tag.delete_tag_only')}
@@ -34,7 +34,7 @@ export function DeleteTagDialog({ tagName, onDeleteTagOnly, onDeleteTagAndEvents
         </div>
         <button
           type="button"
-          className="mt-4 w-full rounded-lg px-4 py-2 text-sm text-[#6b6b6b] hover:bg-gray-50 transition-colors"
+          className="mt-4 w-full rounded-lg px-4 py-2 text-sm text-fg-secondary hover:bg-gray-50 transition-colors"
           onClick={onCancel}
         >
           {t('common.cancel')}

--- a/src/pages/tagManagement/components/DeleteTagDialog.tsx
+++ b/src/pages/tagManagement/components/DeleteTagDialog.tsx
@@ -26,7 +26,7 @@ export function DeleteTagDialog({ tagName, onDeleteTagOnly, onDeleteTagAndEvents
           </button>
           <button
             type="button"
-            className="px-4 py-3 text-left text-sm text-red-500 hover:bg-red-50 transition-colors"
+            className="px-4 py-3 text-left text-sm text-danger hover:bg-danger/10 transition-colors"
             onClick={onDeleteTagAndEvents}
           >
             {t('tag.delete_tag_and_events')}

--- a/src/pages/tagManagement/components/DeleteTagDialog.tsx
+++ b/src/pages/tagManagement/components/DeleteTagDialog.tsx
@@ -11,15 +11,15 @@ export function DeleteTagDialog({ tagName, onDeleteTagOnly, onDeleteTagAndEvents
   const { t } = useTranslation()
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-      <div className="w-full max-w-sm rounded-xl bg-white border border-gray-100 p-6 shadow-xl">
+      <div className="w-full max-w-sm rounded-xl bg-surface-elevated border border-line p-6 shadow-xl">
         <h2 className="text-base font-semibold text-fg">{t('tag.delete_title')}</h2>
         <p className="mt-2 text-sm text-fg-secondary">
           {t('tag.delete_message', { name: tagName })}
         </p>
-        <div className="mt-4 flex flex-col divide-y divide-gray-100">
+        <div className="mt-4 flex flex-col divide-y divide-line">
           <button
             type="button"
-            className="px-4 py-3 text-left text-sm text-fg hover:bg-gray-50 transition-colors"
+            className="px-4 py-3 text-left text-sm text-fg hover:bg-surface-sunken transition-colors"
             onClick={onDeleteTagOnly}
           >
             {t('tag.delete_tag_only')}
@@ -34,7 +34,7 @@ export function DeleteTagDialog({ tagName, onDeleteTagOnly, onDeleteTagAndEvents
         </div>
         <button
           type="button"
-          className="mt-4 w-full rounded-lg px-4 py-2 text-sm text-fg-secondary hover:bg-gray-50 transition-colors"
+          className="mt-4 w-full rounded-lg px-4 py-2 text-sm text-fg-secondary hover:bg-surface-sunken transition-colors"
           onClick={onCancel}
         >
           {t('common.cancel')}

--- a/src/pages/tagManagement/components/TagEditPanel.tsx
+++ b/src/pages/tagManagement/components/TagEditPanel.tsx
@@ -98,7 +98,7 @@ export function TagEditPanel({ mode, onClose }: TagEditPanelProps) {
           type="button"
           onClick={onClose}
           aria-label={t('tag.close_panel', 'Close panel')}
-          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
+          className="flex h-9 w-9 items-center justify-center rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors"
         >
           <ChevronLeft className="h-5 w-5" />
         </button>
@@ -111,7 +111,7 @@ export function TagEditPanel({ mode, onClose }: TagEditPanelProps) {
         </label>
         <input
           id="tag-edit-name"
-          className={`${settingsInput} read-only:bg-gray-50 read-only:text-fg-secondary`}
+          className={`${settingsInput} read-only:bg-surface-elevated read-only:text-fg-secondary`}
           value={name}
           onChange={e => setName(e.target.value)}
           readOnly={isReadonlyName}

--- a/src/pages/tagManagement/components/TagEditPanel.tsx
+++ b/src/pages/tagManagement/components/TagEditPanel.tsx
@@ -98,11 +98,11 @@ export function TagEditPanel({ mode, onClose }: TagEditPanelProps) {
           type="button"
           onClick={onClose}
           aria-label={t('tag.close_panel', 'Close panel')}
-          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
         >
           <ChevronLeft className="h-5 w-5" />
         </button>
-        <h2 className="flex-1 text-lg font-semibold text-[#1f1f1f]">{title}</h2>
+        <h2 className="flex-1 text-lg font-semibold text-fg">{title}</h2>
       </div>
 
       <div className="space-y-2">
@@ -111,14 +111,14 @@ export function TagEditPanel({ mode, onClose }: TagEditPanelProps) {
         </label>
         <input
           id="tag-edit-name"
-          className={`${settingsInput} read-only:bg-gray-50 read-only:text-[#6b6b6b]`}
+          className={`${settingsInput} read-only:bg-gray-50 read-only:text-fg-secondary`}
           value={name}
           onChange={e => setName(e.target.value)}
           readOnly={isReadonlyName}
           placeholder={t('tag.new_placeholder', '새 태그 이름')}
         />
         {isReadonlyName && (
-          <p className="text-xs text-[#969696]">
+          <p className="text-xs text-fg-tertiary">
             {t('tag.readonly_name_notice', '기본 태그 이름은 변경할 수 없습니다')}
           </p>
         )}

--- a/src/pages/tagManagement/components/TagListHeader.tsx
+++ b/src/pages/tagManagement/components/TagListHeader.tsx
@@ -14,18 +14,18 @@ export function TagListHeader({ onCreate, onClose }: Props) {
         type="button"
         onClick={onClose}
         aria-label={t('tag.close_page', '태그 관리 닫기')}
-        className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+        className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
       >
         <ChevronLeft className="h-5 w-5" />
       </button>
-      <h2 className="flex-1 text-lg font-semibold text-[#1f1f1f]">
+      <h2 className="flex-1 text-lg font-semibold text-fg">
         {t('tag.event_types', '이벤트 종류')}
       </h2>
       <button
         type="button"
         onClick={onCreate}
         aria-label={t('tag.add_new', '새 태그 추가')}
-        className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+        className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
       >
         <Plus className="h-5 w-5" />
       </button>

--- a/src/pages/tagManagement/components/TagListHeader.tsx
+++ b/src/pages/tagManagement/components/TagListHeader.tsx
@@ -14,7 +14,7 @@ export function TagListHeader({ onCreate, onClose }: Props) {
         type="button"
         onClick={onClose}
         aria-label={t('tag.close_page', '태그 관리 닫기')}
-        className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
+        className="flex h-9 w-9 items-center justify-center rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors"
       >
         <ChevronLeft className="h-5 w-5" />
       </button>
@@ -25,7 +25,7 @@ export function TagListHeader({ onCreate, onClose }: Props) {
         type="button"
         onClick={onCreate}
         aria-label={t('tag.add_new', '새 태그 추가')}
-        className="flex h-9 w-9 items-center justify-center rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
+        className="flex h-9 w-9 items-center justify-center rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors"
       >
         <Plus className="h-5 w-5" />
       </button>

--- a/src/pages/tagManagement/components/TagRow.tsx
+++ b/src/pages/tagManagement/components/TagRow.tsx
@@ -35,13 +35,13 @@ export function TagRow({ row, onEdit }: TagRowProps) {
         )}
       </button>
 
-      <span className="flex-1 truncate text-sm text-[#1f1f1f]">{row.name}</span>
+      <span className="flex-1 truncate text-sm text-fg">{row.name}</span>
 
       <button
         type="button"
         aria-label={t('tag.open_detail', 'Open tag detail')}
         onClick={onEdit}
-        className="shrink-0 p-1.5 rounded-full text-gray-400 hover:text-[#1f1f1f] hover:bg-gray-50 transition-colors"
+        className="shrink-0 p-1.5 rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
       >
         <Pencil className="h-4 w-4" />
       </button>

--- a/src/pages/tagManagement/components/TagRow.tsx
+++ b/src/pages/tagManagement/components/TagRow.tsx
@@ -41,7 +41,7 @@ export function TagRow({ row, onEdit }: TagRowProps) {
         type="button"
         aria-label={t('tag.open_detail', 'Open tag detail')}
         onClick={onEdit}
-        className="shrink-0 p-1.5 rounded-full text-gray-400 hover:text-fg hover:bg-gray-50 transition-colors"
+        className="shrink-0 p-1.5 rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors"
       >
         <Pencil className="h-4 w-4" />
       </button>

--- a/tests/calendar/MainCalendarGrid.test.tsx
+++ b/tests/calendar/MainCalendarGrid.test.tsx
@@ -168,33 +168,32 @@ describe('MainCalendarGrid', () => {
       expect(numberCircle?.className).toMatch(/ring/)
     })
 
-    it('오늘 날짜 숫자에 원형 오늘 배경색(#1f1f1f)이 적용된다', () => {
+    it('오늘 날짜 숫자에 원형 강조 배경이 적용된다', () => {
       // given: 오늘(2026-03-15)이 포함된 캘린더, 아무것도 선택 안 됨
       useUiStore.setState({ selectedDate: null })
 
       // when: MainCalendarGrid 렌더
       render(<MainCalendarGrid days={marchDays} />)
 
-      // then: 오늘 숫자 원형에 오늘 배경색 적용
+      // then: 오늘 숫자 원형에 배경 스타일이 적용 (색상값은 토큰 var라 구체값 검증 안 함)
       const cells = screen.getAllByTestId('day-cell')
       const todayIndex = marchDays.findIndex(d => d.isToday)
       const numberCircle = cells[todayIndex].querySelector('.rounded-full')
-      expect(numberCircle).toHaveStyle({ backgroundColor: '#1f1f1f' })
+      expect(numberCircle?.getAttribute('style') ?? '').toMatch(/background-color/)
     })
 
-    it('선택되지 않은 일반 날 셀에는 강조 배경색이 없다', () => {
+    it('선택되지 않은 일반 날 셀의 숫자 원형에는 강조 배경이 없다', () => {
       // given: 아무것도 선택되지 않은 상태
       useUiStore.setState({ selectedDate: null })
 
       // when: MainCalendarGrid 렌더
       render(<MainCalendarGrid days={marchDays} />)
 
-      // then: 3월 10일(일반 날) 셀에는 선택/오늘 배경색이 없다
+      // then: 3월 10일(일반 날) 숫자 원형에 강조 배경 스타일이 없다
       const cells = screen.getAllByTestId('day-cell')
       const march10Index = marchDays.findIndex(d => d.isCurrentMonth && d.dayOfMonth === 10)
-      const normalCell = cells[march10Index]
-      expect(normalCell).not.toHaveStyle({ backgroundColor: '#303646' })
-      expect(normalCell).not.toHaveStyle({ backgroundColor: '#f4f4f4' })
+      const numberCircle = cells[march10Index].querySelector('.rounded-full')
+      expect(numberCircle?.getAttribute('style') ?? '').not.toMatch(/background-color/)
     })
   })
 })

--- a/tests/components/ConfirmDialog.test.tsx
+++ b/tests/components/ConfirmDialog.test.tsx
@@ -55,24 +55,24 @@ describe('ConfirmDialog', () => {
     expect(onCancel).toHaveBeenCalled()
   })
 
-  it('danger 플래그가 있으면 확인 버튼에 red 스타일이 적용된다', () => {
+  it('danger 플래그가 있으면 확인 버튼에 data-variant="danger" 속성이 부착된다', () => {
     // given / when
     render(
       <ConfirmDialog message="삭제?" onConfirm={vi.fn()} onCancel={vi.fn()} danger />
     )
 
     // then
-    expect(screen.getByRole('button', { name: '확인' })).toHaveClass('bg-red-500')
+    expect(screen.getByRole('button', { name: '확인' })).toHaveAttribute('data-variant', 'danger')
   })
 
-  it('danger=false이면 blue 스타일이 적용된다', () => {
+  it('danger=false이면 확인 버튼에 data-variant="primary" 속성이 부착된다', () => {
     // given / when
     render(
       <ConfirmDialog message="확인?" onConfirm={vi.fn()} onCancel={vi.fn()} danger={false} />
     )
 
     // then
-    expect(screen.getByRole('button', { name: '확인' })).toHaveClass('bg-blue-500')
+    expect(screen.getByRole('button', { name: '확인' })).toHaveAttribute('data-variant', 'primary')
   })
 
   it('confirmLabel로 버튼 텍스트를 변경할 수 있다', () => {

--- a/tests/components/Header.test.tsx
+++ b/tests/components/Header.test.tsx
@@ -26,8 +26,8 @@ describe('Header', () => {
     renderHeader('/')
 
     // then
-    expect(screen.getByRole('link', { name: '캘린더' })).toHaveClass('bg-gray-100')
-    expect(screen.getByRole('link', { name: '설정' })).not.toHaveClass('bg-gray-100')
+    expect(screen.getByRole('link', { name: '캘린더' })).toHaveClass('bg-surface-sunken')
+    expect(screen.getByRole('link', { name: '설정' })).not.toHaveClass('bg-surface-sunken')
   })
 
   it('/settings 경로에서 설정 탭이 active 클래스를 갖는다', () => {
@@ -35,7 +35,7 @@ describe('Header', () => {
     renderHeader('/settings')
 
     // then
-    expect(screen.getByRole('link', { name: '설정' })).toHaveClass('bg-gray-100')
-    expect(screen.getByRole('link', { name: '캘린더' })).not.toHaveClass('bg-gray-100')
+    expect(screen.getByRole('link', { name: '설정' })).toHaveClass('bg-surface-sunken')
+    expect(screen.getByRole('link', { name: '캘린더' })).not.toHaveClass('bg-surface-sunken')
   })
 })

--- a/tests/components/Header.test.tsx
+++ b/tests/components/Header.test.tsx
@@ -21,21 +21,21 @@ describe('Header', () => {
     expect(screen.getByRole('link', { name: '설정' })).toBeInTheDocument()
   })
 
-  it('/ 경로에서 캘린더 탭이 active 클래스를 갖는다', () => {
+  it('/ 경로에서 캘린더 탭이 aria-current="page" 속성을 갖는다', () => {
     // given / when
     renderHeader('/')
 
-    // then
-    expect(screen.getByRole('link', { name: '캘린더' })).toHaveClass('bg-surface-sunken')
-    expect(screen.getByRole('link', { name: '설정' })).not.toHaveClass('bg-surface-sunken')
+    // then: NavLink는 활성 시 aria-current="page"를 자동 부착
+    expect(screen.getByRole('link', { name: '캘린더' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('link', { name: '설정' })).not.toHaveAttribute('aria-current')
   })
 
-  it('/settings 경로에서 설정 탭이 active 클래스를 갖는다', () => {
+  it('/settings 경로에서 설정 탭이 aria-current="page" 속성을 갖는다', () => {
     // given / when
     renderHeader('/settings')
 
-    // then
-    expect(screen.getByRole('link', { name: '설정' })).toHaveClass('bg-surface-sunken')
-    expect(screen.getByRole('link', { name: '캘린더' })).not.toHaveClass('bg-surface-sunken')
+    // then: NavLink는 활성 시 aria-current="page"를 자동 부착
+    expect(screen.getByRole('link', { name: '설정' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('link', { name: '캘린더' })).not.toHaveAttribute('aria-current')
   })
 })

--- a/tests/components/Toast.test.tsx
+++ b/tests/components/Toast.test.tsx
@@ -30,7 +30,7 @@ describe('ToastContainer', () => {
     expect(screen.getByRole('alert')).toBeInTheDocument()
   })
 
-  it('error 타입이면 bg-red-600 클래스가 적용된다', () => {
+  it('error 타입이면 data-toast-type="error" 속성이 부착된다', () => {
     // given
     useToastStore.setState({
       toasts: [{ id: '1', key: 'error.unknown', type: 'error' }],
@@ -40,10 +40,10 @@ describe('ToastContainer', () => {
     render(<ToastContainer />)
 
     // then
-    expect(screen.getByRole('alert')).toHaveClass('bg-red-600')
+    expect(screen.getByRole('alert')).toHaveAttribute('data-toast-type', 'error')
   })
 
-  it('success 타입이면 bg-green-600 클래스가 적용된다', () => {
+  it('success 타입이면 data-toast-type="success" 속성이 부착된다', () => {
     // given
     useToastStore.setState({
       toasts: [{ id: '1', key: 'event.created.todo', type: 'success' }],
@@ -53,7 +53,7 @@ describe('ToastContainer', () => {
     render(<ToastContainer />)
 
     // then
-    expect(screen.getByRole('alert')).toHaveClass('bg-green-600')
+    expect(screen.getByRole('alert')).toHaveAttribute('data-toast-type', 'success')
   })
 
   it('클릭하면 해당 toast가 제거된다', async () => {


### PR DESCRIPTION
## 문제

이슈 본문 verbatim:
> 다 고정값으로 들어가있음
> -> 색상과 폰트는 미리 세트화 해두고 이를 사용할것

코드 현황: 색상 hex 160건 + Tailwind arbitrary 색 클래스 131건 + 정적 Tailwind utility(`bg-white`/`bg-gray-*` 등) 122건이 컴포넌트에 분산. shadcn 토큰은 다크 변종이 정의돼 있었지만 우리 컴포넌트는 거의 사용 안 함 → 다크 모드 토글 시 텍스트만 반전되고 배경은 깨짐.

## 접근 (브레인스토밍 합의)

1. **스코프**: 색상 전부(텍스트/표면/보더/액션/브랜드/상태) + 다크 정합. 폰트는 별 이슈로 분리.
2. **테마 시스템**: 의미 기반 토큰 + light/dark 페어. `themeStore`(`'system' | 'light' | 'dark'`)는 그대로. 미래 N테마 확장 가능 구조.
3. **토큰 카테고리**: Text 4 / Surface 3 / Border 2 / Action 2 / Brand 1 / State 3 = **16 토큰 × 2(라/다) = 32 정의**.
4. **충돌 해소**: 컴포넌트 실 사용 hex가 진실 (`#1f1f1f` 85건 등). 기존 `@theme` 12 토큰(slate 계열, 사용 미미)은 폐기.
5. **이벤트 팔레트**: CSS 토큰 미적용. `PRESET_COLORS` 8색 단일 출처 유지. `testDataSeeder`만 정합.
6. **마이그레이션 불필요**: 런칭 전이라 점진/하위호환/feature flag 없이 단일 PR 일괄 치환.

## 변경 요약 (11 커밋)

- 토큰 16종 라/다 페어 정의 (`src/index.css`) — `c0dda11`
- testDataSeeder PRESET_COLORS 정렬 — `c4bfb65`
- 메인 화면 컴포넌트 11종 hex → 토큰 — `29ef34a`
- 팝오버/태그 컴포넌트 4종 — `23dea5a`
- MainCalendarGrid 색상 hex 직접 검증 테스트 → 의미 검증으로 치환 (회귀 fix) — `d88144e`
- Settings 셸/sections 10종 — `83faffb`
- Appearance 미리보기 3종 (가짜 이벤트 색도 PRESET_COLORS로 정합) — `0f8d717`
- 태그 관리 8종 (`settings/tagManagement/*` + `pages/tagManagement/*`) — `945f0f5`
- 기존 `@theme` 토큰 사용처 정리 + LoginPage + domain 13파일 — `f73c860`
- 정적 Tailwind utility 122+건(`bg-white`/`bg-gray-*` 등) → 의미 토큰. 다크 배경 반전 정합 확보 — `4ec35a0`
- `.worktrees/` gitignore 인프라 — `4e1863d`

## 시각 검증

- **라이트 모드**: 시각 회귀 없음 (실 사용 hex가 토큰 라이트값과 동일)
- **다크 모드**: 신규 정합. 사용자 검증 통과 (페이지/카드/모달/팝오버/사이드바 정상 반전)
- **잔존 정적 hex (의도적)**: `MainCalendarGrid.tsx:189`/`CalendarAppearancePreview.tsx:56` `#e8a5a5` (주말 강조 데모), `TagFilter.tsx:29` `#d1d5db`/`#9ca3af` (동적 태그 fallback), `CalendarList.tsx:50` `#9ca3af`, `resolveEventTag.ts:4-5` 도메인 fallback 상수
- **화이트리스트**: `ColorPalette.tsx PRESET_COLORS` 8색, Google brand SVG (`#34A853 #4285F4 #EA4335 #FBBC05`), `bg-black/N` 반투명 모달 오버레이

## 비스코프 (별 이슈)

- 폰트 사이즈 arbitrary 클래스(`text-[10px]` 60+건)
- 새 테마 추가 (라/다 외 변종)
- shadcn 토큰 변경
- `themeStore` 구조 변경 (`data-theme` attribute 등)
- `settings/tagManagement` ↔ `pages/tagManagement` 중복 컴포넌트 통합

## Test plan

- [ ] CI 빌드/테스트 통과 (베이스라인 794 PASS / 2 FAIL — `EventTimeDisplay.test.tsx` pre-existing 로케일 이슈)
- [ ] 다크 모드 토글 시 메인/Settings/팝오버/모달 시각 정합 (라이트 ↔ 다크 페어)
- [ ] 라이트 모드 시각 회귀 없음
- [ ] 잔존 hex grep — 화이트리스트 외 0건

closes #75