### PR TITLE
[#106] 종일-기간 이벤트 캘린더 단일(at) 표시 수정 — web allday 데이터 포맷 iOS 패턴 정합

### DIFF
--- a/src/calendar/MainCalendarGrid.tsx
+++ b/src/calendar/MainCalendarGrid.tsx
@@ -59,7 +59,9 @@ function EventBar({ ev, timeType, showEventNames, fontSizeWeight, onEventClick }
       data-testid="event-bar"
       style={{
         gridColumn: `${ev.startCol} / ${ev.endCol + 1}`,
-        backgroundColor: isAtTime ? 'transparent' : `${color}22`,
+        // #106: 옛 alpha 22(12%) → 44(27%) 도 다크/라이트 모두 너무 옅어 chip 영역이 식별 안 됨.
+        // 88(53%) 로 키워 텍스트 가독성을 유지하면서 chip span 이 명확히 보이도록.
+        backgroundColor: isAtTime ? 'transparent' : `${color}88`,
         fontSize,
       }}
       onClick={(e) => {

--- a/src/components/eventForm/EventTimePickerCore.tsx
+++ b/src/components/eventForm/EventTimePickerCore.tsx
@@ -18,12 +18,6 @@ function datetimeLocalToTs(v: string): number | null {
   return isNaN(ts) ? null : Math.floor(ts / 1000)
 }
 
-function tsToDateInput(ts: number): string {
-  const d = new Date(ts * 1000)
-  const p = (n: number) => String(n).padStart(2, '0')
-  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`
-}
-
 function dateInputToTs(v: string): number | null {
   if (!v) return null
   const ts = new Date(v + 'T00:00:00').getTime()

--- a/src/components/eventForm/EventTimePickerCore.tsx
+++ b/src/components/eventForm/EventTimePickerCore.tsx
@@ -34,6 +34,47 @@ function localSecondsFromGmt(): number {
   return -(new Date().getTimezoneOffset() * 60)
 }
 
+function startOfTodayTs(): number {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  return Math.floor(d.getTime() / 1000)
+}
+
+// #106: iOS EventTime.allDay 와 동일한 포맷으로 emit 한다.
+//   period_start = event tz 의 시작일 00:00 epoch
+//   period_end   = event tz 의 종료일 23:59:59 epoch (Calendar.endOfDay 패턴, +86400-1)
+// 이 포맷이어야 alldayLocalDate(#103) 의 (period + offset) UTC date 추출이 정확히 일자를 잡고
+// 캘린더에 다일로 표시된다.
+
+export function newAlldayEventTime(secondsFromGMT: number): EventTime {
+  const start = startOfTodayTs()
+  return { time_type: 'allday', period_start: start, period_end: start + 86400 - 1, seconds_from_gmt: secondsFromGMT }
+}
+
+export function alldayWithStart(prev: EventTime, newStartTs: number): EventTime {
+  if (prev.time_type !== 'allday') return prev
+  // 시작이 종료보다 뒤로 가면 종료를 시작 + 86400 - 1 (1일 종일) 로 정정
+  const period_end = prev.period_end < newStartTs ? newStartTs + 86400 - 1 : prev.period_end
+  return { ...prev, period_start: newStartTs, period_end }
+}
+
+// 입력은 종료 날짜의 자정 epoch (dateInputToTs 결과). +86400-1 로 그 날 23:59:59 로 변환.
+// 시작보다 앞서면 null 반환 (변경 거부).
+export function alldayWithEnd(prev: EventTime, newEndDateTs: number): EventTime | null {
+  if (prev.time_type !== 'allday') return null
+  const period_end = newEndDateTs + 86400 - 1
+  if (period_end < prev.period_start) return null
+  return { ...prev, period_end }
+}
+
+// allday date input 의 value (yyyy-mm-dd) 표시: event tz (secondsFromGMT) 기준 일자를 추출.
+// (period + offset) timestamp 의 UTC wall-clock 시각이 곧 event tz 의 wall-clock — UTC 메소드로 yyyy-mm-dd 추출.
+export function alldayDateInputValue(periodSeconds: number, secondsFromGMT: number): string {
+  const wall = new Date((periodSeconds + secondsFromGMT) * 1000)
+  const p = (n: number) => String(n).padStart(2, '0')
+  return `${wall.getUTCFullYear()}-${p(wall.getUTCMonth() + 1)}-${p(wall.getUTCDate())}`
+}
+
 // --- Component ---
 
 type TimeType = 'none' | 'at' | 'period' | 'allday'
@@ -70,7 +111,7 @@ export function EventTimePickerCore({ value, onChange, allowNone }: EventTimePic
     } else if (type === 'period') {
       next = { time_type: 'period', period_start: now, period_end: now + 3600 }
     } else {
-      next = { time_type: 'allday', period_start: now, period_end: now, seconds_from_gmt: localSecondsFromGmt() }
+      next = newAlldayEventTime(localSecondsFromGmt())
     }
     onChange(next)
   }
@@ -194,11 +235,11 @@ export function EventTimePickerCore({ value, onChange, allowNone }: EventTimePic
               aria-label={t('eventTime.start_date')}
               type="date"
               className={inputClass}
-              value={tsToDateInput(value.period_start + value.seconds_from_gmt)}
+              value={alldayDateInputValue(value.period_start, value.seconds_from_gmt)}
               onChange={e => {
                 const ts = dateInputToTs(e.target.value)
                 if (ts === null || value.time_type !== 'allday') return
-                onChange({ ...value, period_start: ts - value.seconds_from_gmt })
+                onChange(alldayWithStart(value, ts))
               }}
             />
           </div>
@@ -209,13 +250,13 @@ export function EventTimePickerCore({ value, onChange, allowNone }: EventTimePic
               aria-label={t('eventTime.end_date')}
               type="date"
               className={inputClass}
-              value={tsToDateInput(value.period_end + value.seconds_from_gmt)}
+              value={alldayDateInputValue(value.period_end, value.seconds_from_gmt)}
               onChange={e => {
                 const ts = dateInputToTs(e.target.value)
                 if (ts === null || value.time_type !== 'allday') return
-                const newEnd = ts - value.seconds_from_gmt
-                if (newEnd < value.period_start) return
-                onChange({ ...value, period_end: newEnd })
+                const next = alldayWithEnd(value, ts)
+                if (next === null) return
+                onChange(next)
               }}
             />
           </div>

--- a/tests/components/eventForm/EventTimePickerCore.test.ts
+++ b/tests/components/eventForm/EventTimePickerCore.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import {
+  newAlldayEventTime,
+  alldayWithStart,
+  alldayWithEnd,
+} from '../../../src/components/eventForm/EventTimePickerCore'
+import type { EventTime } from '../../../src/models'
+
+// #106: 종일-기간 이벤트가 캘린더에 단일(at) 로 표시되던 회귀.
+// 원인은 EventTimePickerCore 의 allday 데이터 생성이 iOS EventTime.allDay 와 다른 포맷
+// (period_x = ts - secondsFromGMT 트릭 + 새 생성 시 시작=종료=now) 으로 emit 되어
+// alldayLocalDate(#103) 와 호환되지 않아 시작==종료 또는 1일 밀린 일자가 잡혔던 것.
+//
+// iOS 패턴: period_start = event tz 의 시작일 00:00 epoch, period_end = 종료일 23:59:59 epoch.
+// (Calendar.endOfDay = 그 날 마지막 초)
+
+function makeAllday(start: number, end: number, gmt: number): EventTime {
+  return { time_type: 'allday', period_start: start, period_end: end, seconds_from_gmt: gmt }
+}
+
+describe('EventTimePickerCore — allday 데이터 생성 헬퍼 (#106)', () => {
+  describe('newAlldayEventTime', () => {
+    it('새로 만들면 시작은 사용자 환경의 오늘 자정, 종료는 시작 + 86400 - 1 (그 날 23:59:59) 이다', () => {
+      // when
+      const v = newAlldayEventTime(9 * 3600)
+
+      // then
+      expect(v.time_type).toBe('allday')
+      if (v.time_type !== 'allday') return
+      // 종료 - 시작 = 86400 - 1 (= 1일 종일, iOS endOfDay 패턴)
+      expect(v.period_end - v.period_start).toBe(86400 - 1)
+      // 시작은 자정 (Date 변환 시 hh:mm:ss 가 모두 0)
+      const startDate = new Date(v.period_start * 1000)
+      expect(startDate.getHours()).toBe(0)
+      expect(startDate.getMinutes()).toBe(0)
+      expect(startDate.getSeconds()).toBe(0)
+      // secondsFromGmt 보존
+      expect(v.seconds_from_gmt).toBe(9 * 3600)
+    })
+  })
+
+  describe('alldayWithStart', () => {
+    it('시작 날짜를 종료보다 앞 날짜로 바꾸면 종료는 보존된다', () => {
+      // given: 5/15 ~ 5/17 종일 (사용자 환경 자정 epoch 가정)
+      const prev = makeAllday(1000000, 1000000 + 3 * 86400 - 1, 9 * 3600)
+
+      // when: 시작을 5/14 로 변경 (period_start - 86400)
+      const newStart = prev.period_start - 86400
+      const v = alldayWithStart(prev, newStart)
+
+      // then: period_start 만 갱신, period_end 보존
+      if (v.time_type !== 'allday') throw new Error('expected allday')
+      expect(v.period_start).toBe(newStart)
+      expect(v.period_end).toBe(prev.period_end)
+    })
+
+    it('시작 날짜를 종료보다 뒤로 바꾸면 종료가 시작 + 86400 - 1 (1일 종일) 로 정정된다', () => {
+      // given: 5/15 (1일 종일)
+      const prev = makeAllday(1000000, 1000000 + 86400 - 1, 9 * 3600)
+
+      // when: 시작을 5/20 으로 (5일 뒤)
+      const newStart = prev.period_start + 5 * 86400
+      const v = alldayWithStart(prev, newStart)
+
+      // then
+      if (v.time_type !== 'allday') throw new Error('expected allday')
+      expect(v.period_start).toBe(newStart)
+      expect(v.period_end).toBe(newStart + 86400 - 1)
+    })
+  })
+
+  describe('alldayWithEnd', () => {
+    it('종료 날짜를 입력 날짜의 23:59:59 (그 날 자정 + 86400 - 1) 로 emit 한다', () => {
+      // given: 5/15 (1일 종일)
+      const prev = makeAllday(1000000, 1000000 + 86400 - 1, 9 * 3600)
+
+      // when: 종료를 5/17 로 (= 시작 + 2일 후의 자정 epoch 입력)
+      const newEndDateTs = prev.period_start + 2 * 86400  // 5/17 자정
+      const v = alldayWithEnd(prev, newEndDateTs)
+
+      // then: period_end = newEndDateTs + 86400 - 1 (= 5/17 23:59:59 epoch)
+      expect(v).not.toBeNull()
+      if (!v || v.time_type !== 'allday') throw new Error('expected allday')
+      expect(v.period_end).toBe(newEndDateTs + 86400 - 1)
+      expect(v.period_start).toBe(prev.period_start)
+    })
+
+    it('종료 날짜를 시작보다 앞으로 입력하면 null 을 반환한다 (변경 거부)', () => {
+      // given: 5/15
+      const prev = makeAllday(1000000, 1000000 + 86400 - 1, 9 * 3600)
+
+      // when: 종료를 5/14 로 (시작 1일 전)
+      const newEndDateTs = prev.period_start - 86400
+      const v = alldayWithEnd(prev, newEndDateTs)
+
+      // then
+      expect(v).toBeNull()
+    })
+  })
+})

--- a/tests/repro/issue106.test.ts
+++ b/tests/repro/issue106.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { groupEventsByDate, dateToTimestamp } from '../../src/domain/functions/eventTime'
+import { buildWeekEventStack } from '../../src/calendar/weekEventStackBuilder'
+import type { CalendarDay } from '../../src/calendar/calendarUtils'
+import type { Todo } from '../../src/models/Todo'
+
+function makeWeekDays(startDate: Date): CalendarDay[] {
+  const days: CalendarDay[] = []
+  for (let i = 0; i < 7; i++) {
+    const date = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate() + i)
+    const y = date.getFullYear()
+    const m = String(date.getMonth() + 1).padStart(2, '0')
+    const d = String(date.getDate()).padStart(2, '0')
+    days.push({ date, dayOfMonth: date.getDate(), dateKey: `${y}-${m}-${d}`, isCurrentMonth: true, isToday: false })
+  }
+  return days
+}
+
+describe('issue #106 실데이터 재현', () => {
+  it('미중 정상회담 (2일 종일 KST 5/14~5/15) 캘린더 그리드 표시', () => {
+    const todo: Todo = {
+      uuid: 'B77A3369-AD3A-47E2-98D4-B70344C6038A',
+      name: '미중 정상회담',
+      event_tag_id: 'DTB3xvdpHE977FYhOcih',
+      event_time: { time_type: 'allday', period_start: 1778684400, period_end: 1778857199, seconds_from_gmt: 32400 } as never,
+      is_current: false,
+    }
+
+    const lower = dateToTimestamp(new Date(2026, 0, 1))
+    const upper = dateToTimestamp(new Date(2026, 11, 31, 23, 59, 59))
+    const map = groupEventsByDate([todo], [], lower, upper)
+
+    console.log('keys with event:', [...map.keys()].sort())
+    expect(map.get('2026-05-14')?.length ?? 0).toBe(1)
+    expect(map.get('2026-05-15')?.length ?? 0).toBe(1)
+
+    const weekDays = makeWeekDays(new Date(2026, 4, 10))
+    const stack = buildWeekEventStack(weekDays, map)
+    console.log('stack rows:', JSON.stringify(stack.rows.map(r => r.map(e => ({ startCol: e.startCol, endCol: e.endCol }))), null, 2))
+    expect(stack.rows.length).toBe(1)
+    expect(stack.rows[0][0].startCol).toBe(5)
+    expect(stack.rows[0][0].endCol).toBe(6)
+  })
+})


### PR DESCRIPTION
closes #106

## Summary

웹 EventTimePickerCore 의 allday emit 포맷이 iOS EventTime.allDay 와 어긋나 있어, #103 의 alldayLocalDate 적용 후 시작==종료 또는 1일 밀린 일자가 잡혀 다일 종일 이벤트가 단일(at) 처럼 한 셀에만 표시되던 회귀를 수정.

## 진단

| | period_start | period_end |
|---|---|---|
| iOS EventTime.allDay (Calendar.endOfDay 패턴) | event tz 시작일 00:00 epoch | event tz 종료일 23:59:59 epoch (= 시작 + N\*86400 - 1) |
| Web (이전) | 새 생성 시 `now` (현재 시각 그대로) / 입력 시 `dateInputToTs(v) - secondsFromGMT` 트릭 | 동일 트릭으로 다른 날짜 |

`alldayLocalDate(period + offset)` 의 UTC date 추출이 iOS 데이터엔 정확히 일자를 잡지만 웹의 `-offset` 트릭 데이터엔 1일 밀려 시작==종료 가 됐고, 결과적으로 캘린더 day enumerate 가 1일에서 끝나 단일(at) 처럼 보임.

## 변경

- `EventTimePickerCore.newAlldayEventTime` — 새 종일 생성 시 today 자정 epoch ~ +86400-1
- `EventTimePickerCore.alldayWithStart` — 시작 변경 시 종료 보존, 종료가 새 시작보다 앞이면 1일 종일로 정정
- `EventTimePickerCore.alldayWithEnd` — 종료 입력은 그 날 자정 epoch + 86400-1, 시작보다 앞이면 변경 거부
- `EventTimePickerCore.alldayDateInputValue` — date input 의 value 표시도 `alldayLocalDate` 와 동일한 `(period+offset)` UTC date 추출 로직으로 정렬 (사용자 환경 tz 와 무관하게 event tz 의 일자 표시)
- handleTypeChange / 시작·종료 onChange 가 새 헬퍼 사용

## Test plan

- [x] `npx vitest run` — 104 files / 824 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] 신규 단위 테스트 5개 (newAlldayEventTime / alldayWithStart 2 / alldayWithEnd 2)
- [ ] dev 서버에서 종일 다일 이벤트 새로 등록 후 캘린더에 다일로 표시되는지 확인
- [ ] 기존 이벤트 (web 으로 만든 것) 의 표시도 정상화되는지 확인 — 단, 기존에 저장된 데이터는 옛 포맷이라 백엔드에서 다시 fetch 후에도 옛 포맷일 수 있음. 새로 수정/저장한 이벤트부터 새 포맷
- [ ] iOS 로 등록된 종일 다일 이벤트가 web 캘린더에 정확한 날짜 범위로 표시되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)