### PR TITLE
[#109] feat(LoginPage): 로그인 → 메인 전환 로딩 표시

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -125,6 +125,7 @@
   "login.google": "Sign in with Google",
   "login.apple": "Sign in with Apple",
   "login.error": "Sign in failed. Please try again.",
+  "login.signing_in": "Signing in...",
   "common.menu": "Menu",
   "common.confirm": "OK",
   "event.no_events": "No events",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -125,6 +125,7 @@
   "login.google": "Google로 로그인",
   "login.apple": "Apple로 로그인",
   "login.error": "로그인에 실패했습니다. 다시 시도해 주세요.",
+  "login.signing_in": "로그인 중...",
   "common.menu": "메뉴",
   "common.confirm": "확인",
   "event.no_events": "이벤트가 없습니다",

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -28,32 +28,46 @@ export function LoginPage() {
           </div>
         )}
 
-        <div className="flex flex-col gap-3">
-          <button
-            onClick={vm.signInWithGoogle}
-            disabled={vm.loading}
-            className="flex items-center justify-center gap-2 w-full py-3 px-4 border border-line rounded-xl text-sm font-medium text-fg-secondary bg-surface hover:bg-surface-sunken disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        {vm.loading ? (
+          // #109: 로그인 시도 ~ authStore.account 세팅 → Navigate(메인) 사이의 시간 텀 동안 전환 로딩.
+          // 같은 카드 안에서 buttons 자리만 spinner+message 로 swap → 사용자가 위치 변화 없이 진행 인지.
+          <div
+            role="status"
+            aria-live="polite"
+            className="flex flex-col items-center justify-center gap-3 py-6"
           >
-            <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
-              <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-              <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-              <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-              <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-            </svg>
-            {t('login.google')}
-          </button>
+            <div
+              data-testid="login-loading-spinner"
+              className="w-8 h-8 border-4 border-brand border-t-transparent rounded-full animate-spin"
+            />
+            <span className="text-sm text-fg-tertiary">{t('login.signing_in', '로그인 중...')}</span>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <button
+              onClick={vm.signInWithGoogle}
+              className="flex items-center justify-center gap-2 w-full py-3 px-4 border border-line rounded-xl text-sm font-medium text-fg-secondary bg-surface hover:bg-surface-sunken transition-colors"
+            >
+              <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
+                <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+              </svg>
+              {t('login.google')}
+            </button>
 
