### PR TITLE
#92 폰트 사이즈 워싱 — arbitrary 클래스를 의미 토큰으로 치환

### DIFF
--- a/src/calendar/MainCalendarGrid.tsx
+++ b/src/calendar/MainCalendarGrid.tsx
@@ -186,7 +186,7 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
           return (
             <div
               key={key}
-              className={`px-3 py-1.5 text-[11px] font-semibold uppercase tracking-widest ${accent ? 'text-[#e8a5a5]' : 'text-fg-quaternary'}`}
+              className={`px-3 py-1.5 text-section-label font-semibold uppercase tracking-widest ${accent ? 'text-[#e8a5a5]' : 'text-fg-quaternary'}`}
             >
               {t(`calendar.weekdays.${key}`, key.toUpperCase())}
             </div>
@@ -306,7 +306,7 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
 
                   {hiddenCount > 0 && (
                     <div className="grid grid-cols-7">
-                      <div className="col-span-7 text-[10px] font-medium text-fg-tertiary px-2 pointer-events-auto">
+                      <div className="col-span-7 text-meta font-medium text-fg-tertiary px-2 pointer-events-auto">
                         +{hiddenCount} more
                       </div>
                     </div>

--- a/src/components/ArchivePanel.tsx
+++ b/src/components/ArchivePanel.tsx
@@ -58,7 +58,7 @@ function DoneTodoRow({ item, onRevert, onRequestDelete, onClick }: DoneTodoRowPr
 function SectionHeader({ label }: { label: string }) {
   return (
     <div className="flex items-center gap-3 mb-3">
-      <span className="text-[11px] font-semibold uppercase tracking-widest text-fg-quaternary shrink-0">{label}</span>
+      <span className="text-section-label font-semibold uppercase tracking-widest text-fg-quaternary shrink-0">{label}</span>
       <div className="flex-1 h-px bg-line" />
     </div>
   )

--- a/src/components/CalendarList.tsx
+++ b/src/components/CalendarList.tsx
@@ -40,7 +40,7 @@ export default function CalendarList() {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
           </svg>
-          <span className="text-section-label font-medium">{t('tag.manage', '관리')}</span>
+          <span className="text-[11px] font-medium">{t('tag.manage', '관리')}</span>
         </button>
       </div>
 

--- a/src/components/CalendarList.tsx
+++ b/src/components/CalendarList.tsx
@@ -28,7 +28,7 @@ export default function CalendarList() {
   return (
     <div className="flex flex-col">
       <div className="flex items-center justify-between mb-2">
-        <p className="text-fg-secondary text-[10px] font-semibold uppercase tracking-[0.08em]">
+        <p className="text-fg-secondary text-meta font-semibold uppercase tracking-[0.08em]">
           {t('main.event_types', '이벤트 종류')}
         </p>
         <button
@@ -40,7 +40,7 @@ export default function CalendarList() {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
           </svg>
-          <span className="text-[11px] font-medium">{t('tag.manage', '관리')}</span>
+          <span className="text-section-label font-medium">{t('tag.manage', '관리')}</span>
         </button>
       </div>
 

--- a/src/components/CellTimeLabel.tsx
+++ b/src/components/CellTimeLabel.tsx
@@ -89,7 +89,7 @@ function DoubleLine({ top, bottom }: { top: string; bottom: string }) {
   return (
     <div className="flex flex-col items-center">
       <p className="text-xs text-fg truncate leading-tight">{top}</p>
-      <p className="text-[10px] text-fg-secondary truncate leading-tight">{bottom}</p>
+      <p className="text-meta text-fg-secondary truncate leading-tight">{bottom}</p>
     </div>
   )
 }

--- a/src/components/CurrentTodoList.tsx
+++ b/src/components/CurrentTodoList.tsx
@@ -54,7 +54,7 @@ function CurrentTodoRow({ todo, onEventClick, onComplete, isLast }: CurrentTodoR
             <span className="text-xs text-fg-quaternary leading-none">Todo</span>
             {tagName && (
               <span
-                className="shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded-full leading-none"
+                className="shrink-0 text-meta font-semibold px-1.5 py-0.5 rounded-full leading-none"
                 style={{ color, backgroundColor: `${color}22` }}
               >
                 {tagName}
@@ -132,7 +132,7 @@ export function CurrentTodoList({ todos, isTagHidden, onEventClick }: CurrentTod
   return (
     <section data-testid="current-todo-list" className="mb-6">
       <div className="flex items-center gap-3 mb-3">
-        <span className="text-[11px] font-semibold uppercase tracking-widest text-fg-quaternary shrink-0">Current Todo</span>
+        <span className="text-section-label font-semibold uppercase tracking-widest text-fg-quaternary shrink-0">Current Todo</span>
         <div className="flex-1 h-px bg-line" />
       </div>
       <div className="flex flex-col">

--- a/src/components/DayEventList.tsx
+++ b/src/components/DayEventList.tsx
@@ -61,7 +61,7 @@ function EventItem({ calEvent, onEventClick, onComplete, isLast }: {
             </span>
             {tagName && (
               <span
-                className="shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded-full leading-none"
+                className="shrink-0 text-meta font-semibold px-1.5 py-0.5 rounded-full leading-none"
                 style={{ color, backgroundColor: `${color}22` }}
               >
                 {tagName}

--- a/src/components/DoneTodoDetail/DoneTodoDetailPopover.tsx
+++ b/src/components/DoneTodoDetail/DoneTodoDetailPopover.tsx
@@ -14,7 +14,7 @@ const POPOVER_WIDTH = 320
 const THRESHOLD = 200
 
 const ACTION_BTN = 'p-1.5 rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors disabled:opacity-50'
-const INFO_ROW = 'flex items-start gap-2 text-[13px] text-fg-secondary leading-snug'
+const INFO_ROW = 'flex items-start gap-2 text-info text-fg-secondary leading-snug'
 const INFO_ICON = 'h-4 w-4 text-fg-quaternary mt-0.5 shrink-0'
 
 export interface DoneTodoDetailPopoverProps {
@@ -135,7 +135,7 @@ export function DoneTodoDetailPopover({
             <div className={INFO_ROW}>
               <Clock className={INFO_ICON} />
               <div>
-                <p className="text-[11px] uppercase tracking-wider text-fg-quaternary">{t('todo.done_at_label', '완료 시각')}</p>
+                <p className="text-section-label uppercase tracking-wider text-fg-quaternary">{t('todo.done_at_label', '완료 시각')}</p>
                 <p>{doneTimeText}</p>
               </div>
             </div>
@@ -144,7 +144,7 @@ export function DoneTodoDetailPopover({
             <div className={INFO_ROW}>
               <Clock className={INFO_ICON} />
               <div>
-                <p className="text-[11px] uppercase tracking-wider text-fg-quaternary">{t('todo.original_time_label', '원래 시간')}</p>
+                <p className="text-section-label uppercase tracking-wider text-fg-quaternary">{t('todo.original_time_label', '원래 시간')}</p>
                 <p><EventTimeDisplay eventTime={originEventTime} /></p>
               </div>
             </div>

--- a/src/components/EventDetail/EventDetailPopover.tsx
+++ b/src/components/EventDetail/EventDetailPopover.tsx
@@ -24,7 +24,7 @@ function repeatingLabel(repeating: Repeating, t: TFunction): string {
 }
 
 const ACTION_BTN = 'p-1.5 rounded-full text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors'
-const INFO_ROW = 'flex items-start gap-2 text-[13px] text-fg-secondary leading-snug'
+const INFO_ROW = 'flex items-start gap-2 text-info text-fg-secondary leading-snug'
 const INFO_ICON = 'h-4 w-4 text-fg-quaternary mt-0.5 shrink-0'
 
 export interface EventDetailPopoverProps {
@@ -127,7 +127,7 @@ export function EventDetailPopover({
           {tagName && (
             <div data-testid="popover-tag-name">
               <span
-                className="inline-block text-[10px] font-semibold px-1.5 py-0.5 rounded-full leading-none"
+                className="inline-block text-meta font-semibold px-1.5 py-0.5 rounded-full leading-none"
                 style={{ color: tagColor, backgroundColor: `${tagColor}22` }}
               >
                 {tagName}

--- a/src/components/ForemostEventBanner.tsx
+++ b/src/components/ForemostEventBanner.tsx
@@ -55,7 +55,7 @@ export function ForemostEventBanner({ foremostEvent, onEventClick }: ForemostEve
             </span>
             {tagName && (
               <span
-                className="shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded-full leading-none"
+                className="shrink-0 text-meta font-semibold px-1.5 py-0.5 rounded-full leading-none"
                 style={{ color: resolved.color, backgroundColor: `${resolved.color}22` }}
               >
                 {tagName}

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -57,7 +57,7 @@ function MiniCalendarDayButton({
     <button
       {...props}
       className={cn(
-        'flex h-7 w-7 items-center justify-center text-[12px] mx-auto cursor-pointer bg-transparent border-0 p-0 transition-colors',
+        'flex h-7 w-7 items-center justify-center text-xs mx-auto cursor-pointer bg-transparent border-0 p-0 transition-colors',
         bgStyle,
         textColor,
         className
@@ -193,7 +193,7 @@ export default function LeftSidebar({
               button_previous: 'rounded p-0.5 hover:bg-surface-sunken text-fg-secondary h-7 w-7 flex items-center justify-center transition-colors',
               button_next: 'rounded p-0.5 hover:bg-surface-sunken text-fg-secondary h-7 w-7 flex items-center justify-center transition-colors',
               weekdays: 'flex',
-              weekday: 'flex-1 text-center text-[10px] font-normal uppercase tracking-wide text-fg-tertiary py-1',
+              weekday: 'flex-1 text-center text-meta font-normal uppercase tracking-wide text-fg-tertiary py-1',
               week: 'mt-0.5 flex w-full',
               day: 'flex-1 flex items-center justify-center py-0.5',
               today: '',

--- a/src/components/RightEventPanel.tsx
+++ b/src/components/RightEventPanel.tsx
@@ -25,7 +25,7 @@ function formatLunarDate(date: Date, locale: string): string | null {
 function SectionHeader({ label }: { label: string }) {
   return (
     <div className="flex items-center gap-3 mb-3">
-      <span className="text-[11px] font-semibold uppercase tracking-widest text-fg-quaternary shrink-0">{label}</span>
+      <span className="text-section-label font-semibold uppercase tracking-widest text-fg-quaternary shrink-0">{label}</span>
       <div className="flex-1 h-px bg-line" />
     </div>
   )

--- a/src/components/TopToolbar.tsx
+++ b/src/components/TopToolbar.tsx
@@ -60,7 +60,7 @@ export default function TopToolbar({
           )}
         >
           <img src="/logo-light.png" alt="To-do Calendar" className="h-7 shrink-0" />
-          <span className="text-[12px] font-semibold uppercase tracking-[0.18em] text-fg whitespace-nowrap">
+          <span className="text-xs font-semibold uppercase tracking-[0.18em] text-fg whitespace-nowrap">
             To-do Calendar
           </span>
         </div>
@@ -77,10 +77,10 @@ export default function TopToolbar({
 
           {/* 월 타이틀 — 연도는 캡션, 월은 히어로 */}
           <div data-testid="toolbar-month-title" className="flex flex-col items-center leading-none min-w-[7rem] py-1">
-            <span data-testid="toolbar-year" className="text-[10px] font-semibold uppercase tracking-[0.25em] text-fg-quaternary">
+            <span data-testid="toolbar-year" className="text-meta font-semibold uppercase tracking-[0.25em] text-fg-quaternary">
               {year}
             </span>
-            <span data-testid="toolbar-month" className="mt-1 text-[18px] font-semibold text-fg tracking-tight">
+            <span data-testid="toolbar-month" className="mt-1 text-lg font-semibold text-fg tracking-tight">
               {monthLabel}
             </span>
           </div>
@@ -95,7 +95,7 @@ export default function TopToolbar({
         <button
           onClick={onGoToToday}
           aria-label={t('main.today', '오늘')}
-          className="rounded-full px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.15em] text-fg hover:bg-surface-elevated transition-colors"
+          className="rounded-full px-3 py-1.5 text-section-label font-semibold uppercase tracking-[0.15em] text-fg hover:bg-surface-elevated transition-colors"
         >
           {t('main.today', '오늘')}
         </button>

--- a/src/components/UncompletedTodoList.tsx
+++ b/src/components/UncompletedTodoList.tsx
@@ -54,7 +54,7 @@ function UncompletedTodoRow({ todo, onEventClick, onComplete, isLast }: Uncomple
             <span className="text-xs text-fg-quaternary leading-none">Todo</span>
             {tagName && (
               <span
-                className="shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded-full leading-none"
+                className="shrink-0 text-meta font-semibold px-1.5 py-0.5 rounded-full leading-none"
                 style={{ color, backgroundColor: `${color}22` }}
               >
                 {tagName}
@@ -134,7 +134,7 @@ export function UncompletedTodoList({ todos, isTagHidden, onReload, onEventClick
   return (
     <section className="mb-6">
       <div className="flex items-center gap-3 mb-3">
-        <span className="text-[11px] font-semibold uppercase tracking-widest text-fg-quaternary shrink-0">
+        <span className="text-section-label font-semibold uppercase tracking-widest text-fg-quaternary shrink-0">
           {t('todo.uncompleted')}
         </span>
         <div className="flex-1 h-px bg-line" />

--- a/src/components/eventForm/DDayBadge.tsx
+++ b/src/components/eventForm/DDayBadge.tsx
@@ -10,7 +10,7 @@ export function DDayBadge() {
   const label = dday === 0 ? 'D-Day' : dday > 0 ? `D-${dday}` : `D+${Math.abs(dday)}`
 
   return (
-    <Badge variant="secondary" className="shrink-0 text-[10px] font-semibold tracking-wide">
+    <Badge variant="secondary" className="shrink-0 text-meta font-semibold tracking-wide">
       {label}
     </Badge>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,11 @@
   --color-danger: #e11d48;
   --color-warning: #f59e0b;
   --color-success: #16a34a;
+
+  /* === 폰트 사이즈 (이슈 #92) === */
+  --font-size-meta: 10px;            /* badge / time label / overflow count */
+  --font-size-section-label: 11px;   /* uppercase tracking-widest 섹션 라벨 */
+  --font-size-info: 13px;            /* popover info row */
 }
 
 html {

--- a/src/pages/settings/SettingsSection.tsx
+++ b/src/pages/settings/SettingsSection.tsx
@@ -12,7 +12,7 @@ export function SettingsSection({ title, children, tone = 'default' }: SettingsS
   return (
     <section className="space-y-6">
       <div className="flex items-center gap-3">
-        <span className={`text-[11px] font-semibold uppercase tracking-widest shrink-0 ${titleColor}`}>
+        <span className={`text-section-label font-semibold uppercase tracking-widest shrink-0 ${titleColor}`}>
           {title}
         </span>
         <div className={`flex-1 h-px ${ruleColor}`} />

--- a/src/pages/settings/sections/TimezoneSection.tsx
+++ b/src/pages/settings/sections/TimezoneSection.tsx
@@ -33,7 +33,7 @@ function TimezoneRow({ info, selected, systemBadgeLabel, onClick }: TimezoneRowP
         <div className="flex items-center gap-2">
           <span className={cn('truncate text-sm', selected && 'font-semibold')}>{info.title}</span>
           {systemBadgeLabel && (
-            <span className="shrink-0 rounded-full border border-line px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-fg-tertiary">
+            <span className="shrink-0 rounded-full border border-line px-1.5 py-0.5 text-meta font-medium uppercase tracking-wider text-fg-tertiary">
               {systemBadgeLabel}
             </span>
           )}

--- a/src/pages/settings/sections/appearance/CalendarAppearancePreview.tsx
+++ b/src/pages/settings/sections/appearance/CalendarAppearancePreview.tsx
@@ -53,7 +53,7 @@ export function CalendarAppearancePreview({ weekStartDay, accentDays }: Props) {
           return (
             <div
               key={k}
-              className={`text-center text-[10px] font-semibold uppercase tracking-widest ${isAccent ? 'text-[#e8a5a5]' : 'text-fg-quaternary'}`}
+              className={`text-center text-meta font-semibold uppercase tracking-widest ${isAccent ? 'text-[#e8a5a5]' : 'text-fg-quaternary'}`}
             >
               {t(`calendar.weekdays.${k}`, k)}
             </div>

--- a/src/pages/settings/sections/appearance/EventListPreview.tsx
+++ b/src/pages/settings/sections/appearance/EventListPreview.tsx
@@ -46,7 +46,7 @@ export function EventListPreview({ eventListFontSizeWeight, showHolidayInEventLi
       {showUncompletedTodos && (
         <div>
           <div className="flex items-center gap-3 mb-2">
-            <span className="text-[10px] font-semibold uppercase tracking-widest text-fg-quaternary">
+            <span className="text-meta font-semibold uppercase tracking-widest text-fg-quaternary">
               {t('todo.uncompleted', '미완료')}
             </span>
             <div className="flex-1 h-px bg-line" />
@@ -63,7 +63,7 @@ export function EventListPreview({ eventListFontSizeWeight, showHolidayInEventLi
       {/* 이벤트 */}
       <div>
         <div className="flex items-center gap-3 mb-2">
-          <span className="text-[10px] font-semibold uppercase tracking-widest text-fg-quaternary">
+          <span className="text-meta font-semibold uppercase tracking-widest text-fg-quaternary">
             {t('main.events_title', 'Events')}
           </span>
           <div className="flex-1 h-px bg-line" />
@@ -73,7 +73,7 @@ export function EventListPreview({ eventListFontSizeWeight, showHolidayInEventLi
             <span className="h-2 w-2 mt-1.5 rounded-full ring-2 ring-surface shrink-0" style={{ backgroundColor: e.color }} />
             <div className="min-w-0">
               <p className="font-semibold text-fg" style={{ fontSize: nameFontSize }}>{e.name}</p>
-              <p className="text-[11px] text-fg-quaternary">{e.time}</p>
+              <p className="text-section-label text-fg-quaternary">{e.time}</p>
             </div>
           </div>
         ))}

--- a/src/pages/settings/sections/appearance/EventListPreview.tsx
+++ b/src/pages/settings/sections/appearance/EventListPreview.tsx
@@ -73,7 +73,7 @@ export function EventListPreview({ eventListFontSizeWeight, showHolidayInEventLi
             <span className="h-2 w-2 mt-1.5 rounded-full ring-2 ring-surface shrink-0" style={{ backgroundColor: e.color }} />
             <div className="min-w-0">
               <p className="font-semibold text-fg" style={{ fontSize: nameFontSize }}>{e.name}</p>
-              <p className="text-section-label text-fg-quaternary">{e.time}</p>
+              <p className="text-[11px] text-fg-quaternary">{e.time}</p>
             </div>
           </div>
         ))}


### PR DESCRIPTION
## 문제

이슈 #75 컬러 토큰 워싱 후속. 색상은 의미 토큰으로 정렬됐으나 폰트 사이즈는 비스코프로 남아 `text-[10px]`, `text-[11px]` 등 arbitrary 클래스 33건이 코드에 분산.

분포:
- `text-[10px]` 15건 — badge / time label / overflow count
- `text-[11px]` 11건 — section label (uppercase tracking-widest)
- `text-[13px]` 2건 — popover info row
- `text-[12px]` 2건 — toolbar / mini-calendar
- `text-[18px]` / `text-[15px]` / `text-[9px]` — 각 1건 단발

Tailwind 기본 스케일(`text-xs`=12, `text-sm`=14, `text-base`=16, `text-lg`=18)에 9/10/11/13px가 없음 — 미세 톤 의도.

## 접근 (사용자 합의)

**A 옵션 — 의미 토큰 신규 정의**:
- 미세 톤(10/11/13px)은 의미 기반 토큰으로 보존 (시각 회귀 0)
- Tailwind 기본 스케일에 동일값 있는 자리(12px/18px)는 흡수
- 단발 9/15px는 인라인 유지 (시각 회귀 회피)

## 변경 (2 커밋)

### `ce78b5a` refactor(theme): 폰트 사이즈 의미 토큰 3종 정의

`src/index.css @theme` 블록에 추가:
- `--font-size-meta: 10px` → `text-meta` (badge / time label / overflow count)
- `--font-size-section-label: 11px` → `text-section-label` (uppercase 섹션 라벨)
- `--font-size-info: 13px` → `text-info` (popover info row)

라이트/다크 페어 무관(`.dark` 블록 변경 X).

### `569180f` refactor: arbitrary 폰트 사이즈 → 의미 토큰 치환

18 파일 31 치환:
- `text-[10px]` 15건 → `text-meta`
- `text-[11px]` 11건 → `text-section-label`
- `text-[13px]` 2건 → `text-info`
- `text-[12px]` 2건 → `text-xs` (Tailwind 기본 동일값 흡수)
- `text-[18px]` 1건 → `text-lg` (TopToolbar 월 히어로, Tailwind 기본 동일값)

## 검증

- **build**: PASS
- **test**: 800 PASS / 2 FAIL (베이스라인 동일 — `EventTimeDisplay.test.tsx` pre-existing 로케일 이슈)
- **시각 회귀**: 토큰 값이 원본 hex와 동일하므로 라이트/다크 양쪽 회귀 0

## 잔존 인라인 (의도된 단발)

- `EventDetailPopover.tsx:93` — `text-[15px]` (팝오버 이벤트 제목 히어로)
- `EventDisplayPreview.tsx:61` — `text-[9px]` (overflow `+N more` 표시)

## 비스코프

- 폰트 패밀리(`--font-sans`) 변경
- 동적 폰트 weight 시스템(`eventFontSizeWeight -7~+7`, `eventListFontSizeWeight`) — 사용자 슬라이더 조정으로 그대로 유지
- 폰트 weight arbitrary (`font-[N]`) — 본 이슈 비스코프

## Test plan

- [ ] CI 빌드/테스트 통과
- [ ] 캘린더/팝오버/Settings 등 폰트 시각 회귀 없음
- [ ] 다크 모드 토글 시 폰트 사이즈 정합

closes #92