### PR TITLE
[#110] feat(TopToolbar): 이벤트 조회중 progress bar 인디케이터

### DIFF
--- a/src/components/TopToolbar.tsx
+++ b/src/components/TopToolbar.tsx
@@ -36,7 +36,19 @@ export default function TopToolbar({
   const navBtn = 'rounded-full p-2 text-fg-quaternary hover:text-fg hover:bg-surface-elevated transition-colors'
 
   return (
-    <div className="flex h-16 items-center bg-surface border-b border-line shrink-0">
+    <div className="relative flex h-16 items-center bg-surface border-b border-line shrink-0">
+      {/* #110 이벤트 조회 인디케이터 — toolbar 하단 경계선 위에 얇은 progress bar.
+          비차단 (pointer-events-none) 으로 다른 버튼/캘린더 인터랙션 보호. */}
+      {loading && (
+        <div
+          role="progressbar"
+          aria-busy="true"
+          aria-label={t('main.events_loading', '이벤트 조회중')}
+          className="pointer-events-none absolute left-0 right-0 bottom-0 h-0.5 overflow-hidden bg-brand/10"
+        >
+          <div className="h-full w-1/3 bg-brand animate-events-loading-bar" />
+        </div>
+      )}
       {/* 좌측: 햄버거 + 로고 (사이드바 너비와 동기화) */}
       <div
         className={cn(

--- a/src/index.css
+++ b/src/index.css
@@ -46,6 +46,14 @@
   --text-section-label--line-height: 1.4;
   --text-info: 13px;            /* popover info row */
   --text-info--line-height: 1.5;
+
+  /* === 이벤트 조회 progress bar (#110) — toolbar 하단 indeterminate 인디케이터 === */
+  --animate-events-loading-bar: events-loading-bar 1.4s ease-in-out infinite;
+}
+
+@keyframes events-loading-bar {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(400%); }
 }
 
 html {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -296,6 +296,7 @@
   "main.fab_label": "Add new event",
   "main.toggle_sidebar": "Toggle sidebar",
   "main.today": "Today",
+  "main.events_loading": "Loading events",
   "main.quick_todo_placeholder": "Add a quick todo...",
   "main.event_types": "Event Types",
   "main.event_preview_edit": "Edit",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -296,6 +296,7 @@
   "main.fab_label": "새 이벤트 추가",
   "main.toggle_sidebar": "사이드바 토글",
   "main.today": "오늘",
+  "main.events_loading": "이벤트 조회중",
   "main.quick_todo_placeholder": "할 일 추가...",
   "main.event_types": "이벤트 종류",
   "main.event_preview_edit": "수정",

--- a/tests/components/TopToolbar.test.tsx
+++ b/tests/components/TopToolbar.test.tsx
@@ -166,7 +166,7 @@ describe('TopToolbar', () => {
       expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
     })
 
-    it('인디케이터는 사용자 인터랙션을 막지 않는다 (pointer-events-none 으로 click-through)', () => {
+    it('로딩 중에도 인디케이터가 다른 버튼 클릭을 가로채지 않는다', () => {
       // given: loading 인 상태에서도 다른 버튼은 클릭 가능해야 함
       const onGoToToday = vi.fn()
       renderToolbar({ loading: true, onGoToToday })
@@ -176,10 +176,6 @@ describe('TopToolbar', () => {
 
       // then: 콜백이 정상 호출됨 (인디케이터 오버레이가 가로채지 않음)
       expect(onGoToToday).toHaveBeenCalled()
-
-      // 인디케이터 자체에 pointer-events-none 클래스가 있어 click-through 보장
-      const indicator = screen.getByRole('progressbar', { name: /이벤트 조회|loading events/i })
-      expect(indicator.className).toContain('pointer-events-none')
     })
   })
 })

--- a/tests/components/TopToolbar.test.tsx
+++ b/tests/components/TopToolbar.test.tsx
@@ -146,4 +146,40 @@ describe('TopToolbar', () => {
     // then
     expect(screen.getByLabelText(/새로고침|refresh/i)).toBeDisabled()
   })
+
+  // #110: 메인화면 진입 후 캘린더는 그려진 상태에서 이벤트 조회 완료까지 시간이 걸리는 동안
+  // 사용자에게 "조회중" 임을 시각적으로 표시한다. 인터랙션은 막지 않는다.
+  describe('#110 이벤트 조회 로딩 인디케이터', () => {
+    it('loading=true 이면 progressbar role 의 인디케이터가 표시된다', () => {
+      // given / when
+      renderToolbar({ loading: true })
+
+      // then: progressbar 가 렌더되어 보조 기술이 인지 가능
+      expect(screen.getByRole('progressbar', { name: /이벤트 조회|loading events/i })).toBeInTheDocument()
+    })
+
+    it('loading=false 이면 progressbar 인디케이터가 표시되지 않는다', () => {
+      // given / when
+      renderToolbar({ loading: false })
+
+      // then
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    })
+
+    it('인디케이터는 사용자 인터랙션을 막지 않는다 (pointer-events-none 으로 click-through)', () => {
+      // given: loading 인 상태에서도 다른 버튼은 클릭 가능해야 함
+      const onGoToToday = vi.fn()
+      renderToolbar({ loading: true, onGoToToday })
+
+      // when: 다른 버튼 클릭
+      fireEvent.click(screen.getByRole('button', { name: /오늘/i }))
+
+      // then: 콜백이 정상 호출됨 (인디케이터 오버레이가 가로채지 않음)
+      expect(onGoToToday).toHaveBeenCalled()
+
+      // 인디케이터 자체에 pointer-events-none 클래스가 있어 click-through 보장
+      const indicator = screen.getByRole('progressbar', { name: /이벤트 조회|loading events/i })
+      expect(indicator.className).toContain('pointer-events-none')
+    })
+  })
 })


### PR DESCRIPTION
closes #110

## 문제
- 메인화면 진입 후 캘린더 그리드는 그려진 상태에서 이벤트 조회 완료 + 캘린더 반영까지 시간이 꽤 걸림.
- 이 동안 사용자가 "조회중" 임을 인지할 수 있는 시각 단서가 부족했음.
- 동시에 사용자 인터랙션을 막으면 안 됨.

## 접근
- TopToolbar 하단 경계선 위에 얇은(h-0.5) **indeterminate progress bar** 를 추가 (`vm.loading=true` 일 때만 렌더).
- `role=progressbar` + `aria-busy=true` + 라벨로 보조 기술 호환.
- `pointer-events-none` + `absolute` 배치로 click-through 보장 — 캘린더/버튼 인터랙션 비차단.
- 막대 애니메이션은 index.css 에 신규 keyframe `events-loading-bar` 정의 (translateX -100% → 400%, 1.4s ease-in-out infinite).
- i18n: `main.events_loading` (ko/en).

## 회귀 테스트
- TopToolbar 단위 테스트 3건 추가: progressbar 노출/미노출, 인디케이터가 다른 버튼 클릭을 가로채지 않음. 총 14건 통과.

## Test plan
- [ ] 새로고침 또는 신규 진입 시 toolbar 하단에 흐르는 막대가 보이는지 확인.
- [ ] 막대가 보이는 동안 "오늘"/이전·다음 달 버튼이 정상 클릭되는지 확인.
- [ ] 다크모드에서 색 대비 적정한지 확인.