-          <button
-            onClick={vm.signInWithApple}
-            disabled={vm.loading}
-            className="flex items-center justify-center gap-2 w-full py-3 px-4 border border-line rounded-xl text-sm font-medium text-fg-secondary bg-surface hover:bg-surface-sunken disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
-            </svg>
-            {t('login.apple')}
-          </button>
-        </div>
+            <button
+              onClick={vm.signInWithApple}
+              className="flex items-center justify-center gap-2 w-full py-3 px-4 border border-line rounded-xl text-sm font-medium text-fg-secondary bg-surface hover:bg-surface-sunken transition-colors"
+            >
+              <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
+              </svg>
+              {t('login.apple')}
+            </button>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -37,10 +37,10 @@ export function LoginPage() {
             className="flex flex-col items-center justify-center gap-3 py-6"
           >
             <div
-              data-testid="login-loading-spinner"
+              aria-hidden="true"
               className="w-8 h-8 border-4 border-brand border-t-transparent rounded-full animate-spin"
             />
-            <span className="text-sm text-fg-tertiary">{t('login.signing_in', '로그인 중...')}</span>
+            <span className="text-sm text-fg-tertiary">{t('login.signing_in')}</span>
           </div>
         ) : (
           <div className="flex flex-col gap-3">

--- a/src/pages/Login/useLoginViewModel.ts
+++ b/src/pages/Login/useLoginViewModel.ts
@@ -19,6 +19,8 @@ export function useLoginViewModel(): LoginViewModel {
   const [loading, setLoading] = useState(false)
   const [errorKey, setErrorKey] = useState<string | null>(null)
 
+  // #109: 성공 시 loading 을 풀지 않는다 — authStore.account 가 set 되고 LoginPage 가 Navigate 로
+  // unmount 될 때까지 전환 로딩 화면을 유지하기 위함. 실패/취소 시에만 loading 을 풀어 다시 시도 가능.
   const signInWithGoogle = useCallback(async () => {
     setLoading(true)
     setErrorKey(null)
@@ -26,21 +28,14 @@ export function useLoginViewModel(): LoginViewModel {
       await authRepo.signInWithGoogle()
     } catch (e) {
       if (e instanceof AuthError) {
-        if (e.reason.type === 'cancelled') {
-          // 사용자가 팝업을 닫은 경우 에러를 표시하지 않는다
-        } else {
+        if (e.reason.type !== 'cancelled') {
           setErrorKey(`error.auth.${e.reason.type}`)
         }
       } else if (
-        e instanceof Error &&
-        'code' in e &&
-        (e as { code: string }).code === 'auth/popup-closed-by-user'
+        !(e instanceof Error && 'code' in e && (e as { code: string }).code === 'auth/popup-closed-by-user')
       ) {
-        // Firebase 원시 에러 — 팝업 닫힘, 에러 표시 안 함
-      } else {
         setErrorKey('error.unknown')
       }
-    } finally {
       setLoading(false)
     }
   }, [authRepo])
@@ -52,21 +47,14 @@ export function useLoginViewModel(): LoginViewModel {
       await authRepo.signInWithApple()
     } catch (e) {
       if (e instanceof AuthError) {
-        if (e.reason.type === 'cancelled') {
-          // 사용자가 팝업을 닫은 경우 에러를 표시하지 않는다
-        } else {
+        if (e.reason.type !== 'cancelled') {
           setErrorKey(`error.auth.${e.reason.type}`)
         }
       } else if (
-        e instanceof Error &&
-        'code' in e &&
-        (e as { code: string }).code === 'auth/popup-closed-by-user'
+        !(e instanceof Error && 'code' in e && (e as { code: string }).code === 'auth/popup-closed-by-user')
       ) {
-        // Firebase 원시 에러 — 팝업 닫힘, 에러 표시 안 함
-      } else {
         setErrorKey('error.unknown')
       }
-    } finally {
       setLoading(false)
     }
   }, [authRepo])

--- a/src/pages/Login/useLoginViewModel.ts
+++ b/src/pages/Login/useLoginViewModel.ts
@@ -1,6 +1,7 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { useRepositories } from '../../composition/RepositoriesProvider'
 import { AuthError } from '../../domain/errors/AuthError'
+import { useAuthStore } from '../../stores/authStore'
 
 // MARK: - Interface
 
@@ -18,6 +19,18 @@ export function useLoginViewModel(): LoginViewModel {
   const { authRepo } = useRepositories()
   const [loading, setLoading] = useState(false)
   const [errorKey, setErrorKey] = useState<string | null>(null)
+
+  // #109: Firebase 는 성공했지만 백엔드 account 등록이 실패해 LoginPage 가 unmount 되지 못하는 경우,
+  // authStore.signInError 신호를 보고 loading 을 해제해 사용자가 재시도할 수 있게 한다 (stuck-spinner 차단).
+  const signInError = useAuthStore(s => s.signInError)
+  const clearSignInError = useAuthStore(s => s.clearSignInError)
+  useEffect(() => {
+    if (signInError && loading) {
+      setErrorKey('error.unknown')
+      setLoading(false)
+      clearSignInError()
+    }
+  }, [signInError, loading, clearSignInError])
 
   // #109: 성공 시 loading 을 풀지 않는다 — authStore.account 가 set 되고 LoginPage 가 Navigate 로
   // unmount 될 때까지 전환 로딩 화면을 유지하기 위함. 실패/취소 시에만 loading 을 풀어 다시 시도 가능.

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -16,7 +16,12 @@ export interface Account {
 interface AuthState {
   account: Account | null
   loading: boolean
+  // #109: Firebase 인증은 성공했지만 백엔드 `/v1/accounts/info` 등록이 실패해서
+  // account 가 null 로 남는 경우, 로그인 화면이 stuck 되지 않도록 viewmodel 이 관측할 수 있는 신호.
+  // null = 정상 / 'account_register_failed' = 직전 시도가 백엔드 실패.
+  signInError: string | null
   setAccount: (account: Account | null) => void
+  clearSignInError: () => void
   reset: () => void
 }
 
@@ -31,11 +36,12 @@ export const useAuthStore = create<AuthState>((set, get) => {
       }
       try {
         const account = await apiClient.put<Account>('/v1/accounts/info', {})
-        set({ account, loading: false })
+        set({ account, loading: false, signInError: null })
         initialAuthDone = true
       } catch (e) {
         console.warn('계정 등록 실패:', e)
-        set({ account: null, loading: false })
+        // #109: account 는 null 그대로 두되, viewmodel 이 관측할 수 있는 fail 신호를 set 한다.
+        set({ account: null, loading: false, signInError: 'account_register_failed' })
       }
     } else {
       set({ account: null, loading: false })
@@ -45,9 +51,11 @@ export const useAuthStore = create<AuthState>((set, get) => {
   return {
     account: null,
     loading: true,
+    signInError: null,
     setAccount: (account) => set({ account }),
+    clearSignInError: () => set({ signInError: null }),
     reset: () => {
-      set({ account: null, loading: false })
+      set({ account: null, loading: false, signInError: null })
       initialAuthDone = false
     },
   }

--- a/tests/pages/Login/LoginPage.test.tsx
+++ b/tests/pages/Login/LoginPage.test.tsx
@@ -67,17 +67,6 @@ describe('LoginPage', () => {
     await waitFor(() => expect(mockSignInWithApple).toHaveBeenCalledOnce())
   })
 
-  it('로그인 시도 중에는 버튼이 비활성화된다', async () => {
-    mockSignInWithGoogle.mockReturnValue(new Promise(() => {})) // never resolves
-    renderLoginPage()
-
-    fireEvent.click(screen.getByRole('button', { name: /google/i }))
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /google/i })).toBeDisabled()
-    })
-  })
-
   it('로그인 실패 시 에러 메시지가 표시된다', async () => {
     mockSignInWithGoogle.mockRejectedValue(new Error('로그인 실패'))
     renderLoginPage()
@@ -100,6 +89,50 @@ describe('LoginPage', () => {
 
     await waitFor(() => {
       expect(screen.queryByRole('alert')).toBeNull()
+    })
+  })
+
+  // #109: 로그인 → 메인화면 진입 사이 시간 텀 동안 사용자에게 진행 중 상태를 보여준다.
+  // useLoginViewModel 은 성공 시 loading=true 를 유지해 LoginPage 가 unmount(account 세팅 → Navigate)
+  // 될 때까지 전환 로딩 화면을 그릴 수 있게 한다.
+  describe('#109 로그인 전환 로딩 표시', () => {
+    it('로그인 시도 중에는 status 역할의 로딩 인디케이터가 표시된다', async () => {
+      mockSignInWithGoogle.mockReturnValue(new Promise(() => {})) // never resolves
+      renderLoginPage()
+
+      fireEvent.click(screen.getByRole('button', { name: /google/i }))
+
+      // 로딩 상태로 들어가면 status (role=status) 인디케이터가 노출
+      const status = await screen.findByRole('status')
+      expect(status).toBeInTheDocument()
+    })
+
+    it('로그인 시도 중에는 google/apple 버튼이 DOM 에서 사라진다 (전환 화면)', async () => {
+      mockSignInWithGoogle.mockReturnValue(new Promise(() => {})) // never resolves
+      renderLoginPage()
+
+      fireEvent.click(screen.getByRole('button', { name: /google/i }))
+
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: /google/i })).toBeNull()
+        expect(screen.queryByRole('button', { name: /apple/i })).toBeNull()
+      })
+    })
+
+    it('로그인 시도 실패(cancelled) 후에는 로그인 버튼이 다시 노출된다', async () => {
+      // 팝업 닫힘 — 에러 메시지는 안 표시되지만 다시 시도할 수 있어야 함
+      const cancelledError = Object.assign(new Error('popup closed'), {
+        code: 'auth/popup-closed-by-user',
+      })
+      mockSignInWithGoogle.mockRejectedValue(cancelledError)
+      renderLoginPage()
+
+      fireEvent.click(screen.getByRole('button', { name: /google/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /google/i })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /apple/i })).toBeInTheDocument()
+      })
     })
   })
 })

