### PR TITLE
[QA Day1] #97 #98 #99 #100 #101 #102 #103 #104 — 메인/우특/설정 8개 버그·기능 수정

### DIFF
--- a/src/api/todoApi.ts
+++ b/src/api/todoApi.ts
@@ -25,8 +25,8 @@ export const todoApi = {
     return apiClient.get('/v1/todos')
   },
 
-  getUncompletedTodos(): Promise<Todo[]> {
-    return apiClient.get('/v1/todos/uncompleted')
+  getUncompletedTodos(refTime: number): Promise<Todo[]> {
+    return apiClient.get(`/v1/todos/uncompleted?refTime=${refTime}`)
   },
 
   getTodo(id: string): Promise<Todo> {

--- a/src/calendar/MainCalendarGrid.tsx
+++ b/src/calendar/MainCalendarGrid.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import type { CalendarDay } from './calendarUtils'
 import type { CalendarEvent } from '../domain/functions/eventTime'
 import { formatDateKey } from '../domain/functions/eventTime'
-import { buildWeekEventStack, type EventOnWeekRow } from './weekEventStackBuilder'
+import { buildWeekEventStack, computeMoreEventCounts, type EventOnWeekRow } from './weekEventStackBuilder'
 import { useUiStore } from '../stores/uiStore'
 import { useCalendarEventsCache } from '../repositories/caches/calendarEventsCache'
 import { useHolidayCache } from '../repositories/caches/holidayCache'
@@ -200,9 +200,10 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
           const stack = weekStacks[wi] ?? { rows: [] }
           const stackRowsLen = stack.rows.length
           const visibleRows = isFull ? stack.rows : stack.rows.slice(0, maxVisibleRows)
-          const hiddenCount = !isFull && stack.rows.length > maxVisibleRows
-            ? stack.rows.slice(maxVisibleRows).reduce((sum, row) => sum + row.length, 0)
-            : 0
+          // hidden 이벤트는 row 단위 합계가 아니라 day(col) 별로 집계해 각 셀 위치에 +N 표시 (#102)
+          const moreCounts = !isFull
+            ? computeMoreEventCounts(stack, maxVisibleRows, weekDays.length)
+            : []
           const isLastWeek = wi === totalWeeks - 1
 
           return (
@@ -304,11 +305,19 @@ export default function MainCalendarGrid({ days, onEventClick }: MainCalendarGri
                     </div>
                   ))}
 
-                  {hiddenCount > 0 && (
+                  {moreCounts.length > 0 && (
                     <div className="grid grid-cols-7">
-                      <div className="col-span-7 text-meta font-medium text-fg-tertiary px-2 pointer-events-auto">
-                        +{hiddenCount} more
-                      </div>
+                      {moreCounts.map(({ col, count }) => (
+                        <div
+                          key={col}
+                          className="text-meta font-medium text-fg-tertiary px-1.5 pointer-events-auto"
+                          style={{ gridColumn: `${col} / ${col + 1}` }}
+                          data-testid="more-events"
+                          data-day-col={col}
+                        >
+                          +{count}
+                        </div>
+                      ))}
                     </div>
                   )}
                 </div>

--- a/src/calendar/weekEventStackBuilder.ts
+++ b/src/calendar/weekEventStackBuilder.ts
@@ -1,5 +1,6 @@
 import type { CalendarDay } from './calendarUtils'
 import type { CalendarEvent } from '../domain/functions/eventTime'
+import { eventTimeToStartDate } from '../domain/functions/eventTime'
 
 // 반복 이벤트의 각 인스턴스를 구분하기 위한 dedup 키.
 // 같은 uuid의 multi-day 이벤트는 같은 turn을 가지므로 하나의 span으로 병합되고,
@@ -29,6 +30,14 @@ interface DeduplicatedEvent {
   startCol: number
   endCol: number
   spanLength: number
+  startTimestamp: number  // 정렬 tie-break: 종일 이벤트(그 날 00:00)가 시간 이벤트보다 먼저 옴
+}
+
+// CalendarEvent 의 시작 timestamp (초). event_time 이 없으면 0.
+function eventStartTs(calEvent: CalendarEvent): number {
+  const t = calEvent.event.event_time
+  if (!t) return 0
+  return Math.floor(eventTimeToStartDate(t).getTime() / 1000)
 }
 
 /**
@@ -74,6 +83,7 @@ export function buildWeekEventStack(
           startCol: col,
           endCol: col,
           spanLength: 1,
+          startTimestamp: eventStartTs(ev),
         })
       }
     }
@@ -81,11 +91,13 @@ export function buildWeekEventStack(
 
   if (eventMap.size === 0) return { rows: [] }
 
-  // 정렬: 길이 desc → 시작일 asc → 이름 asc
+  // 정렬: 길이 desc → 시작 column asc → 시작 timestamp asc (종일 이벤트가 시간 이벤트보다 먼저)
+  // iOS WeekEventStackBuilder.sortUnStackedEvents 와 동일하게 length → lowerBound 우선.
+  // 이름 정렬은 의도적으로 제외 — 알파벳에 따른 row 배치 흔들림(예: 종일 "피부과 예약"이 "A standup" 뒤로 밀림)을 방지.
   let remaining = Array.from(eventMap.values()).sort((a, b) => {
     if (b.spanLength !== a.spanLength) return b.spanLength - a.spanLength
     if (a.startCol !== b.startCol) return a.startCol - b.startCol
-    return a.event.event.name.localeCompare(b.event.event.name)
+    return a.startTimestamp - b.startTimestamp
   })
 
   const rows: EventRow[] = []
@@ -102,14 +114,17 @@ export function buildWeekEventStack(
     rows.push(row)
   }
 
-  // 행 정렬: 총 커버 일수 desc → 첫 이벤트 시작일 asc
+  // 행 정렬: 총 커버 일수 desc → 첫 이벤트 시작일 asc → 행 내 이벤트 개수 asc
+  // iOS 정렬 (eventExistsLength desc, firstEventDaySequence asc, count asc) 와 동일.
+  // count asc 가 있어야 "단일 긴 이벤트 row" 가 "여러 짧은 이벤트가 합쳐진 같은 cover row" 보다 위로 온다.
   rows.sort((a, b) => {
     const coverA = a.reduce((sum, e) => sum + (e.endCol - e.startCol + 1), 0)
     const coverB = b.reduce((sum, e) => sum + (e.endCol - e.startCol + 1), 0)
     if (coverB !== coverA) return coverB - coverA
     const firstStartA = Math.min(...a.map(e => e.startCol))
     const firstStartB = Math.min(...b.map(e => e.startCol))
-    return firstStartA - firstStartB
+    if (firstStartA !== firstStartB) return firstStartA - firstStartB
+    return a.length - b.length
   })
 
   return { rows }

--- a/src/calendar/weekEventStackBuilder.ts
+++ b/src/calendar/weekEventStackBuilder.ts
@@ -131,6 +131,35 @@ export function buildWeekEventStack(
 }
 
 /**
+ * visibleRowCount 를 초과해 잘려난 hidden row 들의 이벤트를 day(col) 별로 집계한다.
+ * 캘린더 셀마다 그 날에 가려진 이벤트 수를 "+N" 라벨로 표시할 때 사용 (#102).
+ *
+ * @param stack buildWeekEventStack 결과
+ * @param visibleRowCount 이 행 수까지만 표시되고, 그 이상의 행은 hidden 으로 간주
+ * @param weekDayCount 주의 일수 (보통 7)
+ * @returns col 오름차순으로 hidden 카운트가 0보다 큰 항목들
+ */
+export function computeMoreEventCounts(
+  stack: WeekEventStack,
+  visibleRowCount: number,
+  weekDayCount: number,
+): { col: number; count: number }[] {
+  if (visibleRowCount >= stack.rows.length) return []
+  const hiddenRows = stack.rows.slice(visibleRowCount)
+  const counts = new Array(weekDayCount).fill(0) as number[]
+  for (const row of hiddenRows) {
+    for (const ev of row) {
+      for (let c = ev.startCol; c <= ev.endCol; c++) {
+        counts[c - 1] += 1
+      }
+    }
+  }
+  return counts
+    .map((cnt, i) => ({ col: i + 1, count: cnt }))
+    .filter(x => x.count > 0)
+}
+
+/**
  * 재귀적으로 행에 이벤트를 채운다.
  * rangeStart ~ rangeEnd 범위 내에서 가장 긴 이벤트를 배치하고,
  * 좌/우 빈 공간에 재귀적으로 더 채운다.

--- a/src/components/ColorPalette.tsx
+++ b/src/components/ColorPalette.tsx
@@ -1,8 +1,12 @@
 import { useTranslation } from 'react-i18next'
 
+// iOS EventTagDetailViewModelImple.suggestColorHexes 와 동일한 27색 팔레트.
+// 사용자가 충분히 다양한 색을 고를 수 있어야 한다는 QA 피드백 반영.
 export const PRESET_COLORS = [
-  '#ef4444', '#f97316', '#eab308', '#22c55e',
-  '#3b82f6', '#8b5cf6', '#ec4899', '#6b7280',
+  '#F42D2D', '#F9316D', '#FF5722', '#FD838F', '#FFA02E', '#F6DC41', '#B75F17',
+  '#6800f2', '#9370DB', '#6A5ACD', '#4034AB', '#1E90FF', '#4682B4', '#5F9EA0',
+  '#4561DB', '#5e86d6', '#87CEEB', '#088CDA', '#AFEEEE', '#036A73', '#3CB371',
+  '#06A192', '#41E6EC', '#72E985', '#CCD0DC', '#828DA9', '#8DACF6',
 ]
 
 interface ColorPaletteProps {

--- a/src/dev/testDataSeeder.ts
+++ b/src/dev/testDataSeeder.ts
@@ -148,7 +148,7 @@ export async function cleanupTestData(): Promise<string[]> {
 
   const ranged = (await safe('list todos (range)', errors, () => todoApi.getTodos(widePast, wideFuture))) ?? []
   const current = (await safe('list current todos', errors, () => todoApi.getCurrentTodos())) ?? []
-  const uncompleted = (await safe('list uncompleted todos', errors, () => todoApi.getUncompletedTodos())) ?? []
+  const uncompleted = (await safe('list uncompleted todos', errors, () => todoApi.getUncompletedTodos(Math.floor(Date.now() / 1000)))) ?? []
 
   const todoById = new Map<string, Todo>()
   for (const t of [...ranged, ...current, ...uncompleted]) todoById.set(t.uuid, t)

--- a/src/dev/testDataSeeder.ts
+++ b/src/dev/testDataSeeder.ts
@@ -95,12 +95,13 @@ interface SeederTag {
   color_hex: string
 }
 
+// iOS suggestColorHexes 27색 팔레트 기준 의미별 인덱스
 const TAGS: SeederTag[] = [
-  { key: 'work', name: `${TEST_PREFIX}Work`, color_hex: PRESET_COLORS[0] },     // red
-  { key: 'personal', name: `${TEST_PREFIX}Personal`, color_hex: PRESET_COLORS[4] }, // blue
-  { key: 'study', name: `${TEST_PREFIX}Study`, color_hex: PRESET_COLORS[5] },   // purple
-  { key: 'health', name: `${TEST_PREFIX}Health`, color_hex: PRESET_COLORS[3] }, // green
-  { key: 'travel', name: `${TEST_PREFIX}Travel`, color_hex: PRESET_COLORS[1] }, // orange
+  { key: 'work', name: `${TEST_PREFIX}Work`, color_hex: PRESET_COLORS[0] },      // #F42D2D red
+  { key: 'personal', name: `${TEST_PREFIX}Personal`, color_hex: PRESET_COLORS[11] }, // #1E90FF blue
+  { key: 'study', name: `${TEST_PREFIX}Study`, color_hex: PRESET_COLORS[7] },    // #6800f2 purple
+  { key: 'health', name: `${TEST_PREFIX}Health`, color_hex: PRESET_COLORS[20] }, // #3CB371 green
+  { key: 'travel', name: `${TEST_PREFIX}Travel`, color_hex: PRESET_COLORS[4] },  // #FFA02E orange
 ]
 
 interface SeedResult {

--- a/src/domain/functions/eventTime.ts
+++ b/src/domain/functions/eventTime.ts
@@ -19,7 +19,9 @@ export function eventTimeToEndDate(eventTime: EventTime): Date {
     case 'period':
       return new Date(eventTime.period_end * 1000)
     case 'allday':
-      return new Date((eventTime.period_end + eventTime.seconds_from_gmt) * 1000)
+      // iOS EventTime.allDay 의 Range 는 half-open [lower, upper) — period_end 는 종료 다음 날 00:00 이다.
+      // 캘린더 day enumerate 가 종료 다음 날까지 포함하지 않도록 1일(86400s) 차감해 마지막 종일 일자의 시각으로 변환.
+      return new Date((eventTime.period_end + eventTime.seconds_from_gmt - 86400) * 1000)
   }
 }
 

--- a/src/domain/functions/eventTime.ts
+++ b/src/domain/functions/eventTime.ts
@@ -8,7 +8,7 @@ export function eventTimeToStartDate(eventTime: EventTime): Date {
     case 'period':
       return new Date(eventTime.period_start * 1000)
     case 'allday':
-      return new Date((eventTime.period_start + eventTime.seconds_from_gmt) * 1000)
+      return alldayLocalDate(eventTime.period_start, eventTime.seconds_from_gmt)
   }
 }
 
@@ -19,10 +19,24 @@ export function eventTimeToEndDate(eventTime: EventTime): Date {
     case 'period':
       return new Date(eventTime.period_end * 1000)
     case 'allday':
-      // iOS EventTime.allDay 의 Range 는 half-open [lower, upper) — period_end 는 종료 다음 날 00:00 이다.
-      // 캘린더 day enumerate 가 종료 다음 날까지 포함하지 않도록 1일(86400s) 차감해 마지막 종일 일자의 시각으로 변환.
-      return new Date((eventTime.period_end + eventTime.seconds_from_gmt - 86400) * 1000)
+      return alldayLocalDate(eventTime.period_end, eventTime.seconds_from_gmt)
   }
+}
+
+// 종일(allday) 이벤트는 등록 시 정한 timezone(seconds_from_gmt) 의 일자가 의미 단위다.
+// 사용자 로컬 timezone 과 무관하게 "이벤트가 등록된 그 날짜" 를 캘린더 그리드에 그대로 매핑하기 위해
+// event tz 를 고정 기준으로 잡아 그 tz 의 일자를 추출하고, 사용자 로컬 자정 Date 로 변환한다.
+//
+// 기법: (period + seconds_from_gmt) timestamp 의 UTC wall-clock 시각이 곧 event tz 의 wall-clock 시각이다
+// (offset 만큼 timestamp 를 평행이동시킨 결과를 UTC 로 표현하면 그 tz 의 시각이 그대로 나온다).
+// 따라서 UTC 메소드로 뽑은 y/m/d 가 event tz 의 일자. 그 y/m/d 로 new Date(y, m, d) 를 만들면
+// 사용자 로컬 tz 의 자정 Date 가 되어 캘린더 day-cell 에 정확히 떨어진다.
+//
+// iOS Calendar.endOfDay 가 "그 날 23:59:59" 를 반환하므로 period_end 는 종료 날의 마지막 초.
+// 이 값에 동일 변환을 적용하면 종료 날 23:59:59 → UTC 평행이동 후 그 tz 의 같은 종료 날 시각 → 종료 일자 그대로 추출.
+function alldayLocalDate(periodSeconds: number, secondsFromGMT: number): Date {
+  const wallLikeUTC = new Date((periodSeconds + secondsFromGMT) * 1000)
+  return new Date(wallLikeUTC.getUTCFullYear(), wallLikeUTC.getUTCMonth(), wallLikeUTC.getUTCDate())
 }
 
 export function dateToTimestamp(date: Date): number {

--- a/src/pages/Main/useMainViewModel.ts
+++ b/src/pages/Main/useMainViewModel.ts
@@ -70,7 +70,7 @@ export interface MainViewModel {
 // MARK: - Hook
 
 export function useMainViewModel(): MainViewModel {
-  const { eventRepo, holidayRepo, tagRepo, foremostEventRepo } = useRepositories()
+  const { eventRepo, holidayRepo } = useRepositories()
 
   // ── UI 상태 ──────────────────────────────────────────────────────
   const currentMonth = useUiStore(s => s.currentMonth)
@@ -143,6 +143,9 @@ export function useMainViewModel(): MainViewModel {
     [year, month, weekStartDay],
   )
 
+  // 캘린더 그리드 year 변경 시 events + holidays fetch.
+  // currentTodos / uncompletedTodos / foremost / tags 는 AuthGuard 가 인증 통과 시 일괄 prefetch 하므로
+  // 여기서 중복 호출하지 않는다 (#99 — 같은 endpoint 가 2~3벌씩 나가던 문제).
   useEffect(() => {
     if (days.length === 0) return
     const fetchYears = new Set(days.map(d => d.date.getFullYear()))
@@ -150,23 +153,7 @@ export function useMainViewModel(): MainViewModel {
     fetchYears.forEach(y => holidayRepo.fetch(y))
   }, [days, holidayRepo])
 
-  useEffect(() => {
-    eventRepo.fetchCurrentTodos()
-  }, [eventRepo])
-
-  useEffect(() => {
-    eventRepo.fetchUncompletedTodos()
-  }, [eventRepo])
-
-  useEffect(() => {
-    foremostEventRepo.fetch()
-  }, [foremostEventRepo])
-
-  useEffect(() => {
-    tagRepo.fetchAll()
-  }, [tagRepo])
-
-  // LeftSidebar도 월 변경 시 공휴일 fetch — ViewModel이 통합 처리
+  // LeftSidebar 월 변경 시 공휴일 fetch — ViewModel 이 통합 처리
   useEffect(() => {
     const sbYear = sidebarMonth.getFullYear()
     const sbMonth = sidebarMonth.getMonth()

--- a/src/pages/settings/sections/appearance/EventDisplayPreview.tsx
+++ b/src/pages/settings/sections/appearance/EventDisplayPreview.tsx
@@ -1,17 +1,25 @@
 import { PRESET_COLORS } from '../../../../components/ColorPalette'
 import type { EventDisplayLevel } from '../../../../repositories/caches/settingsCache'
 
+// 의미별 색 인덱스 — iOS suggestColorHexes 27색 팔레트 기준
+const C_BLUE = 11   // #1E90FF
+const C_ORANGE = 4  // #FFA02E
+const C_GREEN = 20  // #3CB371
+const C_PURPLE = 7  // #6800f2
+const C_YELLOW = 5  // #F6DC41
+const C_PINK = 3    // #FD838F
+
 const SAMPLE_EVENTS_BY_DAY: { day: number; name: string; color: string }[][] = [
-  [{ day: 1, name: '회의', color: PRESET_COLORS[4] }],          // blue
-  [{ day: 2, name: '커피챗', color: PRESET_COLORS[1] }, { day: 2, name: '리뷰 PR', color: PRESET_COLORS[3] }],  // orange, green
+  [{ day: 1, name: '회의', color: PRESET_COLORS[C_BLUE] }],
+  [{ day: 2, name: '커피챗', color: PRESET_COLORS[C_ORANGE] }, { day: 2, name: '리뷰 PR', color: PRESET_COLORS[C_GREEN] }],
   [
-    { day: 3, name: '디자인 리뷰', color: PRESET_COLORS[5] },   // purple
-    { day: 3, name: '점심 약속', color: PRESET_COLORS[2] },     // yellow
-    { day: 3, name: '운동', color: PRESET_COLORS[3] },           // green
+    { day: 3, name: '디자인 리뷰', color: PRESET_COLORS[C_PURPLE] },
+    { day: 3, name: '점심 약속', color: PRESET_COLORS[C_YELLOW] },
+    { day: 3, name: '운동', color: PRESET_COLORS[C_GREEN] },
   ],
-  [{ day: 4, name: '주간 리포트', color: PRESET_COLORS[4] }],   // blue
+  [{ day: 4, name: '주간 리포트', color: PRESET_COLORS[C_BLUE] }],
   [],
-  [{ day: 6, name: '생일 🎂', color: PRESET_COLORS[6] }],      // pink
+  [{ day: 6, name: '생일 🎂', color: PRESET_COLORS[C_PINK] }],
   [],
 ]
 

--- a/src/repositories/EventRepository.ts
+++ b/src/repositories/EventRepository.ts
@@ -13,7 +13,7 @@ import type { CalendarEvent } from '../domain/functions/eventTime'
 export interface TodoApi {
   getTodos(lower: number, upper: number): Promise<Todo[]>
   getCurrentTodos(): Promise<Todo[]>
-  getUncompletedTodos(): Promise<Todo[]>
+  getUncompletedTodos(refTime: number): Promise<Todo[]>
   getTodo(id: string): Promise<Todo>
   createTodo(body: { name: string; event_tag_id?: string; event_time?: EventTime; repeating?: Repeating; notification_options?: NotificationOption[]; is_current?: boolean }): Promise<Todo>
   updateTodo(id: string, body: Partial<Pick<Todo, 'name' | 'event_tag_id' | 'event_time' | 'repeating' | 'notification_options'>>): Promise<Todo>
@@ -67,7 +67,8 @@ export class EventRepository {
   }
 
   async fetchUncompletedTodos(): Promise<void> {
-    const todos = await this.deps.todoApi.getUncompletedTodos()
+    const refTime = Math.floor(Date.now() / 1000)
+    const todos = await this.deps.todoApi.getUncompletedTodos(refTime)
     useUncompletedTodosCache.getState().replaceAll(todos)
   }
 

--- a/src/repositories/HolidayRepository.ts
+++ b/src/repositories/HolidayRepository.ts
@@ -21,6 +21,8 @@ interface Deps {
 export class HolidayRepository {
   private readonly api: HolidayApi
   private locale: string
+  // 동일 year 동시 fetch 시 같은 promise 를 공유해 API 트래픽을 1회로 줄인다 (#99).
+  private readonly inFlight = new Map<number, Promise<void>>()
 
   constructor(deps: Deps) {
     this.api = deps.api
@@ -34,11 +36,21 @@ export class HolidayRepository {
   // ── fetch: 서버 → 캐시 ────────────────────────────────────────────
 
   async fetch(year: number): Promise<void> {
-    const { code } = useHolidayCache.getState().country
-    const response = await this.api.getHolidays(year, this.locale, code)
-    // 응답이 { items } 가 아닌 빈 객체로 오는 환경(예: 미모킹 단위 테스트)에도
-    // setHolidaysForYear 가 unhandled rejection 을 일으키지 않도록 빈 배열 fallback.
-    useHolidayCache.getState().setHolidaysForYear(year, response?.items ?? [])
+    const existing = this.inFlight.get(year)
+    if (existing) return existing
+    const promise = (async () => {
+      try {
+        const { code } = useHolidayCache.getState().country
+        const response = await this.api.getHolidays(year, this.locale, code)
+        // 응답이 { items } 가 아닌 빈 객체로 오는 환경(예: 미모킹 단위 테스트)에도
+        // setHolidaysForYear 가 unhandled rejection 을 일으키지 않도록 빈 배열 fallback.
+        useHolidayCache.getState().setHolidaysForYear(year, response?.items ?? [])
+      } finally {
+        this.inFlight.delete(year)
+      }
+    })()
+    this.inFlight.set(year, promise)
+    return promise
   }
 
   // ── observe: snapshot ────────────────────────────────────────────

--- a/src/repositories/caches/currentTodosCache.ts
+++ b/src/repositories/caches/currentTodosCache.ts
@@ -16,17 +16,27 @@ interface CurrentTodosState {
   reset: () => void
 }
 
+// 동시 fetch 호출 (AuthGuard + 페이지 ViewModel + dev StrictMode 이중 effect 등) 시
+// 같은 promise 를 공유해 API 호출 1회로 묶는다 (#99).
+let inFlight: Promise<void> | null = null
+
 export const useCurrentTodosCache = create<CurrentTodosState>((set) => ({
   todos: [],
 
   fetch: async () => {
-    try {
-      const todos = await todoApi.getCurrentTodos()
-      set({ todos })
-    } catch (e) {
-      console.warn('Current todo 로드 실패:', e)
-      throw e
-    }
+    if (inFlight) return inFlight
+    inFlight = (async () => {
+      try {
+        const todos = await todoApi.getCurrentTodos()
+        set({ todos })
+      } catch (e) {
+        console.warn('Current todo 로드 실패:', e)
+        throw e
+      } finally {
+        inFlight = null
+      }
+    })()
+    return inFlight
   },
 
   addTodo: (todo: Todo) => set(s => ({ todos: [...s.todos, todo] })),

--- a/src/repositories/caches/eventTagListCache.ts
+++ b/src/repositories/caches/eventTagListCache.ts
@@ -32,6 +32,10 @@ interface EventTagListCacheState {
   updateDefaultTagColor: (kind: 'default' | 'holiday', color_hex: string) => Promise<void>
 }
 
+// 동시 fetchAll 호출 (AuthGuard + 페이지 ViewModel + dev StrictMode 이중 effect 등) 시
+// 같은 promise 를 공유해 API 호출 1회로 묶는다 (#99).
+let fetchAllInFlight: Promise<void> | null = null
+
 export const useEventTagListCache = create<EventTagListCacheState>((set, get) => ({
   tags: new Map(),
   defaultTagColors: null,
@@ -65,18 +69,24 @@ export const useEventTagListCache = create<EventTagListCacheState>((set, get) =>
   // ── legacy business operations (to be removed after T14+ page migration) ──
 
   fetchAll: async () => {
-    try {
-      const [list, defaultColors] = await Promise.all([
-        eventTagApi.getAllTags(),
-        settingApi.getDefaultTagColors(),
-      ])
-      const map = new Map<string, EventTag>()
-      for (const tag of list) map.set(tag.uuid, tag)
-      set({ tags: map, defaultTagColors: defaultColors })
-    } catch (e) {
-      console.warn('태그 로드 실패:', e)
-      throw e
-    }
+    if (fetchAllInFlight) return fetchAllInFlight
+    fetchAllInFlight = (async () => {
+      try {
+        const [list, defaultColors] = await Promise.all([
+          eventTagApi.getAllTags(),
+          settingApi.getDefaultTagColors(),
+        ])
+        const map = new Map<string, EventTag>()
+        for (const tag of list) map.set(tag.uuid, tag)
+        set({ tags: map, defaultTagColors: defaultColors })
+      } catch (e) {
+        console.warn('태그 로드 실패:', e)
+        throw e
+      } finally {
+        fetchAllInFlight = null
+      }
+    })()
+    return fetchAllInFlight
   },
 
   createTag: async (name: string, color_hex?: string) => {

--- a/src/repositories/caches/foremostEventCache.ts
+++ b/src/repositories/caches/foremostEventCache.ts
@@ -17,6 +17,10 @@ interface ForemostEventCacheState {
   removeForemost: () => Promise<void>
 }
 
+// 동시 fetch 호출 (AuthGuard + 페이지 ViewModel + dev StrictMode 이중 effect 등) 시
+// 같은 promise 를 공유해 API 호출 1회로 묶는다 (#99).
+let inFlight: Promise<void> | null = null
+
 export const useForemostEventCache = create<ForemostEventCacheState>((set) => ({
   foremostEvent: null,
 
@@ -29,14 +33,20 @@ export const useForemostEventCache = create<ForemostEventCacheState>((set) => ({
   // ── legacy business operations ────────────────────────────────────
 
   fetch: async () => {
-    try {
-      const event = await foremostApi.getForemostEvent()
-      set({ foremostEvent: event })
-    } catch (e) {
-      console.warn('Foremost event 로드 실패:', e)
-      set({ foremostEvent: null })
-      throw e
-    }
+    if (inFlight) return inFlight
+    inFlight = (async () => {
+      try {
+        const event = await foremostApi.getForemostEvent()
+        set({ foremostEvent: event })
+      } catch (e) {
+        console.warn('Foremost event 로드 실패:', e)
+        set({ foremostEvent: null })
+        throw e
+      } finally {
+        inFlight = null
+      }
+    })()
+    return inFlight
   },
 
   setForemost: async (eventId: string, isTodo: boolean) => {

--- a/src/repositories/caches/holidayCache.ts
+++ b/src/repositories/caches/holidayCache.ts
@@ -80,9 +80,20 @@ export const useHolidayCache = create<HolidayCacheState>((set, get) => ({
   // ── cache primitive operations ────────────────────────────────────
 
   setHolidaysForYear: (year, items) => {
-    const newHolidays = new Map(get().holidays)
+    // 같은 year 에 대해 다중 호출(StrictMode 이중 effect, 동시 trigger 등) 되어도
+    // 결과가 누적되지 않도록 idempotent replace: 해당 year의 기존 키를 모두 제거 후 채운다.
+    const yearPrefix = String(year)
+    const newHolidays = new Map<string, string[]>()
+    for (const [key, names] of get().holidays) {
+      if (!key.startsWith(yearPrefix)) newHolidays.set(key, names)
+    }
+    const seen = new Map<string, Set<string>>()
     for (const item of items) {
       const dateKey = item.start.date
+      const seenForKey = seen.get(dateKey) ?? new Set<string>()
+      if (seenForKey.has(item.summary)) continue
+      seenForKey.add(item.summary)
+      seen.set(dateKey, seenForKey)
       const existing = newHolidays.get(dateKey) ?? []
       newHolidays.set(dateKey, [...existing, item.summary])
     }

--- a/src/repositories/caches/uncompletedTodosCache.ts
+++ b/src/repositories/caches/uncompletedTodosCache.ts
@@ -14,18 +14,28 @@ interface UncompletedTodosState {
   reset: () => void
 }
 
+// 동시 fetch 호출 (AuthGuard + 페이지 ViewModel + dev StrictMode 이중 effect 등) 시
+// 같은 promise 를 공유해 API 호출 1회로 묶는다 (#99).
+let inFlight: Promise<void> | null = null
+
 export const useUncompletedTodosCache = create<UncompletedTodosState>((set, get) => ({
   todos: [],
 
   fetch: async () => {
-    try {
-      const refTime = Math.floor(Date.now() / 1000)
-      const todos = await todoApi.getUncompletedTodos(refTime)
-      set({ todos })
-    } catch (e) {
-      console.warn('미완료 Todo 로드 실패:', e)
-      throw e  // let caller decide how to handle
-    }
+    if (inFlight) return inFlight
+    inFlight = (async () => {
+      try {
+        const refTime = Math.floor(Date.now() / 1000)
+        const todos = await todoApi.getUncompletedTodos(refTime)
+        set({ todos })
+      } catch (e) {
+        console.warn('미완료 Todo 로드 실패:', e)
+        throw e
+      } finally {
+        inFlight = null
+      }
+    })()
+    return inFlight
   },
 
   removeTodo: (id: string) => {

--- a/src/repositories/caches/uncompletedTodosCache.ts
+++ b/src/repositories/caches/uncompletedTodosCache.ts
@@ -19,7 +19,8 @@ export const useUncompletedTodosCache = create<UncompletedTodosState>((set, get)
 
   fetch: async () => {
     try {
-      const todos = await todoApi.getUncompletedTodos()
+      const refTime = Math.floor(Date.now() / 1000)
+      const todos = await todoApi.getUncompletedTodos(refTime)
       set({ todos })
     } catch (e) {
       console.warn('미완료 Todo 로드 실패:', e)

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -7,8 +7,8 @@ function loadTheme(): Theme {
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
     if (stored === 'system' || stored === 'light' || stored === 'dark') return stored
-    return 'light'
-  } catch { return 'light' }
+    return 'system'
+  } catch { return 'system' }
 }
 
 function applyTheme(theme: Theme) {

--- a/tests/api/todoApi.test.ts
+++ b/tests/api/todoApi.test.ts
@@ -35,12 +35,13 @@ describe('todoApi', () => {
     expect((options as RequestInit).method).toBe('GET')
   })
 
-  it('getUncompletedTodos()가 /v1/todos/uncompleted로 GET 호출한다', async () => {
+  it('getUncompletedTodos(refTime)가 /v1/todos/uncompleted?refTime= 으로 GET 호출한다', async () => {
     const { todoApi } = await import('../../src/api/todoApi')
-    await todoApi.getUncompletedTodos()
+    await todoApi.getUncompletedTodos(1700000000)
 
     const [url, options] = fetchSpy.mock.calls[0]
     expect(String(url)).toContain('/v1/todos/uncompleted')
+    expect(String(url)).toContain('refTime=1700000000')
     expect((options as RequestInit).method).toBe('GET')
   })
 

--- a/tests/calendar/weekEventStackBuilder.test.ts
+++ b/tests/calendar/weekEventStackBuilder.test.ts
@@ -305,6 +305,49 @@ describe('buildWeekEventStack', () => {
     expect(result.rows[0][0].endCol).toBe(3)
   })
 
+  // #104: 같은 시작일/같은 길이의 두 이벤트 중 "종일(allday)" 이벤트가 시간 이벤트보다 위 row 에 와야 한다.
+  // iOS WeekEventStackBuilder.swift 정렬: length desc → eventRangesOnWeek.lowerBound asc.
+  // allday 의 lowerBound 는 그 날 00:00 이라 시간 이벤트(예: 10:00)보다 작아 자연스럽게 우선.
+  it('같은 날에 종일 이벤트와 시간 이벤트가 있으면 종일 이벤트가 위 row 에 배치된다 (#104)', () => {
+    // given: 화요일에 종일 이벤트 "피부과 예약"(이름이 알파벳순으로 뒤) + 시간 이벤트 "A standup"
+    const tueDateLocal = new Date(2026, 2, 3, 0, 0, 0, 0)
+    const offsetSec = -tueDateLocal.getTimezoneOffset() * 60
+    const tueStartTs = Math.floor(tueDateLocal.getTime() / 1000)
+    const allday: CalendarEvent = {
+      type: 'schedule',
+      event: {
+        uuid: 'allday',
+        name: '피부과 예약',
+        event_tag_id: null,
+        event_time: {
+          time_type: 'allday',
+          period_start: tueStartTs - offsetSec,
+          period_end: tueStartTs - offsetSec + 86400,
+          seconds_from_gmt: offsetSec,
+        },
+      } as Schedule,
+    }
+    const timed: CalendarEvent = {
+      type: 'schedule',
+      event: {
+        uuid: 'timed',
+        name: 'A standup',
+        event_tag_id: null,
+        event_time: { time_type: 'at', timestamp: tueStartTs + 10 * 3600 }, // 화요일 10시
+      } as Schedule,
+    }
+    const eventsByDate = new Map<string, CalendarEvent[]>([
+      ['2026-03-03', [allday, timed]],
+    ])
+
+    // when
+    const result = buildWeekEventStack(weekDays, eventsByDate)
+
+    // then: 첫 row 에 종일 이벤트가 들어가야 한다 (이름 정렬에 휘둘리지 않음)
+    expect(result.rows.length).toBe(2)
+    expect(result.rows[0].some(e => e.event.event.uuid === 'allday')).toBe(true)
+  })
+
   it('행 정렬: 커버하는 총 일수가 많은 행이 위에 온다', () => {
     // given:
     //   row1에 1일짜리 이벤트 2개 (총 2일 커버)

--- a/tests/calendar/weekEventStackBuilder.test.ts
+++ b/tests/calendar/weekEventStackBuilder.test.ts
@@ -321,8 +321,8 @@ describe('buildWeekEventStack', () => {
         event_tag_id: null,
         event_time: {
           time_type: 'allday',
-          period_start: tueStartTs - offsetSec,
-          period_end: tueStartTs - offsetSec + 86400,
+          period_start: tueStartTs,
+          period_end: tueStartTs + 86400 - 1, // iOS endOfDay: 그 날 23:59:59
           seconds_from_gmt: offsetSec,
         },
       } as Schedule,

--- a/tests/calendar/weekEventStackBuilder.test.ts
+++ b/tests/calendar/weekEventStackBuilder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildWeekEventStack } from '../../src/calendar/weekEventStackBuilder'
+import { buildWeekEventStack, computeMoreEventCounts } from '../../src/calendar/weekEventStackBuilder'
 import type { CalendarDay } from '../../src/calendar/calendarUtils'
 import type { CalendarEvent } from '../../src/domain/functions/eventTime'
 import type { Todo } from '../../src/models/Todo'
@@ -346,6 +346,66 @@ describe('buildWeekEventStack', () => {
     // then: 첫 row 에 종일 이벤트가 들어가야 한다 (이름 정렬에 휘둘리지 않음)
     expect(result.rows.length).toBe(2)
     expect(result.rows[0].some(e => e.event.event.uuid === 'allday')).toBe(true)
+  })
+
+  // #102: visibleRowCount 를 초과한 hidden row 들의 이벤트를 day(col) 별로 집계해
+  // 각 day cell 위치에 "+N" 라벨을 표시하기 위한 헬퍼.
+  describe('computeMoreEventCounts (#102)', () => {
+    it('visible row count 가 stack.rows.length 이상이면 빈 배열을 반환한다', () => {
+      // given: 1행 짜리 stack
+      const ev = makeTodoEvent('t1', 'Solo')
+      const eventsByDate = new Map<string, CalendarEvent[]>([['2026-03-03', [ev]]])
+      const stack = buildWeekEventStack(weekDays, eventsByDate)
+
+      // when / then
+      expect(computeMoreEventCounts(stack, 5, 7)).toEqual([])
+    })
+
+    it('hidden row 안 이벤트가 차지하는 각 col 에 +1 씩 카운팅된다', () => {
+      // given: 4행이 만들어지는 stack (모두 같은 화요일 col=3 에 4개 이벤트 → 4행)
+      const ev1 = makeTodoEvent('t1', 'A')
+      const ev2 = makeTodoEvent('t2', 'B')
+      const ev3 = makeTodoEvent('t3', 'C')
+      const ev4 = makeTodoEvent('t4', 'D')
+      const eventsByDate = new Map<string, CalendarEvent[]>([
+        ['2026-03-03', [ev1, ev2, ev3, ev4]], // Tue = col 3
+      ])
+      const stack = buildWeekEventStack(weekDays, eventsByDate)
+      expect(stack.rows.length).toBe(4)
+
+      // when: visible 2행만 → 2행 hidden, 각각 col 3 의 단일 이벤트
+      const counts = computeMoreEventCounts(stack, 2, 7)
+
+      // then: col 3 에 count 2
+      expect(counts).toEqual([{ col: 3, count: 2 }])
+    })
+
+    it('multi-day 이벤트가 hidden 되면 걸친 모든 col 에 +1 씩 더해진다', () => {
+      // given: 한 행에 multi-day(s1: col 2~5) 1개 — 다른 짧은 이벤트들로 이 multi-day 가 뒤로 밀려 hidden
+      // 짧은 이벤트들이 stack 위에 오게 만들기 위해 단순히 day 별 다수 이벤트로 row 늘림
+      const longEv = makeScheduleEvent('long', 'Multi-day')
+      const shortA = makeTodoEvent('a', 'a')
+      const shortB = makeTodoEvent('b', 'b')
+      const shortC = makeTodoEvent('c', 'c')
+      const eventsByDate = new Map<string, CalendarEvent[]>([
+        ['2026-03-02', [longEv, shortA]],
+        ['2026-03-03', [longEv, shortB]],
+        ['2026-03-04', [longEv, shortC]],
+        ['2026-03-05', [longEv]],
+      ])
+      const stack = buildWeekEventStack(weekDays, eventsByDate)
+      // longEv 가 가장 긴 4-day span 이라 첫 row. 그러므로 visible=1 이면 short 들이 hidden.
+      // hidden row 안의 1-day short 이벤트들이 각 col 에 표시되어야 한다.
+
+      // when: 첫 row 만 visible
+      const counts = computeMoreEventCounts(stack, 1, 7)
+
+      // then: hidden row 들의 short 이벤트가 각 col 에 1씩 (단일 이벤트들은 startCol == endCol)
+      const byCol = Object.fromEntries(counts.map(c => [c.col, c.count]))
+      expect(byCol[2]).toBe(1) // shortA
+      expect(byCol[3]).toBe(1) // shortB
+      expect(byCol[4]).toBe(1) // shortC
+    })
   })
 
   it('행 정렬: 커버하는 총 일수가 많은 행이 위에 온다', () => {

--- a/tests/components/ColorPalette.test.tsx
+++ b/tests/components/ColorPalette.test.tsx
@@ -19,13 +19,22 @@ describe('ColorPalette', () => {
     }
   })
 
+  // iOS 앱의 EventTagDetailViewModelImple.suggestColorHexes 와 동일한 풍부한 팔레트를 제공해야 한다.
+  // 8색짜리 빈약한 팔레트(이전 구현)에서는 사용자가 원하는 컬러를 고르기 어렵다는 QA 피드백.
+  it('iOS suggestColorHexes 와 동일한 풍부한 팔레트를 제공한다 (대표 색 검증)', () => {
+    const required = ['#F42D2D', '#FFA02E', '#F6DC41', '#1E90FF', '#6800f2', '#3CB371', '#FD838F']
+    for (const hex of required) {
+      expect(PRESET_COLORS).toContain(hex)
+    }
+  })
+
   it('선택된 색상 버튼은 aria-pressed="true" 가 되고 그 외는 "false" 다', () => {
     // given / when
-    render(<ColorPalette selected="#22c55e" onChange={() => {}} />)
+    render(<ColorPalette selected="#3CB371" onChange={() => {}} />)
 
     // then
-    expect(screen.getByRole('button', { name: labelPattern('#22c55e') })).toHaveAttribute('aria-pressed', 'true')
-    expect(screen.getByRole('button', { name: labelPattern('#ef4444') })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('button', { name: labelPattern('#3CB371') })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: labelPattern('#F42D2D') })).toHaveAttribute('aria-pressed', 'false')
   })
 
   it('모든 버튼은 type="button" 이라 form 내부에서도 submit 을 유발하지 않는다', () => {
@@ -40,19 +49,19 @@ describe('ColorPalette', () => {
   it('색상 버튼을 클릭하면 해당 색이 선택 상태로 전환된다', async () => {
     // given — 실제 상태를 가진 Wrapper 로 렌더
     function Wrapper() {
-      const [selected, setSelected] = useState('#ef4444')
+      const [selected, setSelected] = useState('#F42D2D')
       return <ColorPalette selected={selected} onChange={setSelected} />
     }
     const user = userEvent.setup()
     render(<Wrapper />)
-    expect(screen.getByRole('button', { name: labelPattern('#ef4444') })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: labelPattern('#F42D2D') })).toHaveAttribute('aria-pressed', 'true')
 
     // when — 다른 색 클릭
-    await user.click(screen.getByRole('button', { name: labelPattern('#22c55e') }))
+    await user.click(screen.getByRole('button', { name: labelPattern('#3CB371') }))
 
     // then — 선택 상태가 새 색으로 이동 (사용자 관점 결과)
-    expect(screen.getByRole('button', { name: labelPattern('#22c55e') })).toHaveAttribute('aria-pressed', 'true')
-    expect(screen.getByRole('button', { name: labelPattern('#ef4444') })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('button', { name: labelPattern('#3CB371') })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: labelPattern('#F42D2D') })).toHaveAttribute('aria-pressed', 'false')
   })
 
   it('custom colors prop 이 주어지면 해당 색상만 렌더한다 (기본 PRESET 무시)', () => {

--- a/tests/domain/functions/eventTime.test.ts
+++ b/tests/domain/functions/eventTime.test.ts
@@ -25,10 +25,18 @@ describe('eventTimeToStartDate', () => {
     expect(date.getTime()).toBe(1700000000 * 1000)
   })
 
-  it('"allday" 타입이면 period_start + seconds_from_gmt로 변환한다', () => {
-    const et: EventTime = { time_type: 'allday', period_start: 1700000000, period_end: 1700086400, seconds_from_gmt: 32400 }
+  // 종일 이벤트는 등록 timezone (seconds_from_gmt) 을 고정 기준으로 잡아 그 tz 의 일자를 표시해야
+  // 사용자 환경 timezone 과 무관하게 "이벤트가 등록된 날짜" 가 보존된다.
+  // 결과 Date 는 사용자 로컬 자정 — 캘린더 day-cell 에 정확히 매핑 가능.
+  it('"allday" 의 startDate 는 event tz (seconds_from_gmt) 기준 시작 일자의 사용자 로컬 자정 Date 를 반환한다', () => {
+    // KST(+9) 2026-05-15 00:00 시작 종일.
+    // period_start = KST 5/15 00:00 의 UTC seconds = UTC 5/14 15:00
+    const periodStart = Math.floor(Date.UTC(2026, 4, 14, 15, 0, 0) / 1000)
+    const offset = 9 * 3600
+    const et: EventTime = { time_type: 'allday', period_start: periodStart, period_end: periodStart + 86400 - 1, seconds_from_gmt: offset }
     const date = eventTimeToStartDate(et)
-    expect(date.getTime()).toBe((1700000000 + 32400) * 1000)
+    expect([date.getFullYear(), date.getMonth(), date.getDate()]).toEqual([2026, 4, 15])
+    expect([date.getHours(), date.getMinutes(), date.getSeconds()]).toEqual([0, 0, 0])
   })
 })
 
@@ -39,13 +47,17 @@ describe('eventTimeToEndDate', () => {
     expect(date.getTime()).toBe(1700100000 * 1000)
   })
 
-  // iOS EventTime.allDay(Range, secondsFromGMT) 는 half-open [lower, upper) 의미. upper 는 종료 다음 날 00:00.
-  // 캘린더 표시에서 endDay 비교에 직접 쓰이므로 1일(86400s) 차감해 "마지막 날의 시각" 으로 변환되어야
-  // assignInstance 의 while(cur <= endDay) 가 종료일까지만 포함하고 다음 날을 +1일 더 표시하지 않는다.
-  it('"allday" 타입이면 (period_end + offset - 86400) 의 Date 즉 마지막 종일 일자의 시각을 반환한다', () => {
-    const et: EventTime = { time_type: 'allday', period_start: 1700000000, period_end: 1700086400, seconds_from_gmt: 32400 }
+  // iOS Calendar.endOfDay 가 "그 날 23:59:59" 를 반환하므로 period_end 는 종료 날의 마지막 초.
+  // event tz 고정 변환을 거치면 종료 일자 그대로 추출 → 사용자 로컬 자정 Date 로 매핑.
+  it('"allday" 의 endDate 는 event tz 기준 종료 일자의 사용자 로컬 자정 Date 를 반환한다 (iOS endOfDay 패턴)', () => {
+    // KST(+9) 2026-05-15 ~ 2026-05-17 (3일 종일). period_end = KST 5/17 23:59:59 의 UTC seconds
+    const periodStart = Math.floor(Date.UTC(2026, 4, 14, 15, 0, 0) / 1000)
+    const periodEnd = periodStart + 3 * 86400 - 1
+    const offset = 9 * 3600
+    const et: EventTime = { time_type: 'allday', period_start: periodStart, period_end: periodEnd, seconds_from_gmt: offset }
     const date = eventTimeToEndDate(et)
-    expect(date.getTime()).toBe((1700086400 + 32400 - 86400) * 1000)
+    expect([date.getFullYear(), date.getMonth(), date.getDate()]).toEqual([2026, 4, 17])
+    expect([date.getHours(), date.getMinutes(), date.getSeconds()]).toEqual([0, 0, 0])
   })
 })
 
@@ -268,14 +280,16 @@ describe('groupEventsByDate', () => {
     expect((e3.event as Schedule).show_turns).toEqual([3])
   })
 
-  // #103: 종일 이벤트의 period_end 는 종료 다음 날 00:00 (half-open exclusive bound) 이라
-  // 가공 없이 그대로 day enumerate 하면 종료 다음 날에도 이벤트가 표시되어 +1일 버그가 났다.
+  // #103: 종일 이벤트는 등록 시 정한 timezone(seconds_from_gmt) 의 일자가 의미 단위.
+  // event tz 를 고정 기준으로 잡고 그 tz 의 일자만 추출해 사용자 로컬 자정 Date 로 변환하면
+  // 사용자 환경 tz 와 무관하게 "이벤트가 등록된 날짜" 가 캘린더 day-cell 에 그대로 매핑된다.
+  // iOS Calendar.endOfDay 패턴: period_end = period_start + N*86400 - 1 (그 날 23:59:59).
   it('1일짜리 종일(allday) 이벤트는 시작일 하루에만 그룹핑되고 다음 날에는 표시되지 않는다 (#103)', () => {
-    // given: 사용자 로컬 tz 기준 어느 하루에 해당하는 종일 이벤트
-    // local midnight 기준으로 정확히 24시간 = 1일
-    const dayStart = new Date(2024, 5, 15, 0, 0, 0, 0) // 로컬 06-15 00:00
-    const dayEnd = new Date(2024, 5, 16, 0, 0, 0, 0)   // 로컬 06-16 00:00 (exclusive)
-    const offset = -dayStart.getTimezoneOffset() * 60   // 환경 tz의 secondsFromGMT
+    // given: 사용자 환경 tz == 데이터 tz 가정. 로컬 6/15 00:00 ~ 6/15 23:59:59 종일.
+    const dayStart = new Date(2024, 5, 15, 0, 0, 0, 0)
+    const offset = -dayStart.getTimezoneOffset() * 60
+    const periodStart = dateToTimestamp(dayStart)
+    const periodEnd = periodStart + 86400 - 1  // iOS endOfDay: 그 날 23:59:59
     const lower = dateToTimestamp(new Date(2024, 5, 1))
     const upper = dateToTimestamp(new Date(2024, 5, 30, 23, 59, 59))
 
@@ -285,8 +299,8 @@ describe('groupEventsByDate', () => {
         name: 'AllDay 1일',
         event_time: {
           time_type: 'allday',
-          period_start: dateToTimestamp(dayStart) - offset, // tz의 그 날 00:00 을 GMT seconds 로
-          period_end: dateToTimestamp(dayEnd) - offset,
+          period_start: periodStart,
+          period_end: periodEnd,
           seconds_from_gmt: offset,
         },
       },
@@ -300,11 +314,12 @@ describe('groupEventsByDate', () => {
     expect(result.get('2024-06-16')).toBeUndefined()
   })
 
-  it('3일짜리 종일(allday) 이벤트는 정확히 3일에만 그룹핑된다 (다음 날 +1일 누락)', () => {
+  it('3일짜리 종일(allday) 이벤트는 정확히 3일에만 그룹핑된다', () => {
     // given: 06-15 ~ 06-17 종일 (3일)
     const dayStart = new Date(2024, 5, 15, 0, 0, 0, 0)
-    const dayEndExclusive = new Date(2024, 5, 18, 0, 0, 0, 0) // 06-18 00:00 (exclusive)
     const offset = -dayStart.getTimezoneOffset() * 60
+    const periodStart = dateToTimestamp(dayStart)
+    const periodEnd = periodStart + 3 * 86400 - 1
     const lower = dateToTimestamp(new Date(2024, 5, 1))
     const upper = dateToTimestamp(new Date(2024, 5, 30, 23, 59, 59))
 
@@ -314,8 +329,8 @@ describe('groupEventsByDate', () => {
         name: 'AllDay 3일',
         event_time: {
           time_type: 'allday',
-          period_start: dateToTimestamp(dayStart) - offset,
-          period_end: dateToTimestamp(dayEndExclusive) - offset,
+          period_start: periodStart,
+          period_end: periodEnd,
           seconds_from_gmt: offset,
         },
       },

--- a/tests/domain/functions/eventTime.test.ts
+++ b/tests/domain/functions/eventTime.test.ts
@@ -38,6 +38,15 @@ describe('eventTimeToEndDate', () => {
     const date = eventTimeToEndDate(et)
     expect(date.getTime()).toBe(1700100000 * 1000)
   })
+
+  // iOS EventTime.allDay(Range, secondsFromGMT) 는 half-open [lower, upper) 의미. upper 는 종료 다음 날 00:00.
+  // 캘린더 표시에서 endDay 비교에 직접 쓰이므로 1일(86400s) 차감해 "마지막 날의 시각" 으로 변환되어야
+  // assignInstance 의 while(cur <= endDay) 가 종료일까지만 포함하고 다음 날을 +1일 더 표시하지 않는다.
+  it('"allday" 타입이면 (period_end + offset - 86400) 의 Date 즉 마지막 종일 일자의 시각을 반환한다', () => {
+    const et: EventTime = { time_type: 'allday', period_start: 1700000000, period_end: 1700086400, seconds_from_gmt: 32400 }
+    const date = eventTimeToEndDate(et)
+    expect(date.getTime()).toBe((1700086400 + 32400 - 86400) * 1000)
+  })
 })
 
 describe('dateToTimestamp', () => {
@@ -257,6 +266,69 @@ describe('groupEventsByDate', () => {
     expect((e1.event as Schedule).show_turns).toEqual([1])
     expect((e2.event as Schedule).show_turns).toEqual([2])
     expect((e3.event as Schedule).show_turns).toEqual([3])
+  })
+
+  // #103: 종일 이벤트의 period_end 는 종료 다음 날 00:00 (half-open exclusive bound) 이라
+  // 가공 없이 그대로 day enumerate 하면 종료 다음 날에도 이벤트가 표시되어 +1일 버그가 났다.
+  it('1일짜리 종일(allday) 이벤트는 시작일 하루에만 그룹핑되고 다음 날에는 표시되지 않는다 (#103)', () => {
+    // given: 사용자 로컬 tz 기준 어느 하루에 해당하는 종일 이벤트
+    // local midnight 기준으로 정확히 24시간 = 1일
+    const dayStart = new Date(2024, 5, 15, 0, 0, 0, 0) // 로컬 06-15 00:00
+    const dayEnd = new Date(2024, 5, 16, 0, 0, 0, 0)   // 로컬 06-16 00:00 (exclusive)
+    const offset = -dayStart.getTimezoneOffset() * 60   // 환경 tz의 secondsFromGMT
+    const lower = dateToTimestamp(new Date(2024, 5, 1))
+    const upper = dateToTimestamp(new Date(2024, 5, 30, 23, 59, 59))
+
+    const schedules: Schedule[] = [
+      {
+        uuid: 's-allday-1d',
+        name: 'AllDay 1일',
+        event_time: {
+          time_type: 'allday',
+          period_start: dateToTimestamp(dayStart) - offset, // tz의 그 날 00:00 을 GMT seconds 로
+          period_end: dateToTimestamp(dayEnd) - offset,
+          seconds_from_gmt: offset,
+        },
+      },
+    ]
+
+    // when
+    const result = groupEventsByDate([], schedules, lower, upper)
+
+    // then: 06-15 만 들어가고 06-16 은 비어 있다
+    expect(result.get('2024-06-15')).toHaveLength(1)
+    expect(result.get('2024-06-16')).toBeUndefined()
+  })
+
+  it('3일짜리 종일(allday) 이벤트는 정확히 3일에만 그룹핑된다 (다음 날 +1일 누락)', () => {
+    // given: 06-15 ~ 06-17 종일 (3일)
+    const dayStart = new Date(2024, 5, 15, 0, 0, 0, 0)
+    const dayEndExclusive = new Date(2024, 5, 18, 0, 0, 0, 0) // 06-18 00:00 (exclusive)
+    const offset = -dayStart.getTimezoneOffset() * 60
+    const lower = dateToTimestamp(new Date(2024, 5, 1))
+    const upper = dateToTimestamp(new Date(2024, 5, 30, 23, 59, 59))
+
+    const schedules: Schedule[] = [
+      {
+        uuid: 's-allday-3d',
+        name: 'AllDay 3일',
+        event_time: {
+          time_type: 'allday',
+          period_start: dateToTimestamp(dayStart) - offset,
+          period_end: dateToTimestamp(dayEndExclusive) - offset,
+          seconds_from_gmt: offset,
+        },
+      },
+    ]
+
+    // when
+    const result = groupEventsByDate([], schedules, lower, upper)
+
+    // then
+    expect(result.get('2024-06-15')).toHaveLength(1)
+    expect(result.get('2024-06-16')).toHaveLength(1)
+    expect(result.get('2024-06-17')).toHaveLength(1)
+    expect(result.get('2024-06-18')).toBeUndefined()
   })
 
   it('exclude_repeatings에 있는 turn은 건너뛴다', () => {

--- a/tests/pages/settings/tagManagement/TagEditPanel.test.tsx
+++ b/tests/pages/settings/tagManagement/TagEditPanel.test.tsx
@@ -110,7 +110,7 @@ describe('TagEditPanel — create 모드', () => {
     const user = userEvent.setup()
     const onBack = vi.fn()
     const { eventTagApi } = await import('../../../../src/api/eventTagApi')
-    vi.mocked(eventTagApi.createTag).mockResolvedValue({ uuid: 'new-id', name: '신규', color_hex: '#22c55e' })
+    vi.mocked(eventTagApi.createTag).mockResolvedValue({ uuid: 'new-id', name: '신규', color_hex: '#3CB371' })
     renderPanel({ kind: 'create' }, onBack, repos)
 
     // when
@@ -174,7 +174,7 @@ describe('TagEditPanel — edit(custom) 모드', () => {
     const user = userEvent.setup()
     const onBack = vi.fn()
     const { eventTagApi } = await import('../../../../src/api/eventTagApi')
-    vi.mocked(eventTagApi.updateTag).mockResolvedValue({ uuid: 'tag-1', name: '새이름', color_hex: '#22c55e' })
+    vi.mocked(eventTagApi.updateTag).mockResolvedValue({ uuid: 'tag-1', name: '새이름', color_hex: '#3CB371' })
     renderPanel({ kind: 'edit', row: customRow }, onBack, repos)
 
     // when
@@ -280,16 +280,16 @@ describe('TagEditPanel — edit(default) 모드', () => {
     const user = userEvent.setup()
     const onBack = vi.fn()
     const { settingApi } = await import('../../../../src/api/settingApi')
-    vi.mocked(settingApi.updateDefaultTagColors).mockResolvedValue({ default: '#22c55e', holiday: '#ef4444' })
+    vi.mocked(settingApi.updateDefaultTagColors).mockResolvedValue({ default: '#3CB371', holiday: '#ef4444' })
     renderPanel({ kind: 'edit', row: defaultRow }, onBack, repos)
 
-    // when: 두 번째 색상 팔레트 버튼(#22c55e) 선택 후 저장
-    await user.click(screen.getByRole('button', { name: /(?:색상 선택|Select color):\s*#22c55e/ }))
+    // when: 새 팔레트의 green(#3CB371) 선택 후 저장
+    await user.click(screen.getByRole('button', { name: /(?:색상 선택|Select color):\s*#3CB371/ }))
     await user.click(screen.getByRole('button', { name: '저장' }))
 
     // then: 캐시의 default 색상이 갱신됨
     await waitFor(() =>
-      expect(useEventTagListCache.getState().defaultTagColors?.default).toBe('#22c55e'),
+      expect(useEventTagListCache.getState().defaultTagColors?.default).toBe('#3CB371'),
     )
     expect(onBack).toHaveBeenCalled()
   })
@@ -323,16 +323,16 @@ describe('TagEditPanel — edit(holiday) 모드', () => {
     const user = userEvent.setup()
     const onBack = vi.fn()
     const { settingApi } = await import('../../../../src/api/settingApi')
-    vi.mocked(settingApi.updateDefaultTagColors).mockResolvedValue({ default: '#4A90D9', holiday: '#22c55e' })
+    vi.mocked(settingApi.updateDefaultTagColors).mockResolvedValue({ default: '#4A90D9', holiday: '#3CB371' })
     renderPanel({ kind: 'edit', row: holidayRow }, onBack, repos)
 
     // when
-    await user.click(screen.getByRole('button', { name: /(?:색상 선택|Select color):\s*#22c55e/ }))
+    await user.click(screen.getByRole('button', { name: /(?:색상 선택|Select color):\s*#3CB371/ }))
     await user.click(screen.getByRole('button', { name: '저장' }))
 
     // then
     await waitFor(() =>
-      expect(useEventTagListCache.getState().defaultTagColors?.holiday).toBe('#22c55e'),
+      expect(useEventTagListCache.getState().defaultTagColors?.holiday).toBe('#3CB371'),
     )
     expect(onBack).toHaveBeenCalled()
   })

--- a/tests/repositories/HolidayRepository.test.ts
+++ b/tests/repositories/HolidayRepository.test.ts
@@ -115,6 +115,46 @@ describe('HolidayRepository', () => {
     })
   })
 
+  // #99: 메인 캘린더 새로고침 시 같은 year 에 대해 holidayRepo.fetch 가 여러 effect 에서
+  // 동시에 trigger 되어 같은 API 가 여러 벌 나가던 트래픽 낭비를 막기 위한 in-flight dedup.
+  describe('fetch — in-flight dedup (#99)', () => {
+    it('같은 year 에 대해 동시 fetch 호출 시 API 는 한 번만 호출된다', async () => {
+      // given: 응답이 즉시 resolve 되지 않도록 deferred 패턴
+      let resolveFn!: (v: HolidayResponse) => void
+      const pending = new Promise<HolidayResponse>(r => { resolveFn = r })
+      const getHolidays = vi.fn(() => pending)
+      const fakeApi: HolidayApi = { getHolidays }
+      const repo = new HolidayRepository({ api: fakeApi, initialLocale: 'en' })
+
+      // when: 같은 year 동시 두 번 trigger
+      const p1 = repo.fetch(2026)
+      const p2 = repo.fetch(2026)
+      resolveFn(makeHolidayResponse([{ summary: '신정', date: '2026-01-01' }]))
+      await Promise.all([p1, p2])
+
+      // then: API 가 한 번만 호출되었다 (네트워크 트래픽 절감 — 사용자 관찰 가능 행위)
+      expect(getHolidays).toHaveBeenCalledTimes(1)
+      // 그리고 결과는 정상 반영
+      expect(repo.getHolidaysSnapshot(2026)).toEqual(
+        expect.arrayContaining([expect.objectContaining({ summary: '신정' })])
+      )
+    })
+
+    it('첫 fetch 가 끝난 뒤 다시 호출하면 새로 fetch 된다 (in-flight 만 dedup, 완료 후엔 통과)', async () => {
+      // given
+      const getHolidays = vi.fn(async () => makeHolidayResponse([{ summary: '신정', date: '2026-01-01' }]))
+      const fakeApi: HolidayApi = { getHolidays }
+      const repo = new HolidayRepository({ api: fakeApi, initialLocale: 'en' })
+
+      // when
+      await repo.fetch(2026)
+      await repo.fetch(2026)
+
+      // then: 두 번 호출 (in-flight 윈도우 밖이라 둘 다 수행 — refresh 시나리오 보장)
+      expect(getHolidays).toHaveBeenCalledTimes(2)
+    })
+  })
+
   describe('fetch — 연도별 독립', () => {
     it('2025년 fetch 후 2026년 fetch해도 2025년 캐시는 보존된다', async () => {
       // given: 연도에 따라 다른 공휴일을 반환

--- a/tests/repositories/caches/holidayCache.test.ts
+++ b/tests/repositories/caches/holidayCache.test.ts
@@ -29,6 +29,59 @@ describe('holidayCache', () => {
       expect(useHolidayCache.getState().getHolidayNames('2026-03-01')).toEqual(['삼일절'])
       expect(useHolidayCache.getState().getHolidayNames('2026-06-15')).toEqual([])
     })
+
+    // 다중 fetch 트리거(StrictMode 이중 effect, 여러 화면이 같은 year를 동시에 fetch 하는 등) 로
+    // 같은 year에 대해 setHolidaysForYear 가 중복 호출되어도 결과는 idempotent 해야 한다.
+    it('같은 연도로 중복 호출해도 같은 공휴일이 누적되지 않는다 (idempotent replace)', () => {
+      // given: 2026년 공휴일이 한 번 저장됐다
+      const items = [
+        { summary: '신정', start: { date: '2026-01-01' }, end: { date: '2026-01-02' } },
+        { summary: '삼일절', start: { date: '2026-03-01' }, end: { date: '2026-03-02' } },
+      ]
+      useHolidayCache.getState().setHolidaysForYear(2026, items)
+
+      // when: 같은 연도 같은 데이터로 한 번 더 호출
+      useHolidayCache.getState().setHolidaysForYear(2026, items)
+
+      // then: 같은 날짜를 조회해도 공휴일 이름이 한 번만 나온다
+      expect(useHolidayCache.getState().getHolidayNames('2026-01-01')).toEqual(['신정'])
+      expect(useHolidayCache.getState().getHolidayNames('2026-03-01')).toEqual(['삼일절'])
+    })
+
+    it('같은 연도라도 다른 항목 집합으로 다시 호출하면 새 집합으로 교체된다', () => {
+      // given: 2026년 공휴일 1세트
+      useHolidayCache.getState().setHolidaysForYear(2026, [
+        { summary: '신정', start: { date: '2026-01-01' }, end: { date: '2026-01-02' } },
+      ])
+
+      // when: 같은 연도에 다른 항목 세트로 교체 호출
+      useHolidayCache.getState().setHolidaysForYear(2026, [
+        { summary: '삼일절', start: { date: '2026-03-01' }, end: { date: '2026-03-02' } },
+      ])
+
+      // then: 새 세트만 남고 이전 1월 1일 공휴일은 사라진다
+      expect(useHolidayCache.getState().getHolidayNames('2026-01-01')).toEqual([])
+      expect(useHolidayCache.getState().getHolidayNames('2026-03-01')).toEqual(['삼일절'])
+    })
+
+    it('다른 연도 캐시는 같은 연도 재호출의 영향을 받지 않는다', () => {
+      // given: 2025/2026 둘 다 로드된 상태
+      useHolidayCache.getState().setHolidaysForYear(2025, [
+        { summary: '신정', start: { date: '2025-01-01' }, end: { date: '2025-01-02' } },
+      ])
+      useHolidayCache.getState().setHolidaysForYear(2026, [
+        { summary: '신정', start: { date: '2026-01-01' }, end: { date: '2026-01-02' } },
+      ])
+
+      // when: 2026년만 다시 호출
+      useHolidayCache.getState().setHolidaysForYear(2026, [
+        { summary: '신정', start: { date: '2026-01-01' }, end: { date: '2026-01-02' } },
+      ])
+
+      // then: 2025년은 그대로
+      expect(useHolidayCache.getState().getHolidayNames('2025-01-01')).toEqual(['신정'])
+      expect(useHolidayCache.getState().getHolidayNames('2026-01-01')).toEqual(['신정'])
+    })
   })
 
   describe('clearYear', () => {

--- a/tests/repositories/caches/uncompletedTodosCache.test.ts
+++ b/tests/repositories/caches/uncompletedTodosCache.test.ts
@@ -64,4 +64,24 @@ describe('useUncompletedTodosCache', () => {
     // then: 빈 목록
     expect(useUncompletedTodosCache.getState().todos).toEqual([])
   })
+
+  // #99: 동일 cache 에 동시 fetch 호출 시 (AuthGuard + useMainViewModel + StrictMode 이중 effect 등) API 1회만.
+  it('동시에 여러 번 fetch 호출 시 API 는 한 번만 호출된다 (in-flight dedup)', async () => {
+    // given: 응답이 즉시 resolve 되지 않게 deferred
+    const { todoApi } = await import('../../../src/api/todoApi')
+    let resolveFn!: (v: Todo[]) => void
+    const pending = new Promise<Todo[]>(r => { resolveFn = r })
+    vi.mocked(todoApi.getUncompletedTodos).mockReturnValue(pending)
+
+    // when: 동시에 3번 호출
+    const p1 = useUncompletedTodosCache.getState().fetch()
+    const p2 = useUncompletedTodosCache.getState().fetch()
+    const p3 = useUncompletedTodosCache.getState().fetch()
+    resolveFn([makeTodo('u1', '미완료')])
+    await Promise.all([p1, p2, p3])
+
+    // then: API 는 1회만 호출 — 사용자 관찰 가능 행위 (네트워크 트래픽 절감)
+    expect(todoApi.getUncompletedTodos).toHaveBeenCalledTimes(1)
+    expect(useUncompletedTodosCache.getState().todos).toHaveLength(1)
+  })
 })

--- a/tests/stores/themeStore.test.ts
+++ b/tests/stores/themeStore.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+describe('themeStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.classList.remove('dark')
+    vi.resetModules()
+  })
+
+  it('localStorage에 저장된 값이 없으면 디폴트 테마는 system이다', async () => {
+    // when
+    const { useThemeStore } = await import('../../src/stores/themeStore')
+
+    // then
+    expect(useThemeStore.getState().theme).toBe('system')
+  })
+
+  it('localStorage에 저장된 값이 있으면 해당 테마로 초기화된다', async () => {
+    // given
+    localStorage.setItem('theme', 'dark')
+
+    // when
+    const { useThemeStore } = await import('../../src/stores/themeStore')
+
+    // then
+    expect(useThemeStore.getState().theme).toBe('dark')
+  })
+
+  it('setTheme 호출 시 localStorage에 저장되고 state가 갱신된다', async () => {
+    // given
+    const { useThemeStore } = await import('../../src/stores/themeStore')
+
+    // when
+    useThemeStore.getState().setTheme('light')
+
+    // then
+    expect(useThemeStore.getState().theme).toBe('light')
+    expect(localStorage.getItem('theme')).toBe('light')
+  })
+})


### PR DESCRIPTION
## Summary

오늘(2026-05-03) QA에서 발견된 메인 캘린더·우측 패널·설정 영역 8개 이슈를 한 브랜치로 묶어 수정. 단순 → 복잡 순서로 commit 분할, 각 commit 은 단독으로 빌드/테스트 통과.

## Closes

- closes #97 — 이벤트 태그 색상 팔레트 확대 (iOS suggestColorHexes 27색)
- closes #98 — uncompleted todo 400 (refTime 쿼리 누락)
- closes #99 — 메인 캘린더 새로고침 시 holiday API 다중 호출 (in-flight dedup)
- closes #100 — 외형/테마 디폴트 light → system
- closes #101 — 우측 이벤트 패널 공휴일 중복 노출 (idempotent setHolidaysForYear)
- closes #102 — +N more 라벨 위치(day cell 단위)/폰트 정정
- closes #103 — 종일 이벤트가 종료 다음 날까지 +1일 더 표시
- closes #104 — 메인 캘린더 이벤트 정렬 (WeekEventStackBuilder 정합)

## 주요 변경 (commit 단위)

| 이슈 | 핵심 변경 |
|---|---|
| #100 | `themeStore.loadTheme` 디폴트 'system'. localStorage 미저장 시 OS prefers-color-scheme 따른다. |
| #98 | `todoApi.getUncompletedTodos(refTime: number)` 시그니처 + URL `?refTime=` 부착. 호출자 4곳 (`uncompletedTodosCache`, `EventRepository`, `testDataSeeder`) 모두 `Math.floor(Date.now()/1000)` 전달. iOS `loadUncompletedTodosFromRemote(now)` 와 동일. |
| #97 | `ColorPalette.PRESET_COLORS` 8 → 27 (iOS `EventTagDetailViewModelImple.suggestColorHexes`). dev seeder/preview 의 인덱스 매핑도 새 팔레트의 의미별 색에 맞춰 정정. |
| #101 | `holidayCache.setHolidaysForYear` append-only → idempotent replace (year 키 clear 후 채움 + items 자체 dedup). 다중 fetch trigger 가 누적되지 않는다. |
| #103 | `eventTime.eventTimeToEndDate` allday 케이스에서 `period_end + offset - 86400` 으로 마지막 종일 일자의 시각 반환. iOS `EventTime.allDay` 의 half-open `[lower, upper)` 의미 정합. |
| #104 | `weekEventStackBuilder` 정렬: 이름 비교 제거 + 시작 timestamp asc 추가 (종일이 시간 이벤트보다 위). 행 정렬에 이벤트 개수 asc tie-break 추가. iOS `WeekEventStackBuilder` 와 정합. |
| #102 | `+N more` 라벨을 row 전체 (col-span-7) 단일 합계 → day(col) 단위 위치 표시로 교체. `computeMoreEventCounts(stack, visibleRowCount, weekDayCount)` 헬퍼 도입. |
| #99 | `HolidayRepository` 에 inFlight Map dedup 추가. 같은 year 동시 호출 시 promise 공유 → API 1회 호출. (todos/uncompleted/foremost/tags 의 dev StrictMode 이중 effect 가 prod 에서도 문제인지 별도 추가 확인 필요) |

## Test plan

- [x] `npx vitest run` — 103 files / 818 tests pass
- [x] `npx tsc --noEmit` — clean
- [ ] dev 서버 띄워 새로고침 시 Network 패널에서 `holidays` GET 이 year 당 1회만 나가는지 확인 (#99 본질 확정)
- [ ] 종일 이벤트(1일/다일) 가 캘린더/이벤트 목록에서 정확히 시작~종료일에만 표시되는지 (#103)
- [ ] 우측 패널에서 같은 공휴일 이름 1회만 표시 (#101)
- [ ] 메인 캘린더에 종일+시간 이벤트 동시 존재 시 종일이 위 row (#104)
- [ ] medium 모드에서 hidden 이벤트 발생 시 해당 day cell 위치에 +N 라벨 (#102)
- [ ] 외형 설정 진입 시 디폴트 system (#100)
- [ ] 태그 생성 시 27색 팔레트 노출 (#97)
- [ ] uncompleted todo 호출 200 응답 (#98)

🤖 Generated with [Claude Code](https://claude.com/claude-code)