### PR TITLE
[#108] fix(EventTimePicker): 타입(주기/종일) 토글 시 선택 날짜 보존

### DIFF
--- a/src/components/eventForm/EventTimePickerCore.tsx
+++ b/src/components/eventForm/EventTimePickerCore.tsx
@@ -28,23 +28,6 @@ function localSecondsFromGmt(): number {
   return -(new Date().getTimezoneOffset() * 60)
 }
 
-function startOfTodayTs(): number {
-  const d = new Date()
-  d.setHours(0, 0, 0, 0)
-  return Math.floor(d.getTime() / 1000)
-}
-
-// #106: iOS EventTime.allDay 와 동일한 포맷으로 emit 한다.
-//   period_start = event tz 의 시작일 00:00 epoch
-//   period_end   = event tz 의 종료일 23:59:59 epoch (Calendar.endOfDay 패턴, +86400-1)
-// 이 포맷이어야 alldayLocalDate(#103) 의 (period + offset) UTC date 추출이 정확히 일자를 잡고
-// 캘린더에 다일로 표시된다.
-
-export function newAlldayEventTime(secondsFromGMT: number): EventTime {
-  const start = startOfTodayTs()
-  return { time_type: 'allday', period_start: start, period_end: start + 86400 - 1, seconds_from_gmt: secondsFromGMT }
-}
-
 export function alldayWithStart(prev: EventTime, newStartTs: number): EventTime {
   if (prev.time_type !== 'allday') return prev
   // 시작이 종료보다 뒤로 가면 종료를 시작 + 86400 - 1 (1일 종일) 로 정정
@@ -67,6 +50,32 @@ export function alldayDateInputValue(periodSeconds: number, secondsFromGMT: numb
   const wall = new Date((periodSeconds + secondsFromGMT) * 1000)
   const p = (n: number) => String(n).padStart(2, '0')
   return `${wall.getUTCFullYear()}-${p(wall.getUTCMonth() + 1)}-${p(wall.getUTCDate())}`
+}
+
+// #108: 타입 토글 시 prev value 의 기준 timestamp 를 보존해 selectedDate 손실 차단.
+// prev=null 일 때만 now 를 baseTs 로 사용한다 (기존 동작 유지).
+export function nextEventTimeForType(
+  prev: EventTime | null,
+  type: 'at' | 'period' | 'allday',
+  now: number,
+  secondsFromGMT: number,
+): EventTime {
+  const baseTs =
+    prev === null ? now
+    : prev.time_type === 'at' ? prev.timestamp
+    : prev.time_type === 'period' ? prev.period_start
+    : prev.period_start  // allday — 이미 event tz 자정 epoch
+  if (type === 'at') {
+    return { time_type: 'at', timestamp: baseTs }
+  }
+  if (type === 'period') {
+    return { time_type: 'period', period_start: baseTs, period_end: baseTs + 3600 }
+  }
+  // allday: baseTs 의 일자의 local 자정으로 정규화
+  const d = new Date(baseTs * 1000)
+  d.setHours(0, 0, 0, 0)
+  const start = Math.floor(d.getTime() / 1000)
+  return { time_type: 'allday', period_start: start, period_end: start + 86400 - 1, seconds_from_gmt: secondsFromGMT }
 }
 
 // --- Component ---
@@ -99,24 +108,11 @@ export function EventTimePickerCore({ value, onChange, allowNone }: EventTimePic
       onChange(null)
       return
     }
-    let next: EventTime
-    if (type === 'at') {
-      next = { time_type: 'at', timestamp: now }
-    } else if (type === 'period') {
-      next = { time_type: 'period', period_start: now, period_end: now + 3600 }
-    } else {
-      next = newAlldayEventTime(localSecondsFromGmt())
-    }
-    onChange(next)
+    onChange(nextEventTimeForType(value, type, now, localSecondsFromGmt()))
   }
 
   function handleAllDayToggle(checked: boolean) {
-    if (checked) {
-      handleTypeChange('allday')
-    } else {
-      const ts = value?.time_type === 'allday' ? value.period_start : now
-      onChange({ time_type: 'at', timestamp: ts })
-    }
+    handleTypeChange(checked ? 'allday' : 'at')
   }
 
   // dark:[color-scheme:dark] — 다크모드에서 native datetime-local / date 의 calendar picker indicator 가 어두운 배경에 안 보이는 이슈 해결

--- a/tests/components/eventForm/EventTimePickerCore.test.ts
+++ b/tests/components/eventForm/EventTimePickerCore.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import {
-  newAlldayEventTime,
   alldayWithStart,
   alldayWithEnd,
+  nextEventTimeForType,
 } from '../../../src/components/eventForm/EventTimePickerCore'
 import type { EventTime } from '../../../src/models'
 
@@ -19,26 +19,6 @@ function makeAllday(start: number, end: number, gmt: number): EventTime {
 }
 
 describe('EventTimePickerCore — allday 데이터 생성 헬퍼 (#106)', () => {
-  describe('newAlldayEventTime', () => {
-    it('새로 만들면 시작은 사용자 환경의 오늘 자정, 종료는 시작 + 86400 - 1 (그 날 23:59:59) 이다', () => {
-      // when
-      const v = newAlldayEventTime(9 * 3600)
-
-      // then
-      expect(v.time_type).toBe('allday')
-      if (v.time_type !== 'allday') return
-      // 종료 - 시작 = 86400 - 1 (= 1일 종일, iOS endOfDay 패턴)
-      expect(v.period_end - v.period_start).toBe(86400 - 1)
-      // 시작은 자정 (Date 변환 시 hh:mm:ss 가 모두 0)
-      const startDate = new Date(v.period_start * 1000)
-      expect(startDate.getHours()).toBe(0)
-      expect(startDate.getMinutes()).toBe(0)
-      expect(startDate.getSeconds()).toBe(0)
-      // secondsFromGmt 보존
-      expect(v.seconds_from_gmt).toBe(9 * 3600)
-    })
-  })
-
   describe('alldayWithStart', () => {
     it('시작 날짜를 종료보다 앞 날짜로 바꾸면 종료는 보존된다', () => {
       // given: 5/15 ~ 5/17 종일 (사용자 환경 자정 epoch 가정)
@@ -95,6 +75,142 @@ describe('EventTimePickerCore — allday 데이터 생성 헬퍼 (#106)', () => 
 
       // then
       expect(v).toBeNull()
+    })
+  })
+})
+
+// #108: 시간 타입(at/period/allday) 토글 시 기존 value 의 날짜가 손실되어 'now' 로 리셋되던 회귀.
+// 폼 진입 시 selectedDate 로 at 이 세팅되어도, 사용자가 종일/주기 토글 → at 다시 선택 시
+// 현재 시간 기준으로 timestamp 가 새로 잡혀 선택 날짜가 사라졌다.
+//
+// nextEventTimeForType 은 prev value 의 기준 timestamp 를 보존한다:
+//   - prev=null  → now (기존 동작 유지)
+//   - prev.at    → prev.timestamp
+//   - prev.period→ prev.period_start
+//   - prev.allday→ prev.period_start (이미 event tz 자정 epoch)
+// allday 로 전환 시에는 baseTs 를 local 자정으로 정규화 (iOS startOfDay 패턴).
+
+describe('nextEventTimeForType (#108) — 타입 변경 시 기존 날짜 보존', () => {
+  const NOW = 1_700_000_000  // 임의 현재 시각 (테스트에서 baseTs 와 구분 가능한 값)
+  const GMT = 9 * 3600
+
+  describe('prev = null (값 없음)', () => {
+    it('null → at 이면 now 기준 timestamp 로 시작한다', () => {
+      const v = nextEventTimeForType(null, 'at', NOW, GMT)
+      expect(v.time_type).toBe('at')
+      if (v.time_type !== 'at') return
+      expect(v.timestamp).toBe(NOW)
+    })
+
+    it('null → period 이면 now 기준 1시간 구간으로 시작한다', () => {
+      const v = nextEventTimeForType(null, 'period', NOW, GMT)
+      expect(v.time_type).toBe('period')
+      if (v.time_type !== 'period') return
+      expect(v.period_start).toBe(NOW)
+      expect(v.period_end).toBe(NOW + 3600)
+    })
+
+    it('null → allday 이면 오늘(now 의 일자) 자정 ~ 23:59:59 종일 이벤트로 시작한다', () => {
+      const v = nextEventTimeForType(null, 'allday', NOW, GMT)
+      expect(v.time_type).toBe('allday')
+      if (v.time_type !== 'allday') return
+      expect(v.period_end - v.period_start).toBe(86400 - 1)
+      const d = new Date(v.period_start * 1000)
+      expect(d.getHours()).toBe(0)
+      expect(d.getMinutes()).toBe(0)
+      expect(d.getSeconds()).toBe(0)
+      expect(v.seconds_from_gmt).toBe(GMT)
+    })
+  })
+
+  describe('prev = at (선택 날짜 보존이 핵심)', () => {
+    // NOW 와 다른 일자에 14:30 을 잡는다 — baseTs 가 now 가 아닌 prev 에서 왔는지 검증
+    const selectedTs = (() => {
+      const d = new Date(NOW * 1000)
+      d.setMonth(d.getMonth() - 3)
+      d.setDate(15)
+      d.setHours(14, 30, 0, 0)
+      return Math.floor(d.getTime() / 1000)
+    })()
+    const prevAt: EventTime = { time_type: 'at', timestamp: selectedTs }
+
+    it('at → period 시 기존 timestamp 가 period_start 로 보존되고 종료는 +1시간', () => {
+      const v = nextEventTimeForType(prevAt, 'period', NOW, GMT)
+      expect(v.time_type).toBe('period')
+      if (v.time_type !== 'period') return
+      expect(v.period_start).toBe(selectedTs)
+      expect(v.period_end).toBe(selectedTs + 3600)
+    })
+
+    it('at → allday 시 기존 timestamp 의 local 일자(자정) 이 period_start 가 된다', () => {
+      const v = nextEventTimeForType(prevAt, 'allday', NOW, GMT)
+      expect(v.time_type).toBe('allday')
+      if (v.time_type !== 'allday') return
+      const expectedStart = (() => {
+        const d = new Date(selectedTs * 1000)
+        d.setHours(0, 0, 0, 0)
+        return Math.floor(d.getTime() / 1000)
+      })()
+      expect(v.period_start).toBe(expectedStart)
+      expect(v.period_end).toBe(expectedStart + 86400 - 1)
+      expect(v.seconds_from_gmt).toBe(GMT)
+    })
+
+    it('at → at 은 동일 timestamp 를 유지한다 (no-op 안전성)', () => {
+      const v = nextEventTimeForType(prevAt, 'at', NOW, GMT)
+      expect(v.time_type).toBe('at')
+      if (v.time_type !== 'at') return
+      expect(v.timestamp).toBe(selectedTs)
+    })
+  })
+
+  describe('prev = period', () => {
+    const periodStart = 1_690_000_000
+    const prevPeriod: EventTime = { time_type: 'period', period_start: periodStart, period_end: periodStart + 1800 }
+
+    it('period → at 시 period_start 가 timestamp 로 보존된다', () => {
+      const v = nextEventTimeForType(prevPeriod, 'at', NOW, GMT)
+      expect(v.time_type).toBe('at')
+      if (v.time_type !== 'at') return
+      expect(v.timestamp).toBe(periodStart)
+    })
+
+    it('period → allday 시 period_start 의 일자 자정이 새 period_start', () => {
+      const v = nextEventTimeForType(prevPeriod, 'allday', NOW, GMT)
+      expect(v.time_type).toBe('allday')
+      if (v.time_type !== 'allday') return
+      const expectedStart = (() => {
+        const d = new Date(periodStart * 1000)
+        d.setHours(0, 0, 0, 0)
+        return Math.floor(d.getTime() / 1000)
+      })()
+      expect(v.period_start).toBe(expectedStart)
+      expect(v.period_end).toBe(expectedStart + 86400 - 1)
+    })
+  })
+
+  describe('prev = allday', () => {
+    const alldayStart = 1_690_000_000
+    const prevAllday: EventTime = {
+      time_type: 'allday',
+      period_start: alldayStart,
+      period_end: alldayStart + 86400 - 1,
+      seconds_from_gmt: GMT,
+    }
+
+    it('allday → at 시 period_start 가 timestamp 로 보존된다', () => {
+      const v = nextEventTimeForType(prevAllday, 'at', NOW, GMT)
+      expect(v.time_type).toBe('at')
+      if (v.time_type !== 'at') return
+      expect(v.timestamp).toBe(alldayStart)
+    })
+
+    it('allday → period 시 period_start 가 그대로 새 period_start, 종료는 +1시간', () => {
+      const v = nextEventTimeForType(prevAllday, 'period', NOW, GMT)
+      expect(v.time_type).toBe('period')
+      if (v.time_type !== 'period') return
+      expect(v.period_start).toBe(alldayStart)
+      expect(v.period_end).toBe(alldayStart + 3600)
     })
   })
 })


### PR DESCRIPTION
closes #108

## 문제
- 특정 일자 선택 후 이벤트 생성 화면 진입 → at 으로 선택 일자 표시 (정상).
- 그 다음 시간 기준을 "주기" 또는 "종일" 로 토글하면 날짜가 선택 일자가 아닌 **현재 시간 기준** 으로 리셋됨.
- 이슈 본문 주문대로 이벤트 수정(편집) 화면도 동일 패턴 (편집 시에는 prev value 가 항상 존재하므로 보존이 자연스럽게 작동).

## 원인
`EventTimePickerCore.handleTypeChange()` 가 새 타입에 대해 `now = floor(Date.now()/1000)` 또는 `startOfTodayTs()` 로 timestamp 를 새로 만들면서 기존 `value` 의 날짜 정보를 버렸다.

## 접근
- 신규 순수 함수 `nextEventTimeForType(prev, type, now, secondsFromGmt)` 추출 — prev 의 timestamp/period_start 를 baseTs 로 보존하고, allday 전환 시 baseTs 의 일자의 local 자정으로 정규화.
- `handleTypeChange` 와 `handleAllDayToggle` 을 신규 헬퍼 호출로 단일화.
- 기존 `newAlldayEventTime` 은 `nextEventTimeForType(null, 'allday', ...)` 가 동일 invariant 를 흡수하므로 제거.

## 회귀 테스트
- prev = null/at/period/allday × 변경 type at/period/allday 조합으로 baseTs 보존 + allday local 자정 정규화 검증.
- 기존 EventTimePicker / ScheduleForm / TodoForm 테스트 135건 모두 통과.

## Test plan
- [ ] 캘린더에서 특정 날짜 선택 → 이벤트 생성 → 종일 토글 → 다시 at 토글: 날짜가 선택 일자로 유지되는지 확인.
- [ ] 동일 시나리오에서 주기 토글 → at: 날짜 유지 확인.
- [ ] 편집 모드에서 종일 → at, 주기 → at 토글 시 원본 날짜 유지 확인.