--- a/tests/pages/Login/useLoginViewModel.test.ts
+++ b/tests/pages/Login/useLoginViewModel.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
+import { renderHook, act, waitFor } from '@testing-library/react'
 import { createElement } from 'react'
 import { RepositoriesProvider } from '../../../src/composition/RepositoriesProvider'
 import { useLoginViewModel } from '../../../src/pages/Login/useLoginViewModel'
 import { AuthError } from '../../../src/domain/errors/AuthError'
+import { useAuthStore } from '../../../src/stores/authStore'
 import type { Repositories } from '../../../src/composition/container'
 
 // ── Firebase / API 부수 초기화 차단 ─────────────────────────────────
@@ -52,6 +53,11 @@ function makeWrapper(repos: Repositories) {
 }
 
 describe('useLoginViewModel', () => {
+  // #109: authStore 의 signInError 신호를 viewmodel 이 관측하므로 각 테스트 전 초기화한다.
+  beforeEach(() => {
+    useAuthStore.setState({ account: null, loading: false, signInError: null })
+  })
+
   describe('초기 상태', () => {
     it('loading은 false, errorKey는 null이다', () => {
       const authRepo = createFakeAuthRepo()
@@ -225,6 +231,58 @@ describe('useLoginViewModel', () => {
       })
 
       expect(result.current.errorKey).toBeNull()
+    })
+  })
+
+  // #109: stuck-spinner 회귀 차단.
+  // Firebase 인증은 성공했으나 authStore 의 백엔드 account 등록이 실패한 경우 (signInError 신호),
+  // viewmodel 은 loading 을 해제하고 errorKey 를 설정해 사용자가 재시도할 수 있어야 한다.
+  describe('signInError 신호 (백엔드 account 등록 실패)', () => {
+    it('로그인 시도 중 signInError 신호가 set 되면 loading 이 해제되고 errorKey 가 설정된다', async () => {
+      const authRepo = createFakeAuthRepo()
+      const { result } = renderHook(
+        () => useLoginViewModel(),
+        { wrapper: makeWrapper(createFakeRepos(authRepo)) },
+      )
+
+      // when: signInWithGoogle 가 resolve 됐지만 LoginPage 는 unmount 되지 않은 상태
+      await act(async () => {
+        await result.current.signInWithGoogle()
+      })
+      expect(result.current.loading).toBe(true)
+
+      // 백엔드 account 등록 실패 신호 도착
+      act(() => {
+        useAuthStore.setState({ signInError: 'account_register_failed' })
+      })
+
+      // then: 사용자 재시도 가능 상태 — loading 풀리고 errorKey 노출
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+        expect(result.current.errorKey).toBe('error.unknown')
+      })
+    })
+
+    it('Apple 로그인 경로에서도 signInError 신호로 loading 이 해제된다', async () => {
+      const authRepo = createFakeAuthRepo()
+      const { result } = renderHook(
+        () => useLoginViewModel(),
+        { wrapper: makeWrapper(createFakeRepos(authRepo)) },
+      )
+
+      await act(async () => {
+        await result.current.signInWithApple()
+      })
+      expect(result.current.loading).toBe(true)
+
+      act(() => {
+        useAuthStore.setState({ signInError: 'account_register_failed' })
+      })
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+        expect(result.current.errorKey).toBe('error.unknown')
+      })
     })
   })
 })

--- a/tests/pages/Login/useLoginViewModel.test.ts
+++ b/tests/pages/Login/useLoginViewModel.test.ts
@@ -65,7 +65,9 @@ describe('useLoginViewModel', () => {
   })
 
   describe('signInWithGoogle', () => {
-    it('성공 시 errorKey가 null로 유지된다', async () => {
+    // #109: 로그인 성공 후 authStore 의 account 가 세팅되고 LoginPage 가 Navigate 로 unmount 되기까지
+    // 시간 텀이 있다. 이 동안 vm.loading=true 를 유지해 LoginPage 가 전환 중 로딩 표시를 그릴 수 있게 한다.
+    it('성공 시 errorKey 는 null, loading 은 true 로 유지된다 (페이지 전환 대기)', async () => {
       const authRepo = createFakeAuthRepo()
       const { result } = renderHook(
         () => useLoginViewModel(),
@@ -77,10 +79,10 @@ describe('useLoginViewModel', () => {
       })
 
       expect(result.current.errorKey).toBeNull()
-      expect(result.current.loading).toBe(false)
+      expect(result.current.loading).toBe(true)
     })
 
-    it('AuthError(cancelled) 시 errorKey가 null로 유지된다', async () => {
+    it('AuthError(cancelled) 시 errorKey 는 null, loading 은 false 로 해제된다', async () => {
       const authRepo = createFakeAuthRepo({
         signInWithGoogle: () => Promise.reject(new AuthError({ type: 'cancelled' })),
       })
@@ -94,9 +96,11 @@ describe('useLoginViewModel', () => {
       })
 
       expect(result.current.errorKey).toBeNull()
+      // #109: 취소는 다시 시도할 수 있도록 loading 해제 (전환 대기 아님)
+      expect(result.current.loading).toBe(false)
     })
 
-    it('auth/popup-closed-by-user 에러 시 errorKey가 null로 유지된다', async () => {
+    it('auth/popup-closed-by-user 에러 시 errorKey 는 null, loading 은 false 로 해제된다', async () => {
       const popupClosedError = Object.assign(new Error('popup closed'), {
         code: 'auth/popup-closed-by-user',
       })
@@ -113,9 +117,10 @@ describe('useLoginViewModel', () => {
       })
 
       expect(result.current.errorKey).toBeNull()
+      expect(result.current.loading).toBe(false)
     })
 
-    it('AuthError(network) 시 errorKey가 설정된다', async () => {
+    it('AuthError(network) 시 errorKey 가 설정되고 loading 은 false', async () => {
       const authRepo = createFakeAuthRepo({
         signInWithGoogle: () => Promise.reject(new AuthError({ type: 'network' })),
       })
@@ -129,9 +134,10 @@ describe('useLoginViewModel', () => {
       })
 
       expect(result.current.errorKey).toBe('error.auth.network')
+      expect(result.current.loading).toBe(false)
     })
 
-    it('알 수 없는 에러 시 errorKey가 error.unknown으로 설정된다', async () => {
+    it('알 수 없는 에러 시 errorKey 가 error.unknown 이고 loading 은 false', async () => {
       const authRepo = createFakeAuthRepo({
         signInWithGoogle: () => Promise.reject(new Error('unknown')),
       })
@@ -145,11 +151,12 @@ describe('useLoginViewModel', () => {
       })
 
       expect(result.current.errorKey).toBe('error.unknown')
+      expect(result.current.loading).toBe(false)
     })
   })
 
   describe('signInWithApple', () => {
-    it('성공 시 errorKey가 null로 유지된다', async () => {
+    it('성공 시 errorKey 는 null, loading 은 true 로 유지된다 (페이지 전환 대기)', async () => {
       const authRepo = createFakeAuthRepo()
       const { result } = renderHook(
         () => useLoginViewModel(),
@@ -161,10 +168,10 @@ describe('useLoginViewModel', () => {
       })
 
       expect(result.current.errorKey).toBeNull()
-      expect(result.current.loading).toBe(false)
+      expect(result.current.loading).toBe(true)
     })
 
-    it('AuthError(cancelled) 시 errorKey가 null로 유지된다', async () => {
+    it('AuthError(cancelled) 시 errorKey 는 null, loading 은 false 로 해제된다', async () => {
       const authRepo = createFakeAuthRepo({
         signInWithApple: () => Promise.reject(new AuthError({ type: 'cancelled' })),
       })
@@ -178,6 +185,7 @@ describe('useLoginViewModel', () => {
       })
 
       expect(result.current.errorKey).toBeNull()
+      expect(result.current.loading).toBe(false)
     })
 
     it('알 수 없는 에러 시 errorKey가 error.unknown으로 설정된다', async () => {

--- a/tests/stores/authStore.test.ts
+++ b/tests/stores/authStore.test.ts
@@ -42,7 +42,7 @@ describe('authStore', () => {
       expect(state.loading).toBe(false)
     })
 
-    it('계정 등록 실패 시 account는 null이고 loading은 끝난다', async () => {
+    it('계정 등록 실패 시 account는 null이고 loading은 끝나며 signInError 신호가 set 된다', async () => {
       // given
       const { apiClient } = await import('../../src/api/apiClient')
       vi.mocked(apiClient.put).mockRejectedValue(new Error('network error'))
@@ -54,6 +54,19 @@ describe('authStore', () => {
       const state = useAuthStore.getState()
       expect(state.account).toBeNull()
       expect(state.loading).toBe(false)
+      // #109: 로그인 화면이 stuck 되지 않도록 fail 신호를 노출한다.
+      expect(state.signInError).toBe('account_register_failed')
+    })
+
+    it('계정 등록 성공 시 signInError 는 null 로 유지된다', async () => {
+      // given: 직전 시도가 실패해 signInError 가 set 되어 있던 상황
+      useAuthStore.setState({ signInError: 'account_register_failed' })
+
+      // when
+      await authCallbackRef.current({ uid: 'firebase-user' })
+
+      // then
+      expect(useAuthStore.getState().signInError).toBeNull()
     })
 
     it('미인증 상태를 받으면 account가 null이고 loading이 끝난다', async () => {
@@ -101,6 +114,31 @@ describe('authStore', () => {
       // then
       expect(useAuthStore.getState().account).toBeNull()
       expect(useAuthStore.getState().loading).toBe(false)
+    })
+
+    it('reset 호출 시 signInError 도 초기화된다', () => {
+      // given
+      useAuthStore.setState({ signInError: 'account_register_failed' })
+
+      // when
+      useAuthStore.getState().reset()
+
+      // then
+      expect(useAuthStore.getState().signInError).toBeNull()
+    })
+  })
+
+  // #109: viewmodel 이 신호 처리를 마친 뒤 명시적으로 클리어할 수 있어야 한다.
+  describe('clearSignInError', () => {
+    it('clearSignInError 호출 시 signInError 가 null 로 돌아간다', () => {
+      // given
+      useAuthStore.setState({ signInError: 'account_register_failed' })
+
+      // when
+      useAuthStore.getState().clearSignInError()
+
+      // then
+      expect(useAuthStore.getState().signInError).toBeNull()
     })
   })
 })


### PR DESCRIPTION
closes #109

## 문제
- 로그인 버튼 클릭 → authRepo.signIn 호출 성공 → useLoginViewModel 의 finally 블록이 setLoading(false) 호출 → 그러나 authStore.account 는 onAuthStateChanged 리스너로 비동기 set 되므로 시간 텀 발생.
- 이 텀 동안 LoginPage 는 vm.loading=false / account=null 상태로 정상 버튼만 표시 → 사용자는 진행 중 여부를 알 수 없음.

## 접근
- `useLoginViewModel` — 성공 시 setLoading(false) 를 풀지 않고 유지. authStore.account 가 set 되어 LoginPage 가 `<Navigate to=\"/\">` 로 unmount 될 때까지 전환 로딩 화면 유지.
- 실패 / 취소 / popup-closed 분기에서만 setLoading(false) 호출 — 사용자 재시도 가능.
- `LoginPage` — vm.loading 일 때 google/apple 버튼 자리를 `role=status` spinner + "로그인 중..." 메시지로 swap. 동일 카드 안에서 위치 변화 없이 진행 인지.
- i18n: `login.signing_in` (ko/en).

## 회귀 테스트
- useLoginViewModel: 성공 시 loading=true, 취소/popup-closed/네트워크 에러 시 loading=false 분기별 검증.
- LoginPage: loading 진입 시 status 인디케이터 노출 + buttons 사라짐, cancelled 후 buttons 복귀.

## Test plan
- [ ] Google 로그인 시도 → 로딩 spinner + "로그인 중..." 표시 → 메인 진입 확인.
- [ ] Apple 로그인 동일 확인.
- [ ] 팝업 닫기로 취소 시 로그인 버튼이 다시 보이고 재시도 가능한지 확인.