### PR TITLE
[#116] 모바일 레이아웃 대응 (드로어 + 인라인 스택 + sheet)

### DIFF
--- a/e2e/mobile-layout.spec.ts
+++ b/e2e/mobile-layout.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect, devices } from '@playwright/test'
+import { setupAuthContext } from './helpers/auth'
+
+// iPhone 13 viewport(390×844) + 터치 에뮬레이션. WebKit이 설치된 환경에서는
+// `...devices['iPhone 13']` 그대로 사용하면 defaultBrowserType이 webkit으로 설정된다.
+// 현재 환경에서는 chromium만 설치되어 있으므로 viewport/touch 설정만 추출해 사용.
+test.use({
+  viewport: { width: 390, height: 844 },
+  deviceScaleFactor: 3,
+  isMobile: true,
+  hasTouch: true,
+  userAgent: devices['iPhone 13'].userAgent,
+})
+
+test('모바일: 햄버거 → 드로어 → 닫기, 날짜 탭 → RightPanel, 새 이벤트 → 라우트 진입', async ({
+  context,
+  page,
+}) => {
+  await setupAuthContext(context)
+  await page.goto('/')
+
+  // 메인 화면 진입 확인
+  await expect(page.getByTestId('main-flex')).toBeVisible()
+
+  // 1) 햄버거 버튼 → 드로어 열림
+  // aria-label: t('main.toggle_sidebar', '사이드바 토글') — fallback '사이드바 토글'
+  await page.getByRole('button', { name: /사이드바 토글|toggle sidebar/i }).click()
+  await expect(page.getByTestId('drawer-backdrop')).toBeVisible()
+
+  // 2) 백드롭 클릭 → 드로어 닫힘
+  await page.getByTestId('drawer-backdrop').click()
+  await expect(page.getByTestId('drawer-backdrop')).toBeHidden()
+
+  // 3) 오늘 날짜 셀 탭 → RightPanel h1 노출
+  await page.locator('[data-testid="day-cell"][data-today]').first().click()
+  await expect(page.locator('h1').first()).toBeVisible()
+
+  // 4) "+ Create" 버튼 클릭 → 메뉴 노출 → Todo 선택 → /todos/new 라우트 진입
+  await page.getByTestId('create-event-button').click()
+  await page.getByRole('menuitem', { name: /todo/i }).click()
+  await expect(page).toHaveURL(/\/todos\/new/)
+})

--- a/src/components/CreateEventButton.tsx
+++ b/src/components/CreateEventButton.tsx
@@ -1,12 +1,12 @@
 import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useEventFormStore } from '../stores/eventFormStore'
+import { useOpenEventForm } from '../hooks/useOpenEventForm'
 import { cn } from '@/lib/utils'
 
 export function CreateEventButton() {
   const { t } = useTranslation()
   const buttonRef = useRef<HTMLButtonElement>(null)
-  const openForm = useEventFormStore(s => s.openForm)
+  const openForm = useOpenEventForm()
   const [showMenu, setShowMenu] = useState(false)
 
   function handleSelect(type: 'todo' | 'schedule') {

--- a/src/components/DoneTodoDetail/DoneTodoDetailPopover.tsx
+++ b/src/components/DoneTodoDetail/DoneTodoDetailPopover.tsx
@@ -9,6 +9,8 @@ import { tagDisplayName } from '../../domain/functions/tagDisplay'
 import { ConfirmDialog } from '../ConfirmDialog'
 import { EventTimeDisplay } from '../EventTimeDisplay'
 import { formatNotification } from '../../utils/formatNotification'
+import { useIsMobile } from '../../hooks/useIsMobile'
+import { BottomSheet } from '../ui/BottomSheet'
 
 const POPOVER_WIDTH = 320
 const THRESHOLD = 200
@@ -33,26 +35,22 @@ export function DoneTodoDetailPopover({
   onDeleted,
 }: DoneTodoDetailPopoverProps) {
   const { t, i18n } = useTranslation()
+  const isMobile = useIsMobile()
   const vm = useDoneTodoDetailPopoverViewModel(doneTodo)
   const resolved = useResolvedEventTag(doneTodo.event_tag_id)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
   // ESC 닫기 — ConfirmDialog 가 떠 있는 동안에는 dialog 자체의 ESC 핸들러가 onCancel 을 처리하도록
   // popover 측 ESC 는 showDeleteConfirm guard 로 일시 비활성. dialog 가 닫히면 다시 활성.
+  // 모바일에서는 BottomSheet 가 자체적으로 ESC 를 처리하므로 등록 skip.
   useEffect(() => {
+    if (isMobile) return
     function onKey(e: KeyboardEvent) {
       if (e.key === 'Escape' && !showDeleteConfirm) onClose()
     }
     document.addEventListener('keydown', onKey)
     return () => document.removeEventListener('keydown', onKey)
-  }, [onClose, showDeleteConfirm])
-
-  // 위치 계산 — EventDetailPopover 와 동일 inline 패턴
-  const showBelow = window.innerHeight - anchorRect.bottom > THRESHOLD
-  const top = showBelow ? anchorRect.bottom + 4 : anchorRect.top - 4
-  const translateY = showBelow ? '0' : '-100%'
-  const leftRaw = anchorRect.left
-  const left = Math.min(leftRaw, window.innerWidth - POPOVER_WIDTH - 16)
+  }, [onClose, showDeleteConfirm, isMobile])
 
   const dateLocale = i18n.language === 'en' ? 'en-US' : 'ko-KR'
   const doneTimeText = doneTodo.done_at
@@ -72,6 +70,132 @@ export function DoneTodoDetailPopover({
   const tagColor = resolved.color
   const tagName = tagDisplayName(resolved, t)
 
+  const body = (
+    <>
+      {/* 우상단 3 버튼 */}
+      <div className="absolute top-3 right-3 flex items-center gap-1">
+        <button
+          type="button"
+          aria-label={t('todo.revert', '되돌리기')}
+          disabled={vm.isReverting}
+          onClick={async () => {
+            // 실패 시 popover 는 그대로 두고 토스트만 노출 — 사용자 재시도 동선 보존
+            const ok = await vm.revert()
+            if (ok) onReverted()
+          }}
+          className={ACTION_BTN}
+        >
+          <RotateCcw className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          aria-label={t('common.delete', '삭제')}
+          disabled={vm.isDeleting}
+          onClick={() => setShowDeleteConfirm(true)}
+          className={`${ACTION_BTN} hover:text-danger hover:bg-danger/10`}
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          aria-label={t('common.close', '닫기')}
+          onClick={onClose}
+          className={ACTION_BTN}
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* 이름 + 태그 */}
+      <p className="pr-24 text-lg font-semibold text-fg">{doneTodo.name}</p>
+      <div className="mt-1 flex items-center gap-2">
+        <span className="h-2 w-2 rounded-full" style={{ backgroundColor: tagColor }} />
+        <span className="text-xs text-fg-secondary">{tagName}</span>
+      </div>
+
+      {/* 본문: 시간 / 알림 / url / memo / place */}
+      <div className="mt-4 space-y-2">
+        {doneTimeText && (
+          <div className={INFO_ROW}>
+            <Clock className={INFO_ICON} />
+            <div>
+              <p className="text-section-label uppercase tracking-wider text-fg-quaternary">{t('todo.done_at_label', '완료 시각')}</p>
+              <p>{doneTimeText}</p>
+            </div>
+          </div>
+        )}
+        {originEventTime && (
+          <div className={INFO_ROW}>
+            <Clock className={INFO_ICON} />
+            <div>
+              <p className="text-section-label uppercase tracking-wider text-fg-quaternary">{t('todo.original_time_label', '원래 시간')}</p>
+              <p><EventTimeDisplay eventTime={originEventTime} /></p>
+            </div>
+          </div>
+        )}
+        {notificationText && (
+          <div className={INFO_ROW}>
+            <Bell className={INFO_ICON} />
+            <p>{notificationText}</p>
+          </div>
+        )}
+        {vm.detail?.url && (
+          <div className={INFO_ROW}>
+            <Link2 className={INFO_ICON} />
+            <a
+              href={vm.detail.url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-fg underline underline-offset-2 hover:opacity-60 transition-opacity truncate"
+            >
+              {vm.detail.url}
+            </a>
+          </div>
+        )}
+        {vm.detail?.memo && (
+          <div className={INFO_ROW}>
+            <FileText className={INFO_ICON} />
+            <p className="whitespace-pre-wrap">{vm.detail.memo}</p>
+          </div>
+        )}
+        {vm.detail?.place && (
+          <div className={INFO_ROW}>
+            <MapPin className={INFO_ICON} />
+            <p>{vm.detail.place}</p>
+          </div>
+        )}
+      </div>
+    </>
+  )
+
+  if (isMobile) {
+    return (
+      <>
+        <BottomSheet open onClose={onClose}>{body}</BottomSheet>
+        {showDeleteConfirm && (
+          <ConfirmDialog
+            message={t('todo.done_delete_confirm')}
+            danger
+            onConfirm={async () => {
+              const ok = await vm.remove()
+              setShowDeleteConfirm(false)
+              // 실패 시에는 popover 를 닫지 않아 사용자가 재시도하거나 확인할 수 있게 한다
+              if (ok) onDeleted()
+            }}
+            onCancel={() => setShowDeleteConfirm(false)}
+          />
+        )}
+      </>
+    )
+  }
+
+  // 데스크톱: 기존 좌표 anchored 카드
+  const showBelow = window.innerHeight - anchorRect.bottom > THRESHOLD
+  const top = showBelow ? anchorRect.bottom + 4 : anchorRect.top - 4
+  const translateY = showBelow ? '0' : '-100%'
+  const leftRaw = anchorRect.left
+  const left = Math.min(leftRaw, window.innerWidth - POPOVER_WIDTH - 16)
+
   const popover = (
     <>
       {/* 백드롭 */}
@@ -87,100 +211,7 @@ export function DoneTodoDetailPopover({
         data-testid="done-todo-detail-popover"
       >
         <h2 className="sr-only">{t('todo.done_detail_title', '완료된 할 일')}</h2>
-
-        {/* 우상단 3 버튼 */}
-        <div className="absolute top-3 right-3 flex items-center gap-1">
-          <button
-            type="button"
-            aria-label={t('todo.revert', '되돌리기')}
-            disabled={vm.isReverting}
-            onClick={async () => {
-              // 실패 시 popover 는 그대로 두고 토스트만 노출 — 사용자 재시도 동선 보존
-              const ok = await vm.revert()
-              if (ok) onReverted()
-            }}
-            className={ACTION_BTN}
-          >
-            <RotateCcw className="h-4 w-4" />
-          </button>
-          <button
-            type="button"
-            aria-label={t('common.delete', '삭제')}
-            disabled={vm.isDeleting}
-            onClick={() => setShowDeleteConfirm(true)}
-            className={`${ACTION_BTN} hover:text-danger hover:bg-danger/10`}
-          >
-            <Trash2 className="h-4 w-4" />
-          </button>
-          <button
-            type="button"
-            aria-label={t('common.close', '닫기')}
-            onClick={onClose}
-            className={ACTION_BTN}
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-
-        {/* 이름 + 태그 */}
-        <p className="pr-24 text-lg font-semibold text-fg">{doneTodo.name}</p>
-        <div className="mt-1 flex items-center gap-2">
-          <span className="h-2 w-2 rounded-full" style={{ backgroundColor: tagColor }} />
-          <span className="text-xs text-fg-secondary">{tagName}</span>
-        </div>
-
-        {/* 본문: 시간 / 알림 / url / memo / place */}
-        <div className="mt-4 space-y-2">
-          {doneTimeText && (
-            <div className={INFO_ROW}>
-              <Clock className={INFO_ICON} />
-              <div>
-                <p className="text-section-label uppercase tracking-wider text-fg-quaternary">{t('todo.done_at_label', '완료 시각')}</p>
-                <p>{doneTimeText}</p>
-              </div>
-            </div>
-          )}
-          {originEventTime && (
-            <div className={INFO_ROW}>
-              <Clock className={INFO_ICON} />
-              <div>
-                <p className="text-section-label uppercase tracking-wider text-fg-quaternary">{t('todo.original_time_label', '원래 시간')}</p>
-                <p><EventTimeDisplay eventTime={originEventTime} /></p>
-              </div>
-            </div>
-          )}
-          {notificationText && (
-            <div className={INFO_ROW}>
-              <Bell className={INFO_ICON} />
-              <p>{notificationText}</p>
-            </div>
-          )}
-          {vm.detail?.url && (
-            <div className={INFO_ROW}>
-              <Link2 className={INFO_ICON} />
-              <a
-                href={vm.detail.url}
-                target="_blank"
-                rel="noreferrer"
-                className="text-fg underline underline-offset-2 hover:opacity-60 transition-opacity truncate"
-              >
-                {vm.detail.url}
-              </a>
-            </div>
-          )}
-          {vm.detail?.memo && (
-            <div className={INFO_ROW}>
-              <FileText className={INFO_ICON} />
-              <p className="whitespace-pre-wrap">{vm.detail.memo}</p>
-            </div>
-          )}
-          {vm.detail?.place && (
-            <div className={INFO_ROW}>
-              <MapPin className={INFO_ICON} />
-              <p>{vm.detail.place}</p>
-            </div>
-          )}
-        </div>
+        {body}
       </div>
 
       {showDeleteConfirm && (

--- a/src/components/EventDetail/EventDetailPopover.tsx
+++ b/src/components/EventDetail/EventDetailPopover.tsx
@@ -10,6 +10,8 @@ import { tagDisplayName } from '../../domain/functions/tagDisplay'
 import { EventTimeDisplay } from '../EventTimeDisplay'
 import { useEventDetailPopoverViewModel } from './useEventDetailPopoverViewModel'
 import { formatNotification } from '../../utils/formatNotification'
+import { useIsMobile } from '../../hooks/useIsMobile'
+import { BottomSheet } from '../ui/BottomSheet'
 
 function repeatingLabel(repeating: Repeating, t: TFunction): string {
   const { option } = repeating
@@ -43,6 +45,7 @@ export function EventDetailPopover({
   onDelete,
 }: EventDetailPopoverProps) {
   const { t } = useTranslation()
+  const isMobile = useIsMobile()
   const vm = useEventDetailPopoverViewModel(calEvent)
 
   const event = calEvent.event
@@ -54,14 +57,134 @@ export function EventDetailPopover({
   const notifications = event.notification_options ?? null
 
   useEffect(() => {
+    if (isMobile) return  // BottomSheet가 처리
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key === 'Escape') onClose()
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [onClose])
+  }, [onClose, isMobile])
 
-  // Position — show below if enough space, otherwise above
+  const body = (
+    <>
+      {/* 헤더 — 이벤트 이름 + 액션 3버튼 */}
+      <div className="flex items-start gap-2 px-4 pt-3.5 pb-3 border-b border-line">
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <span
+            className="h-2 w-2 shrink-0 rounded-full ring-2 ring-surface-elevated"
+            style={{ backgroundColor: tagColor }}
+            data-testid="tag-color-dot"
+          />
+          <h3 className="text-[15px] font-semibold text-fg leading-snug break-words min-w-0">
+            {event.name}
+          </h3>
+        </div>
+        <div className="flex gap-0.5 shrink-0 -mr-1">
+          <button
+            className={ACTION_BTN}
+            data-testid="popover-edit-btn"
+            aria-label={t('common.edit', '수정')}
+            onClick={onEdit}
+          >
+            <Pencil className="h-4 w-4" />
+          </button>
+          <button
+            className={ACTION_BTN}
+            data-testid="popover-delete-btn"
+            aria-label={t('common.delete', '삭제')}
+            onClick={onDelete}
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+          <button
+            className={ACTION_BTN}
+            data-testid="popover-close-btn"
+            aria-label={t('common.close', '닫기')}
+            onClick={onClose}
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* 바디 — 태그 pill + info rows */}
+      <div className="px-4 py-3 space-y-2.5">
+        {tagName && (
+          <div data-testid="popover-tag-name">
+            <span
+              className="inline-block text-meta font-semibold px-1.5 py-0.5 rounded-full leading-none"
+              style={{ color: tagColor, backgroundColor: `${tagColor}22` }}
+            >
+              {tagName}
+            </span>
+          </div>
+        )}
+
+        {eventTime && (
+          <div className={INFO_ROW}>
+            <Clock className={INFO_ICON} />
+            <span className="min-w-0">
+              <EventTimeDisplay eventTime={eventTime} />
+            </span>
+          </div>
+        )}
+
+        {repeating && (
+          <div className={INFO_ROW} data-testid="repeating-info">
+            <Repeat className={INFO_ICON} />
+            <span className="min-w-0">{repeatingLabel(repeating, t)}</span>
+          </div>
+        )}
+
+        {notifications && notifications.length > 0 && (
+          <div className={INFO_ROW} data-testid="notification-info">
+            <Bell className={INFO_ICON} />
+            <span className="min-w-0 break-words">
+              {notifications.map(n => formatNotification(n, t)).join(', ')}
+            </span>
+          </div>
+        )}
+
+        {vm.eventDetail?.place && (
+          <div className={INFO_ROW}>
+            <MapPin className={INFO_ICON} />
+            <span className="min-w-0 break-words">{vm.eventDetail.place}</span>
+          </div>
+        )}
+
+        {vm.eventDetail?.url && (
+          <div className={INFO_ROW}>
+            <Link2 className={INFO_ICON} />
+            <a
+              href={vm.eventDetail.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="min-w-0 text-fg underline underline-offset-2 hover:opacity-60 transition-opacity break-all"
+            >
+              {vm.eventDetail.url}
+            </a>
+          </div>
+        )}
+
+        {vm.eventDetail?.memo && (
+          <div className={INFO_ROW}>
+            <FileText className={INFO_ICON} />
+            <span className="min-w-0 whitespace-pre-wrap break-words">{vm.eventDetail.memo}</span>
+          </div>
+        )}
+      </div>
+    </>
+  )
+
+  if (isMobile) {
+    return (
+      <BottomSheet open onClose={onClose}>
+        {body}
+      </BottomSheet>
+    )
+  }
+
+  // 데스크톱: 기존 좌표 anchored 카드
   const THRESHOLD = 300
   const showBelow = window.innerHeight - anchorRect.bottom > THRESHOLD
   const top = showBelow ? anchorRect.bottom + 4 : anchorRect.top - 4
@@ -82,112 +205,7 @@ export function EventDetailPopover({
         style={{ top, left, transform: `translateY(${translateY})` }}
         data-testid="event-detail-popover"
       >
-        {/* 헤더 — 이벤트 이름 + 액션 3버튼 */}
-        <div className="flex items-start gap-2 px-4 pt-3.5 pb-3 border-b border-line">
-          <div className="flex items-center gap-2 flex-1 min-w-0">
-            <span
-              className="h-2 w-2 shrink-0 rounded-full ring-2 ring-surface-elevated"
-              style={{ backgroundColor: tagColor }}
-              data-testid="tag-color-dot"
-            />
-            <h3 className="text-[15px] font-semibold text-fg leading-snug break-words min-w-0">
-              {event.name}
-            </h3>
-          </div>
-          <div className="flex gap-0.5 shrink-0 -mr-1">
-            <button
-              className={ACTION_BTN}
-              data-testid="popover-edit-btn"
-              aria-label={t('common.edit', '수정')}
-              onClick={onEdit}
-            >
-              <Pencil className="h-4 w-4" />
-            </button>
-            <button
-              className={ACTION_BTN}
-              data-testid="popover-delete-btn"
-              aria-label={t('common.delete', '삭제')}
-              onClick={onDelete}
-            >
-              <Trash2 className="h-4 w-4" />
-            </button>
-            <button
-              className={ACTION_BTN}
-              data-testid="popover-close-btn"
-              aria-label={t('common.close', '닫기')}
-              onClick={onClose}
-            >
-              <X className="h-4 w-4" />
-            </button>
-          </div>
-        </div>
-
-        {/* 바디 — 태그 pill + info rows */}
-        <div className="px-4 py-3 space-y-2.5">
-          {tagName && (
-            <div data-testid="popover-tag-name">
-              <span
-                className="inline-block text-meta font-semibold px-1.5 py-0.5 rounded-full leading-none"
-                style={{ color: tagColor, backgroundColor: `${tagColor}22` }}
-              >
-                {tagName}
-              </span>
-            </div>
-          )}
-
-          {eventTime && (
-            <div className={INFO_ROW}>
-              <Clock className={INFO_ICON} />
-              <span className="min-w-0">
-                <EventTimeDisplay eventTime={eventTime} />
-              </span>
-            </div>
-          )}
-
-          {repeating && (
-            <div className={INFO_ROW} data-testid="repeating-info">
-              <Repeat className={INFO_ICON} />
-              <span className="min-w-0">{repeatingLabel(repeating, t)}</span>
-            </div>
-          )}
-
-          {notifications && notifications.length > 0 && (
-            <div className={INFO_ROW} data-testid="notification-info">
-              <Bell className={INFO_ICON} />
-              <span className="min-w-0 break-words">
-                {notifications.map(n => formatNotification(n, t)).join(', ')}
-              </span>
-            </div>
-          )}
-
-          {vm.eventDetail?.place && (
-            <div className={INFO_ROW}>
-              <MapPin className={INFO_ICON} />
-              <span className="min-w-0 break-words">{vm.eventDetail.place}</span>
-            </div>
-          )}
-
-          {vm.eventDetail?.url && (
-            <div className={INFO_ROW}>
-              <Link2 className={INFO_ICON} />
-              <a
-                href={vm.eventDetail.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="min-w-0 text-fg underline underline-offset-2 hover:opacity-60 transition-opacity break-all"
-              >
-                {vm.eventDetail.url}
-              </a>
-            </div>
-          )}
-
-          {vm.eventDetail?.memo && (
-            <div className={INFO_ROW}>
-              <FileText className={INFO_ICON} />
-              <span className="min-w-0 whitespace-pre-wrap break-words">{vm.eventDetail.memo}</span>
-            </div>
-          )}
-        </div>
+        {body}
       </div>
     </>
   )

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -84,6 +84,7 @@ export default function LeftSidebar(props: LeftSidebarProps) {
   const content = <LeftSidebarContent {...props} />
 
   if (isMobile) {
+    // Drawer는 open=true 일 때만 렌더되므로 toggle = close로 동치 — onClose에 onToggleSidebar 그대로 위임
     return (
       <Drawer open={props.sidebarOpen} onClose={props.onToggleSidebar}>
         <div className="flex h-full flex-col bg-surface-elevated px-3 pt-4 pb-4 overflow-y-auto">

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -3,9 +3,11 @@ import { useTranslation } from 'react-i18next'
 import type { DayButton } from 'react-day-picker'
 import { Calendar } from '@/components/ui/calendar'
 import CalendarList from './CalendarList'
+import { Drawer } from '@/components/ui/Drawer'
 import { formatDateKey } from '../domain/functions/eventTime'
 import { cn } from '@/lib/utils'
 import { SIDEBAR_WIDTH_CLASS } from '../constants/layout'
+import { useIsMobile } from '../hooks/useIsMobile'
 
 const WEEKDAY_KEYS = [
   'calendar.weekdays.sun',
@@ -74,17 +76,51 @@ export interface LeftSidebarProps {
   onSetSelectedDate: (date: Date) => void
   onSetSidebarMonth: (date: Date) => void
   onOpenEventForm: (rect: DOMRect | null, type: 'todo' | 'schedule') => void
+  onToggleSidebar: () => void
 }
 
-export default function LeftSidebar({
-  sidebarOpen,
+export default function LeftSidebar(props: LeftSidebarProps) {
+  const isMobile = useIsMobile()
+  const content = <LeftSidebarContent {...props} />
+
+  if (isMobile) {
+    return (
+      <Drawer open={props.sidebarOpen} onClose={props.onToggleSidebar}>
+        <div className="flex h-full flex-col bg-surface-elevated px-3 pt-4 pb-4 overflow-y-auto">
+          {content}
+        </div>
+      </Drawer>
+    )
+  }
+
+  // 데스크톱: 기존 인라인 width 토글
+  return (
+    <div
+      className={cn(
+        'hidden md:flex flex-col transition-[width] duration-200 bg-surface-elevated overflow-hidden shrink-0',
+        props.sidebarOpen ? SIDEBAR_WIDTH_CLASS : 'w-0'
+      )}
+    >
+      <div
+        className={cn(
+          'flex-1 overflow-y-auto flex flex-col px-3 pt-4 pb-4 transition-opacity duration-150',
+          props.sidebarOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        )}
+      >
+        {content}
+      </div>
+    </div>
+  )
+}
+
+function LeftSidebarContent({
   sidebarMonth,
   selectedDate,
   getHolidayNames,
   onSetSelectedDate,
   onSetSidebarMonth,
   onOpenEventForm,
-}: LeftSidebarProps) {
+}: Omit<LeftSidebarProps, 'sidebarOpen' | 'onToggleSidebar'>) {
   const { t } = useTranslation()
   const [showCreateMenu, setShowCreateMenu] = useState(false)
   const createButtonRef = useRef<HTMLButtonElement>(null)
@@ -95,121 +131,109 @@ export default function LeftSidebar({
   }
 
   return (
-    <div
-      className={cn(
-        'hidden md:flex flex-col transition-[width] duration-200 bg-surface-elevated overflow-hidden shrink-0',
-        sidebarOpen ? SIDEBAR_WIDTH_CLASS : 'w-0'
-      )}
-    >
-      <div
-        className={cn(
-          'flex-1 overflow-y-auto flex flex-col px-3 pt-4 pb-4 transition-opacity duration-150',
-          sidebarOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
-        )}
-      >
-        {/* Section: Create CTA */}
-        <div className="relative">
-          <button
-            ref={createButtonRef}
-            data-testid="sidebar-create-event"
-            aria-haspopup="menu"
-            aria-expanded={showCreateMenu}
-            className="flex w-full items-center justify-between rounded-full bg-surface border border-line px-4 py-2.5 shadow-sm hover:shadow transition-shadow"
-            onClick={() => setShowCreateMenu(!showCreateMenu)}
-          >
-            <span className="flex items-center gap-2 text-fg">
-              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-              </svg>
-              <span className="text-sm font-medium">{t('main.create_event', 'Create')}</span>
-            </span>
-            <svg
-              className={cn('h-3.5 w-3.5 text-fg-tertiary transition-transform', showCreateMenu && 'rotate-180')}
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 9l-7 7-7-7" />
+    <>
+      {/* Section: Create CTA */}
+      <div className="relative">
+        <button
+          ref={createButtonRef}
+          data-testid="sidebar-create-event"
+          aria-haspopup="menu"
+          aria-expanded={showCreateMenu}
+          className="flex w-full items-center justify-between rounded-full bg-surface border border-line px-4 py-2.5 shadow-sm hover:shadow transition-shadow"
+          onClick={() => setShowCreateMenu(!showCreateMenu)}
+        >
+          <span className="flex items-center gap-2 text-fg">
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
             </svg>
-          </button>
-          {showCreateMenu && (
-            <>
-              <div className="fixed inset-0 z-40" onClick={() => setShowCreateMenu(false)} />
-              <div
-                role="menu"
-                className="absolute top-full left-0 mt-1.5 z-50 w-full overflow-hidden rounded-xl bg-surface-elevated border border-line shadow-lg"
+            <span className="text-sm font-medium">{t('main.create_event', 'Create')}</span>
+          </span>
+          <svg
+            className={cn('h-3.5 w-3.5 text-fg-tertiary transition-transform', showCreateMenu && 'rotate-180')}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+        {showCreateMenu && (
+          <>
+            <div className="fixed inset-0 z-40" onClick={() => setShowCreateMenu(false)} />
+            <div
+              role="menu"
+              className="absolute top-full left-0 mt-1.5 z-50 w-full overflow-hidden rounded-xl bg-surface-elevated border border-line shadow-lg"
+            >
+              <button
+                role="menuitem"
+                className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken transition-colors"
+                onClick={() => {
+                  setShowCreateMenu(false)
+                  const rect = createButtonRef.current?.getBoundingClientRect() ?? null
+                  onOpenEventForm(rect, 'todo')
+                }}
               >
-                <button
-                  role="menuitem"
-                  className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken transition-colors"
-                  onClick={() => {
-                    setShowCreateMenu(false)
-                    const rect = createButtonRef.current?.getBoundingClientRect() ?? null
-                    onOpenEventForm(rect, 'todo')
-                  }}
-                >
-                  <svg className="h-4 w-4 text-fg-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                  </svg>
-                  Todo
-                </button>
-                <div className="border-t border-line" />
-                <button
-                  role="menuitem"
-                  className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken transition-colors"
-                  onClick={() => {
-                    setShowCreateMenu(false)
-                    const rect = createButtonRef.current?.getBoundingClientRect() ?? null
-                    onOpenEventForm(rect, 'schedule')
-                  }}
-                >
-                  <svg className="h-4 w-4 text-fg-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                  </svg>
-                  Schedule
-                </button>
-              </div>
-            </>
-          )}
-        </div>
-        {/* Section: Mini Calendar */}
-        <div className="mt-5">
-          <Calendar
-            className="!bg-transparent"
-            mode="single"
-            selected={selectedDate ?? undefined}
-            onSelect={(date) => date && onSetSelectedDate(date)}
-            month={sidebarMonth}
-            onMonthChange={onSetSidebarMonth}
-            formatters={{ formatWeekdayName }}
-            modifiers={{ sunday: isSundayModifier }}
-            classNames={{
-              root: 'w-full bg-transparent',
-              months: 'relative flex flex-col gap-0',
-              month: 'flex w-full flex-col gap-2',
-              month_caption: 'flex h-7 w-full items-center justify-center px-7',
-              caption_label: 'text-sm font-semibold text-fg select-none',
-              nav: 'absolute inset-x-0 top-0 flex w-full items-center justify-between',
-              button_previous: 'rounded p-0.5 hover:bg-surface-sunken text-fg-secondary h-7 w-7 flex items-center justify-center transition-colors',
-              button_next: 'rounded p-0.5 hover:bg-surface-sunken text-fg-secondary h-7 w-7 flex items-center justify-center transition-colors',
-              weekdays: 'flex',
-              weekday: 'flex-1 text-center text-meta font-normal uppercase tracking-wide text-fg-tertiary py-1',
-              week: 'mt-0.5 flex w-full',
-              day: 'flex-1 flex items-center justify-center py-0.5',
-              today: '',
-              selected: '',
-              outside: '',
-            }}
-            components={{
-              DayButton: (props) => <MiniCalendarDayButton {...props} getHolidayNames={getHolidayNames} />,
-            }}
-          />
-        </div>
-        {/* Section: Tag Filters */}
-        <div className="mt-6 flex-1">
-          <CalendarList />
-        </div>
+                <svg className="h-4 w-4 text-fg-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                Todo
+              </button>
+              <div className="border-t border-line" />
+              <button
+                role="menuitem"
+                className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-medium text-fg hover:bg-surface-sunken transition-colors"
+                onClick={() => {
+                  setShowCreateMenu(false)
+                  const rect = createButtonRef.current?.getBoundingClientRect() ?? null
+                  onOpenEventForm(rect, 'schedule')
+                }}
+              >
+                <svg className="h-4 w-4 text-fg-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                Schedule
+              </button>
+            </div>
+          </>
+        )}
       </div>
-    </div>
+      {/* Section: Mini Calendar */}
+      <div className="mt-5">
+        <Calendar
+          className="!bg-transparent"
+          mode="single"
+          selected={selectedDate ?? undefined}
+          onSelect={(date) => date && onSetSelectedDate(date)}
+          month={sidebarMonth}
+          onMonthChange={onSetSidebarMonth}
+          formatters={{ formatWeekdayName }}
+          modifiers={{ sunday: isSundayModifier }}
+          classNames={{
+            root: 'w-full bg-transparent',
+            months: 'relative flex flex-col gap-0',
+            month: 'flex w-full flex-col gap-2',
+            month_caption: 'flex h-7 w-full items-center justify-center px-7',
+            caption_label: 'text-sm font-semibold text-fg select-none',
+            nav: 'absolute inset-x-0 top-0 flex w-full items-center justify-between',
+            button_previous: 'rounded p-0.5 hover:bg-surface-sunken text-fg-secondary h-7 w-7 flex items-center justify-center transition-colors',
+            button_next: 'rounded p-0.5 hover:bg-surface-sunken text-fg-secondary h-7 w-7 flex items-center justify-center transition-colors',
+            weekdays: 'flex',
+            weekday: 'flex-1 text-center text-meta font-normal uppercase tracking-wide text-fg-tertiary py-1',
+            week: 'mt-0.5 flex w-full',
+            day: 'flex-1 flex items-center justify-center py-0.5',
+            today: '',
+            selected: '',
+            outside: '',
+          }}
+          components={{
+            DayButton: (props) => <MiniCalendarDayButton {...props} getHolidayNames={getHolidayNames} />,
+          }}
+        />
+      </div>
+      {/* Section: Tag Filters */}
+      <div className="mt-6 flex-1">
+        <CalendarList />
+      </div>
+    </>
   )
 }

--- a/src/components/RightEventPanel.tsx
+++ b/src/components/RightEventPanel.tsx
@@ -11,6 +11,7 @@ import { DayEventList } from './DayEventList'
 import { QuickTodoInput } from './QuickTodoInput'
 import { CreateEventButton } from './CreateEventButton'
 import { ArchivePanel } from './ArchivePanel'
+import { useIsMobile } from '../hooks/useIsMobile'
 import type { RightPanelMode } from '../stores/uiStore'
 
 function formatLunarDate(date: Date, locale: string): string | null {
@@ -69,6 +70,7 @@ export function RightEventPanel({
   onDoneTodoClick,
 }: RightEventPanelProps) {
   const { t, i18n } = useTranslation()
+  const isMobile = useIsMobile()
   const dateLocale = i18n.language === 'en' ? 'en-US' : 'ko-KR'
 
   if (rightPanelMode === 'archive') {
@@ -95,15 +97,17 @@ export function RightEventPanel({
         >
           <CheckCircle2 className="h-4 w-4" />
         </button>
-        <button
-          onClick={onToggleRightPanel}
-          aria-label={t('common.close', '패널 닫기')}
-          className="p-1.5 rounded-full hover:bg-surface-sunken transition-colors text-fg-quaternary hover:text-fg-secondary"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M6 6l12 12M18 6L6 18" />
-          </svg>
-        </button>
+        {!isMobile && (
+          <button
+            onClick={onToggleRightPanel}
+            aria-label={t('common.close', '패널 닫기')}
+            className="p-1.5 rounded-full hover:bg-surface-sunken transition-colors text-fg-quaternary hover:text-fg-secondary"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M6 6l12 12M18 6L6 18" />
+            </svg>
+          </button>
+        )}
       </div>
 
       {/* 스크롤 영역 */}
@@ -163,7 +167,7 @@ export function RightEventPanel({
       </div>
 
       {/* 하단 고정 */}
-      <div className="shrink-0 border-t border-line p-4 flex flex-col gap-2">
+      <div className="shrink-0 border-t border-line p-4 pb-[max(theme(spacing.4),env(safe-area-inset-bottom))] flex flex-col gap-2">
         <QuickTodoInput />
         <CreateEventButton />
       </div>

--- a/src/components/RightEventPanel.tsx
+++ b/src/components/RightEventPanel.tsx
@@ -167,7 +167,7 @@ export function RightEventPanel({
       </div>
 
       {/* 하단 고정 */}
-      <div className="shrink-0 border-t border-line p-4 pb-[max(theme(spacing.4),env(safe-area-inset-bottom))] flex flex-col gap-2">
+      <div className="shrink-0 border-t border-line p-4 pb-[max(1rem,env(safe-area-inset-bottom))] flex flex-col gap-2">
         <QuickTodoInput />
         <CreateEventButton />
       </div>

--- a/src/components/TopToolbar.tsx
+++ b/src/components/TopToolbar.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/utils'
 import { SIDEBAR_WIDTH_CLASS } from '../constants/layout'
+import { useIsMobile } from '../hooks/useIsMobile'
 import TestDataSeederButton from './dev/TestDataSeederButton'
 
 export interface TopToolbarProps {
@@ -27,6 +28,7 @@ export default function TopToolbar({
 }: TopToolbarProps) {
   const { t, i18n } = useTranslation()
   const navigate = useNavigate()
+  const isMobile = useIsMobile()
 
   const year = currentMonth.getFullYear()
   const dateLocale = i18n.language === 'en' ? 'en-US' : 'ko-KR'
@@ -49,11 +51,11 @@ export default function TopToolbar({
           <div className="h-full w-1/3 bg-brand animate-events-loading-bar" />
         </div>
       )}
-      {/* 좌측: 햄버거 + 로고 (사이드바 너비와 동기화) */}
+      {/* 좌측: 햄버거 + 로고 (사이드바 너비와 동기화) — 모바일은 항상 w-12 */}
       <div
         className={cn(
           'shrink-0 flex items-center overflow-hidden transition-all duration-200',
-          sidebarOpen ? SIDEBAR_WIDTH_CLASS : 'w-12'
+          isMobile ? 'w-12' : sidebarOpen ? SIDEBAR_WIDTH_CLASS : 'w-12'
         )}
       >
         <button
@@ -65,17 +67,19 @@ export default function TopToolbar({
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
           </svg>
         </button>
-        <div
-          className={cn(
-            'flex items-center gap-2 transition-all duration-200',
-            sidebarOpen ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-1 pointer-events-none'
-          )}
-        >
-          <img src="/logo-light.png" alt="To-do Calendar" className="h-7 shrink-0" />
-          <span className="text-xs font-semibold uppercase tracking-[0.18em] text-fg whitespace-nowrap">
-            To-do Calendar
-          </span>
-        </div>
+        {!isMobile && (
+          <div
+            className={cn(
+              'flex items-center gap-2 transition-all duration-200',
+              sidebarOpen ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-1 pointer-events-none'
+            )}
+          >
+            <img src="/logo-light.png" alt="To-do Calendar" className="h-7 shrink-0" />
+            <span className="text-xs font-semibold uppercase tracking-[0.18em] text-fg whitespace-nowrap">
+              To-do Calendar
+            </span>
+          </div>
+        )}
       </div>
 
       {/* 중앙: 월 네비 + 오늘 + 우측 액션 */}

--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import { cn } from '@/lib/utils'
+
+export interface BottomSheetProps {
+  open: boolean
+  onClose: () => void
+  children: ReactNode
+  className?: string
+}
+
+const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+export function BottomSheet({ open, onClose, children, className }: BottomSheetProps) {
+  const sheetRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        onClose()
+        return
+      }
+      if (e.key !== 'Tab' || !sheetRef.current) return
+      const focusables = Array.from(sheetRef.current.querySelectorAll<HTMLElement>(FOCUSABLE))
+      if (focusables.length === 0) return
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      const active = document.activeElement as HTMLElement | null
+      if (e.shiftKey && active === first) { last.focus(); e.preventDefault() }
+      else if (!e.shiftKey && active === last) { first.focus(); e.preventDefault() }
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return createPortal(
+    <>
+      <div
+        data-testid="bottom-sheet-backdrop"
+        className="fixed inset-0 z-40 bg-black/40 animate-in fade-in-0 duration-150"
+        onClick={onClose}
+      />
+      <div
+        ref={sheetRef}
+        role="dialog"
+        aria-modal="true"
+        className={cn(
+          'fixed inset-x-0 bottom-0 z-50 max-h-[85vh] overflow-y-auto rounded-t-2xl bg-surface-elevated shadow-2xl pb-[env(safe-area-inset-bottom)] animate-in slide-in-from-bottom duration-200',
+          className,
+        )}
+      >
+        <div className="flex justify-center pt-2 pb-1">
+          <div aria-hidden className="h-1 w-9 rounded-full bg-fg-quaternary/40" />
+        </div>
+        {children}
+      </div>
+    </>,
+    document.body,
+  )
+}

--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -16,6 +16,10 @@ export function BottomSheet({ open, onClose, children, className }: BottomSheetP
 
   useEffect(() => {
     if (!open) return
+    // open 시 sheet 내부 첫 focusable로 초점 이동 — focus trap이 의미 있으려면 초점이 sheet 안에 있어야 함
+    const initial = sheetRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE)
+    initial?.[0]?.focus()
+
     function handleKey(e: KeyboardEvent) {
       if (e.key === 'Escape') {
         onClose()

--- a/src/components/ui/Drawer.tsx
+++ b/src/components/ui/Drawer.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import { cn } from '@/lib/utils'
+
+export interface DrawerProps {
+  open: boolean
+  onClose: () => void
+  children: ReactNode
+  className?: string
+}
+
+const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+export function Drawer({ open, onClose, children, className }: DrawerProps) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    // open 시 drawer 내부 첫 focusable로 초점 이동 — focus trap이 의미 있으려면 초점이 안에 있어야 함
+    const initial = ref.current?.querySelectorAll<HTMLElement>(FOCUSABLE)
+    initial?.[0]?.focus()
+
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        onClose()
+        return
+      }
+      if (e.key !== 'Tab' || !ref.current) return
+      const focusables = Array.from(ref.current.querySelectorAll<HTMLElement>(FOCUSABLE))
+      if (focusables.length === 0) return
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      const active = document.activeElement as HTMLElement | null
+      if (e.shiftKey && active === first) { last.focus(); e.preventDefault() }
+      else if (!e.shiftKey && active === last) { first.focus(); e.preventDefault() }
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return createPortal(
+    <>
+      <div
+        data-testid="drawer-backdrop"
+        className="fixed inset-0 z-40 bg-black/35 animate-in fade-in-0 duration-150"
+        onClick={onClose}
+      />
+      <div
+        ref={ref}
+        role="dialog"
+        aria-modal="true"
+        className={cn(
+          'fixed inset-y-0 left-0 z-50 w-64 bg-surface-elevated shadow-2xl animate-in slide-in-from-left duration-200',
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </>,
+    document.body,
+  )
+}

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+
+const MOBILE_QUERY = '(max-width: 767px)'
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return window.matchMedia(MOBILE_QUERY).matches
+  })
+
+  useEffect(() => {
+    const mql = window.matchMedia(MOBILE_QUERY)
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches)
+    setIsMobile(mql.matches)
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [])
+
+  return isMobile
+}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -16,7 +16,8 @@ export function useKeyboardShortcuts() {
 
       switch (e.key) {
         case 'n': {
-          // New event (Todo by default) — open popover instead of navigating
+          // 'n' 단축키는 데스크톱 power user용 — 모바일은 useOpenEventForm으로 라우트 분기되지만
+          // 키보드 단축키 자체가 모바일 viewport에서 사실상 트리거되지 않으므로 분기 없이 store 직접 호출.
           const formStore = useEventFormStore.getState()
           if (formStore.isOpen) return  // 이미 폼 열림
           formStore.openForm(null, 'todo')

--- a/src/hooks/useOpenEventForm.ts
+++ b/src/hooks/useOpenEventForm.ts
@@ -1,0 +1,18 @@
+import { useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useIsMobile } from './useIsMobile'
+import { useEventFormStore } from '../stores/eventFormStore'
+
+export function useOpenEventForm() {
+  const isMobile = useIsMobile()
+  const navigate = useNavigate()
+  const openForm = useEventFormStore(s => s.openForm)
+
+  return useCallback((rect: DOMRect | null, type: 'todo' | 'schedule') => {
+    if (isMobile) {
+      navigate(type === 'todo' ? '/todos/new' : '/schedules/new')
+      return
+    }
+    openForm(rect, type)
+  }, [isMobile, navigate, openForm])
+}

--- a/src/pages/Main/MainPage.tsx
+++ b/src/pages/Main/MainPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
+import { cn } from '@/lib/utils'
 import TopToolbar from '../../components/TopToolbar'
 import LeftSidebar from '../../components/LeftSidebar'
 import MainCalendar from '../../calendar/MainCalendar'
@@ -102,7 +103,7 @@ export function MainPage() {
           onGoToNextMonth={vm.goToNextMonth}
           onRefresh={vm.refresh}
         />
-        <div className="flex flex-1 min-h-0">
+        <div data-testid="main-flex" className="flex flex-1 min-h-0 flex-col md:flex-row">
           <LeftSidebar
             sidebarOpen={vm.sidebarOpen}
             sidebarMonth={vm.sidebarMonth}
@@ -113,21 +114,25 @@ export function MainPage() {
             onOpenEventForm={vm.openEventForm}
             onToggleSidebar={vm.toggleSidebar}
           />
-          <MainCalendar
-            currentMonth={vm.currentMonth}
-            weekStartDay={vm.weekStartDay}
-            eventDisplayLevel={vm.eventDisplayLevel}
-            onEventClick={handleEventClick}
-          />
+          <div data-testid="main-calendar-wrap" className="flex flex-col h-[50vh] md:h-auto md:flex-1 overflow-hidden">
+            <MainCalendar
+              currentMonth={vm.currentMonth}
+              weekStartDay={vm.weekStartDay}
+              eventDisplayLevel={vm.eventDisplayLevel}
+              onEventClick={handleEventClick}
+            />
+          </div>
 
-          {/* 인라인 패널: 열리면 중앙 캘린더가 줄어듦 */}
+          {/* 인라인 RightPanel: 모바일에선 항상 stack(아래), 데스크톱은 토글 width */}
           <div
-            className={`shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out ${
-              vm.rightPanelOpen ? 'w-[408px]' : 'w-0'
-            }`}
+            className={cn(
+              'shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out',
+              'w-full md:w-0',
+              vm.rightPanelOpen ? 'md:w-[408px]' : 'md:w-0',
+            )}
           >
-            <div className="w-[408px] h-full py-4 pr-4">
-              <div className="h-full rounded-lg border border-line bg-surface shadow-sm overflow-hidden">
+            <div className="w-full md:w-[408px] h-full md:py-4 md:pr-4">
+              <div className="h-full md:rounded-lg md:border md:border-line bg-surface md:shadow-sm overflow-hidden">
                 <RightEventPanel
                   selectedDate={vm.selectedDate}
                   rightPanelMode={vm.rightPanelMode}

--- a/src/pages/Main/MainPage.tsx
+++ b/src/pages/Main/MainPage.tsx
@@ -111,6 +111,7 @@ export function MainPage() {
             onSetSelectedDate={vm.setSelectedDate}
             onSetSidebarMonth={vm.setSidebarMonth}
             onOpenEventForm={vm.openEventForm}
+            onToggleSidebar={vm.toggleSidebar}
           />
           <MainCalendar
             currentMonth={vm.currentMonth}

--- a/src/pages/Main/useMainViewModel.ts
+++ b/src/pages/Main/useMainViewModel.ts
@@ -7,7 +7,7 @@ import { useHolidayCache } from '../../repositories/caches/holidayCache'
 import { useForemostEventCache } from '../../repositories/caches/foremostEventCache'
 import { useEventTagListCache } from '../../repositories/caches/eventTagListCache'
 import { useSettingsCache, type WeekStartDay, type EventDisplayLevel } from '../../repositories/caches/settingsCache'
-import { useEventFormStore } from '../../stores/eventFormStore'
+import { useOpenEventForm } from '../../hooks/useOpenEventForm'
 import { useCurrentTodos } from '../../repositories/hooks/useCurrentTodos'
 import { useUncompletedTodos } from '../../repositories/hooks/useUncompletedTodos'
 import { useMonthEvents } from '../../repositories/hooks/useMonthEvents'
@@ -92,7 +92,7 @@ export function useMainViewModel(): MainViewModel {
   const exitArchivePanel = useUiStore(s => s.exitArchivePanel)
 
   // ── 이벤트 폼 액션 ───────────────────────────────────────────────
-  const openEventForm = useEventFormStore(s => s.openForm)
+  const openEventForm = useOpenEventForm()
 
   // ── 설정 ──────────────────────────────────────────────────────────
   const weekStartDay = useSettingsCache(s => s.calendarAppearance.weekStartDay)

--- a/src/pages/ScheduleForm/ScheduleFormPage.tsx
+++ b/src/pages/ScheduleForm/ScheduleFormPage.tsx
@@ -133,13 +133,13 @@ export function ScheduleFormPage() {
       {vm.errorKey && vm.errorKey.includes('invalid_') && (
         <div
           role="alert"
-          className="border-b border-destructive/20 bg-destructive/10 px-6 py-2 text-sm text-destructive"
+          className="border-b border-destructive/20 bg-destructive/10 px-4 md:px-6 py-2 text-sm text-destructive"
         >
           {t(vm.errorKey)}
         </div>
       )}
 
-      <div className={`max-w-5xl px-6 py-6 space-y-6 ${vm.loading ? 'pointer-events-none opacity-60' : ''}`}>
+      <div className={`max-w-5xl px-4 md:px-6 py-6 space-y-6 ${vm.loading ? 'pointer-events-none opacity-60' : ''}`}>
         <EventTimeSection
           eventTime={vm.eventTime}
           onEventTimeChange={vm.setEventTime}

--- a/src/pages/TodoForm/TodoFormPage.tsx
+++ b/src/pages/TodoForm/TodoFormPage.tsx
@@ -139,7 +139,7 @@ export function TodoFormPage() {
       {vm.errorKey && vm.errorKey.includes('invalid_') && (
         <div
           role="alert"
-          className="border-b border-destructive/20 bg-destructive/10 px-6 py-2 text-sm text-destructive"
+          className="border-b border-destructive/20 bg-destructive/10 px-4 md:px-6 py-2 text-sm text-destructive"
         >
           {t(vm.errorKey)}
         </div>
@@ -147,13 +147,13 @@ export function TodoFormPage() {
       {inlineError && (
         <div
           role="alert"
-          className="border-b border-destructive/20 bg-destructive/10 px-6 py-2 text-sm text-destructive"
+          className="border-b border-destructive/20 bg-destructive/10 px-4 md:px-6 py-2 text-sm text-destructive"
         >
           {inlineError}
         </div>
       )}
 
-      <div className={`max-w-5xl px-6 py-6 space-y-6 ${vm.loading ? 'pointer-events-none opacity-60' : ''}`}>
+      <div className={`max-w-5xl px-4 md:px-6 py-6 space-y-6 ${vm.loading ? 'pointer-events-none opacity-60' : ''}`}>
         <EventTimeSection
           eventTime={vm.eventTime}
           onEventTimeChange={vm.setEventTime}

--- a/tests/components/CreateEventButton.test.tsx
+++ b/tests/components/CreateEventButton.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import userEvent from '@testing-library/user-event'
 import { CreateEventButton } from '../../src/components/CreateEventButton'
 import { useEventFormStore } from '../../src/stores/eventFormStore'
@@ -9,19 +10,23 @@ vi.mock('../../src/firebase', () => ({
   db: {},
 }))
 
+function renderWithRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>)
+}
+
 describe('CreateEventButton', () => {
   beforeEach(() => {
     useEventFormStore.getState().closeForm()
   })
 
   it('새 이벤트 버튼을 렌더링한다', () => {
-    render(<CreateEventButton />)
+    renderWithRouter(<CreateEventButton />)
 
     expect(screen.getByRole('button', { name: '새 이벤트' })).toBeInTheDocument()
   })
 
   it('클릭 후 Todo를 선택하면 todo 타입으로 폼이 열린다', async () => {
-    render(<CreateEventButton />)
+    renderWithRouter(<CreateEventButton />)
 
     // when: 버튼 클릭 → 드롭다운 표시 → Todo 선택
     await userEvent.click(screen.getByRole('button', { name: '새 이벤트' }))

--- a/tests/components/DoneTodoDetail/DoneTodoDetailPopover.test.tsx
+++ b/tests/components/DoneTodoDetail/DoneTodoDetailPopover.test.tsx
@@ -178,5 +178,6 @@ describe('DoneTodoDetailPopover', () => {
 
     // then: BottomSheet 백드롭이 보이고, 데스크톱 floating 카드는 같이 뜨지 않는다
     expect(screen.getByTestId('bottom-sheet-backdrop')).toBeInTheDocument()
+    expect(screen.queryByTestId('done-todo-detail-popover')).not.toBeInTheDocument()
   })
 })

--- a/tests/components/DoneTodoDetail/DoneTodoDetailPopover.test.tsx
+++ b/tests/components/DoneTodoDetail/DoneTodoDetailPopover.test.tsx
@@ -5,6 +5,11 @@ import { DoneTodoDetailPopover } from '../../../src/components/DoneTodoDetail/Do
 import { useDoneTodosCache } from '../../../src/repositories/caches/doneTodosCache'
 import { useCurrentTodosCache } from '../../../src/repositories/caches/currentTodosCache'
 import type { DoneTodo } from '../../../src/models'
+import { useIsMobile } from '../../../src/hooks/useIsMobile'
+
+vi.mock('../../../src/hooks/useIsMobile', () => ({
+  useIsMobile: vi.fn(() => false),
+}))
 
 const mockGetDoneTodoDetail = vi.fn()
 const mockRevertDoneTodo = vi.fn(async () => ({
@@ -41,6 +46,7 @@ const sample: DoneTodo = {
 }
 
 beforeEach(() => {
+  vi.mocked(useIsMobile).mockReturnValue(false)
   mockGetDoneTodoDetail.mockReset().mockResolvedValue(null)
   mockRevertDoneTodo.mockReset().mockResolvedValue({
     todo: { uuid: 'todo-1', name: '완료된 일', is_current: true },
@@ -150,5 +156,27 @@ describe('DoneTodoDetailPopover', () => {
       expect(useDoneTodosCache.getState().items.find(i => i.uuid === sample.uuid)).toBeUndefined()
     })
     expect(onDeleted).toHaveBeenCalled()
+  })
+
+  it('데스크톱이면 floating 카드로 렌더한다', () => {
+    // given: 데스크톱 환경
+    vi.mocked(useIsMobile).mockReturnValue(false)
+
+    // when: 팝오버 렌더
+    renderPopover()
+
+    // then: BottomSheet 백드롭은 없다
+    expect(screen.queryByTestId('bottom-sheet-backdrop')).not.toBeInTheDocument()
+  })
+
+  it('모바일이면 BottomSheet 백드롭이 렌더된다', () => {
+    // given: 모바일 환경
+    vi.mocked(useIsMobile).mockReturnValue(true)
+
+    // when: 팝오버 렌더
+    renderPopover()
+
+    // then: BottomSheet 백드롭이 보이고, 데스크톱 floating 카드는 같이 뜨지 않는다
+    expect(screen.getByTestId('bottom-sheet-backdrop')).toBeInTheDocument()
   })
 })

--- a/tests/components/EventDetail/EventDetailPopover.test.tsx
+++ b/tests/components/EventDetail/EventDetailPopover.test.tsx
@@ -9,6 +9,11 @@ import type { EventTime, Repeating, NotificationOption } from '../../../src/mode
 import type { EventDetailRepository } from '../../../src/repositories/EventDetailRepository'
 import type { Repositories } from '../../../src/composition/container'
 import { RepositoriesProvider } from '../../../src/composition/RepositoriesProvider'
+import { useIsMobile } from '../../../src/hooks/useIsMobile'
+
+vi.mock('../../../src/hooks/useIsMobile', () => ({
+  useIsMobile: vi.fn(() => false),
+}))
 
 vi.mock('../../../src/api/eventTagApi', () => ({
   eventTagApi: { getAllTags: vi.fn(async () => []) },
@@ -132,6 +137,7 @@ function renderPopover(
 describe('EventDetailPopover', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(useIsMobile).mockReturnValue(false)
     useEventTagListCache.setState({ tags: new Map() })
   })
 
@@ -306,5 +312,31 @@ describe('EventDetailPopover', () => {
     // then
     expect(screen.getByText('팀 미팅')).toBeInTheDocument()
     expect(screen.getByTestId('event-detail-popover')).toBeInTheDocument()
+  })
+
+  it('데스크톱이면 floating 카드(data-testid="event-detail-popover")로 렌더한다', () => {
+    // given: 데스크톱 환경
+    vi.mocked(useIsMobile).mockReturnValue(false)
+    const calEvent = makeTodoEvent()
+
+    // when: 팝오버 렌더
+    renderPopover(calEvent)
+
+    // then: floating 카드가 렌더되고, BottomSheet 백드롭은 없다
+    expect(screen.getByTestId('event-detail-popover')).toBeInTheDocument()
+    expect(screen.queryByTestId('bottom-sheet-backdrop')).not.toBeInTheDocument()
+  })
+
+  it('모바일이면 BottomSheet 백드롭과 함께 같은 본문이 렌더된다', () => {
+    // given: 모바일 환경
+    vi.mocked(useIsMobile).mockReturnValue(true)
+    const calEvent = makeTodoEvent({ name: '모바일 할 일' })
+
+    // when: 팝오버 렌더
+    renderPopover(calEvent)
+
+    // then: BottomSheet 백드롭이 렌더되고, 본문도 함께 보인다
+    expect(screen.getByTestId('bottom-sheet-backdrop')).toBeInTheDocument()
+    expect(screen.getByText('모바일 할 일')).toBeInTheDocument()
   })
 })

--- a/tests/components/EventDetail/EventDetailPopover.test.tsx
+++ b/tests/components/EventDetail/EventDetailPopover.test.tsx
@@ -335,8 +335,9 @@ describe('EventDetailPopover', () => {
     // when: 팝오버 렌더
     renderPopover(calEvent)
 
-    // then: BottomSheet 백드롭이 렌더되고, 본문도 함께 보인다
+    // then: BottomSheet 백드롭이 렌더되고, 본문도 함께 보인다. 데스크톱 floating 카드는 같이 뜨지 않는다.
     expect(screen.getByTestId('bottom-sheet-backdrop')).toBeInTheDocument()
     expect(screen.getByText('모바일 할 일')).toBeInTheDocument()
+    expect(screen.queryByTestId('event-detail-popover')).not.toBeInTheDocument()
   })
 })

--- a/tests/components/LeftSidebar.test.tsx
+++ b/tests/components/LeftSidebar.test.tsx
@@ -44,6 +44,8 @@ function renderSidebar(props?: Partial<LeftSidebarProps>) {
 describe('LeftSidebar', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // 모바일 케이스에서 mockReturnValue(true) 한 게 다음 테스트로 새지 않도록 매번 false로 초기화
+    vi.mocked(useIsMobile).mockReturnValue(false)
     useEventFormStore.getState().closeForm()
   })
 

--- a/tests/components/LeftSidebar.test.tsx
+++ b/tests/components/LeftSidebar.test.tsx
@@ -14,6 +14,11 @@ vi.mock('../../src/api/holidayApi', () => ({
   holidayApi: { getHolidays: async () => ({ items: [] }) },
 }))
 
+vi.mock('../../src/hooks/useIsMobile', () => ({
+  useIsMobile: vi.fn(() => false),
+}))
+import { useIsMobile } from '../../src/hooks/useIsMobile'
+
 function defaultProps(overrides: Partial<LeftSidebarProps> = {}): LeftSidebarProps {
   return {
     sidebarOpen: true,
@@ -23,6 +28,7 @@ function defaultProps(overrides: Partial<LeftSidebarProps> = {}): LeftSidebarPro
     onSetSelectedDate: vi.fn(),
     onSetSidebarMonth: vi.fn(),
     onOpenEventForm: vi.fn(),
+    onToggleSidebar: vi.fn(),
     ...overrides,
   }
 }
@@ -164,5 +170,40 @@ describe('LeftSidebar', () => {
     // then: eventFormStore가 열리고 eventType이 todo
     expect(useEventFormStore.getState().isOpen).toBe(true)
     expect(useEventFormStore.getState().eventType).toBe('todo')
+  })
+
+  it('모바일이고 sidebarOpen=false 이면 Drawer가 렌더되지 않는다', () => {
+    // given
+    vi.mocked(useIsMobile).mockReturnValue(true)
+
+    // when
+    renderSidebar({ sidebarOpen: false })
+
+    // then
+    expect(screen.queryByTestId('drawer-backdrop')).not.toBeInTheDocument()
+  })
+
+  it('모바일이고 sidebarOpen=true 이면 Drawer 백드롭이 렌더된다', () => {
+    // given
+    vi.mocked(useIsMobile).mockReturnValue(true)
+
+    // when
+    renderSidebar({ sidebarOpen: true })
+
+    // then
+    expect(screen.getByTestId('drawer-backdrop')).toBeInTheDocument()
+  })
+
+  it('모바일이고 Drawer 백드롭을 클릭하면 onToggleSidebar가 호출된다', async () => {
+    // given
+    vi.mocked(useIsMobile).mockReturnValue(true)
+    const onToggle = vi.fn()
+    renderSidebar({ sidebarOpen: true, onToggleSidebar: onToggle })
+
+    // when
+    await userEvent.click(screen.getByTestId('drawer-backdrop'))
+
+    // then
+    expect(onToggle).toHaveBeenCalled()
   })
 })

--- a/tests/components/RightEventPanel.test.tsx
+++ b/tests/components/RightEventPanel.test.tsx
@@ -21,6 +21,11 @@ vi.mock('../../src/firebase', () => ({
   getAuthInstance: vi.fn(() => ({})),
   db: {},
 }))
+vi.mock('../../src/hooks/useIsMobile', () => ({
+  useIsMobile: vi.fn(() => false),
+}))
+
+import { useIsMobile } from '../../src/hooks/useIsMobile'
 
 const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async () => {
@@ -60,6 +65,7 @@ function renderComponent(props: Partial<RightEventPanelProps> = {}) {
 describe('RightEventPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(useIsMobile).mockReturnValue(false)
   })
 
   it('QuickTodoInput과 CreateEventButton이 항상 표시된다', () => {
@@ -129,5 +135,17 @@ describe('RightEventPanel', () => {
     // then: 날짜 섹션 없이도 currentTodo가 보임
     expect(screen.getByText('현재 할 일')).toBeInTheDocument()
     expect(screen.queryByText('이벤트가 없습니다')).not.toBeInTheDocument()
+  })
+
+  it('데스크톱에서는 패널 닫기 버튼이 표시된다', () => {
+    vi.mocked(useIsMobile).mockReturnValue(false)
+    renderComponent()
+    expect(screen.getByRole('button', { name: /닫기|패널 닫기/ })).toBeInTheDocument()
+  })
+
+  it('모바일에서는 패널 닫기 버튼이 표시되지 않는다', () => {
+    vi.mocked(useIsMobile).mockReturnValue(true)
+    renderComponent()
+    expect(screen.queryByRole('button', { name: /닫기|패널 닫기/ })).not.toBeInTheDocument()
   })
 })

--- a/tests/components/TopToolbar.test.tsx
+++ b/tests/components/TopToolbar.test.tsx
@@ -3,6 +3,11 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import TopToolbar, { type TopToolbarProps } from '../../src/components/TopToolbar'
 
+vi.mock('../../src/hooks/useIsMobile', () => ({
+  useIsMobile: vi.fn(() => false),
+}))
+import { useIsMobile } from '../../src/hooks/useIsMobile'
+
 const noop = vi.fn()
 
 function defaultProps(overrides: Partial<TopToolbarProps> = {}): TopToolbarProps {
@@ -30,6 +35,7 @@ function renderToolbar(props?: Partial<TopToolbarProps>) {
 describe('TopToolbar', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(useIsMobile).mockReturnValue(false)
   })
 
   it('현재 월 제목을 표시한다', () => {
@@ -145,6 +151,28 @@ describe('TopToolbar', () => {
 
     // then
     expect(screen.getByLabelText(/새로고침|refresh/i)).toBeDisabled()
+  })
+
+  it('데스크톱에서 sidebarOpen=true 이면 로고/라벨이 표시된다', () => {
+    // given
+    vi.mocked(useIsMobile).mockReturnValue(false)
+
+    // when
+    renderToolbar({ sidebarOpen: true })
+
+    // then
+    expect(screen.getByText('To-do Calendar')).toBeInTheDocument()
+  })
+
+  it('모바일이면 sidebarOpen=true 이어도 로고/라벨이 표시되지 않는다', () => {
+    // given
+    vi.mocked(useIsMobile).mockReturnValue(true)
+
+    // when
+    renderToolbar({ sidebarOpen: true })
+
+    // then
+    expect(screen.queryByText('To-do Calendar')).not.toBeInTheDocument()
   })
 
   // #110: 메인화면 진입 후 캘린더는 그려진 상태에서 이벤트 조회 완료까지 시간이 걸리는 동안

--- a/tests/components/ui/BottomSheet.test.tsx
+++ b/tests/components/ui/BottomSheet.test.tsx
@@ -76,4 +76,17 @@ describe('BottomSheet', () => {
     // then
     expect(onClose).not.toHaveBeenCalled()
   })
+
+  it('open 시 sheet 내부 첫 focusable 요소로 초점이 이동한다', () => {
+    // given / when
+    render(
+      <BottomSheet open onClose={vi.fn()}>
+        <button>first</button>
+        <button>second</button>
+      </BottomSheet>
+    )
+
+    // then
+    expect(screen.getByRole('button', { name: 'first' })).toHaveFocus()
+  })
 })

--- a/tests/components/ui/BottomSheet.test.tsx
+++ b/tests/components/ui/BottomSheet.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BottomSheet } from '../../../src/components/ui/BottomSheet'
+
+describe('BottomSheet', () => {
+  it('open=false 이면 콘텐츠를 렌더하지 않는다', () => {
+    // given / when
+    render(
+      <BottomSheet open={false} onClose={vi.fn()}>
+        <p>hidden body</p>
+      </BottomSheet>
+    )
+
+    // then
+    expect(screen.queryByText('hidden body')).not.toBeInTheDocument()
+  })
+
+  it('open=true 이면 콘텐츠와 백드롭을 렌더한다', () => {
+    // given / when
+    render(
+      <BottomSheet open onClose={vi.fn()}>
+        <p>visible body</p>
+      </BottomSheet>
+    )
+
+    // then
+    expect(screen.getByText('visible body')).toBeInTheDocument()
+    expect(screen.getByTestId('bottom-sheet-backdrop')).toBeInTheDocument()
+  })
+
+  it('백드롭 클릭 시 onClose가 호출된다', async () => {
+    // given
+    const onClose = vi.fn()
+    render(
+      <BottomSheet open onClose={onClose}>
+        <p>body</p>
+      </BottomSheet>
+    )
+
+    // when
+    await userEvent.click(screen.getByTestId('bottom-sheet-backdrop'))
+
+    // then
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('Esc 키로 onClose가 호출된다', async () => {
+    // given
+    const onClose = vi.fn()
+    render(
+      <BottomSheet open onClose={onClose}>
+        <p>body</p>
+      </BottomSheet>
+    )
+
+    // when
+    await userEvent.keyboard('{Escape}')
+
+    // then
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('시트 본문 클릭은 onClose를 호출하지 않는다', async () => {
+    // given
+    const onClose = vi.fn()
+    render(
+      <BottomSheet open onClose={onClose}>
+        <button>action</button>
+      </BottomSheet>
+    )
+
+    // when
+    await userEvent.click(screen.getByRole('button', { name: 'action' }))
+
+    // then
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/tests/components/ui/Drawer.test.tsx
+++ b/tests/components/ui/Drawer.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Drawer } from '../../../src/components/ui/Drawer'
+
+describe('Drawer', () => {
+  it('open=false 이면 콘텐츠를 렌더하지 않는다', () => {
+    render(
+      <Drawer open={false} onClose={vi.fn()}>
+        <p>hidden</p>
+      </Drawer>
+    )
+    expect(screen.queryByText('hidden')).not.toBeInTheDocument()
+  })
+
+  it('open=true 이면 콘텐츠와 백드롭을 렌더한다', () => {
+    render(
+      <Drawer open onClose={vi.fn()}>
+        <p>visible</p>
+      </Drawer>
+    )
+    expect(screen.getByText('visible')).toBeInTheDocument()
+    expect(screen.getByTestId('drawer-backdrop')).toBeInTheDocument()
+  })
+
+  it('백드롭 클릭 시 onClose가 호출된다', async () => {
+    const onClose = vi.fn()
+    render(
+      <Drawer open onClose={onClose}>
+        <p>body</p>
+      </Drawer>
+    )
+    await userEvent.click(screen.getByTestId('drawer-backdrop'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('Esc 키로 onClose가 호출된다', async () => {
+    const onClose = vi.fn()
+    render(
+      <Drawer open onClose={onClose}>
+        <p>body</p>
+      </Drawer>
+    )
+    await userEvent.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('open 시 drawer 내부 첫 focusable 요소로 초점이 이동한다', () => {
+    render(
+      <Drawer open onClose={vi.fn()}>
+        <button>first</button>
+        <button>second</button>
+      </Drawer>
+    )
+    expect(screen.getByRole('button', { name: 'first' })).toHaveFocus()
+  })
+})

--- a/tests/components/ui/Drawer.test.tsx
+++ b/tests/components/ui/Drawer.test.tsx
@@ -5,53 +5,88 @@ import { Drawer } from '../../../src/components/ui/Drawer'
 
 describe('Drawer', () => {
   it('open=false 이면 콘텐츠를 렌더하지 않는다', () => {
+    // given / when
     render(
       <Drawer open={false} onClose={vi.fn()}>
         <p>hidden</p>
       </Drawer>
     )
+
+    // then
     expect(screen.queryByText('hidden')).not.toBeInTheDocument()
   })
 
   it('open=true 이면 콘텐츠와 백드롭을 렌더한다', () => {
+    // given / when
     render(
       <Drawer open onClose={vi.fn()}>
         <p>visible</p>
       </Drawer>
     )
+
+    // then
     expect(screen.getByText('visible')).toBeInTheDocument()
     expect(screen.getByTestId('drawer-backdrop')).toBeInTheDocument()
   })
 
   it('백드롭 클릭 시 onClose가 호출된다', async () => {
+    // given
     const onClose = vi.fn()
     render(
       <Drawer open onClose={onClose}>
         <p>body</p>
       </Drawer>
     )
+
+    // when
     await userEvent.click(screen.getByTestId('drawer-backdrop'))
+
+    // then
     expect(onClose).toHaveBeenCalled()
   })
 
   it('Esc 키로 onClose가 호출된다', async () => {
+    // given
     const onClose = vi.fn()
     render(
       <Drawer open onClose={onClose}>
         <p>body</p>
       </Drawer>
     )
+
+    // when
     await userEvent.keyboard('{Escape}')
+
+    // then
     expect(onClose).toHaveBeenCalled()
   })
 
+  it('drawer 본문 클릭은 onClose를 호출하지 않는다', async () => {
+    // given
+    const onClose = vi.fn()
+    render(
+      <Drawer open onClose={onClose}>
+        <button>action</button>
+      </Drawer>
+    )
+
+    // when
+    await userEvent.click(screen.getByRole('button', { name: 'action' }))
+
+    // then
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
   it('open 시 drawer 내부 첫 focusable 요소로 초점이 이동한다', () => {
+    // given / when
     render(
       <Drawer open onClose={vi.fn()}>
         <button>first</button>
         <button>second</button>
       </Drawer>
     )
+
+    // then
     expect(screen.getByRole('button', { name: 'first' })).toHaveFocus()
   })
 })

--- a/tests/hooks/useIsMobile.test.ts
+++ b/tests/hooks/useIsMobile.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useIsMobile } from '../../src/hooks/useIsMobile'
+
+type MQListener = (e: MediaQueryListEvent) => void
+
+function setupMatchMedia(initialMatches: boolean) {
+  let listener: MQListener | null = null
+  const mql = {
+    get matches() { return current },
+    media: '(max-width: 767px)',
+    onchange: null,
+    addEventListener: vi.fn((_: string, l: MQListener) => { listener = l }),
+    removeEventListener: vi.fn(() => { listener = null }),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }
+  let current = initialMatches
+  window.matchMedia = vi.fn().mockReturnValue(mql) as any
+  return {
+    fire(matches: boolean) {
+      current = matches
+      listener?.({ matches } as MediaQueryListEvent)
+    },
+  }
+}
+
+describe('useIsMobile', () => {
+  const original = window.matchMedia
+  afterEach(() => { window.matchMedia = original })
+
+  it('초기 viewport가 모바일이면 true를 반환한다', () => {
+    // given: 모바일 viewport
+    setupMatchMedia(true)
+
+    // when
+    const { result } = renderHook(() => useIsMobile())
+
+    // then
+    expect(result.current).toBe(true)
+  })
+
+  it('초기 viewport가 데스크톱이면 false를 반환한다', () => {
+    // given
+    setupMatchMedia(false)
+
+    // when
+    const { result } = renderHook(() => useIsMobile())
+
+    // then
+    expect(result.current).toBe(false)
+  })
+
+  it('viewport가 데스크톱에서 모바일로 바뀌면 true로 갱신된다', () => {
+    // given
+    const { fire } = setupMatchMedia(false)
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(false)
+
+    // when
+    act(() => fire(true))
+
+    // then
+    expect(result.current).toBe(true)
+  })
+})

--- a/tests/hooks/useOpenEventForm.test.tsx
+++ b/tests/hooks/useOpenEventForm.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { useOpenEventForm } from '../../src/hooks/useOpenEventForm'
+
+vi.mock('../../src/hooks/useIsMobile', () => ({
+  useIsMobile: vi.fn(() => false),
+}))
+import { useIsMobile } from '../../src/hooks/useIsMobile'
+
+const openFormMock = vi.fn()
+vi.mock('../../src/stores/eventFormStore', () => ({
+  useEventFormStore: (selector: any) => selector({ openForm: openFormMock }),
+}))
+
+function LocationProbe({ onLocation }: { onLocation: (path: string) => void }) {
+  const loc = useLocation()
+  onLocation(loc.pathname)
+  return null
+}
+
+function setup() {
+  let path = ''
+  const { result } = renderHook(() => useOpenEventForm(), {
+    wrapper: ({ children }) => (
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/*" element={<><LocationProbe onLocation={p => (path = p)} />{children as any}</>} />
+        </Routes>
+      </MemoryRouter>
+    ),
+  })
+  return { result, getPath: () => path }
+}
+
+describe('useOpenEventForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useIsMobile).mockReturnValue(false)
+  })
+
+  it('데스크톱이면 eventFormStore.openForm으로 위임한다', () => {
+    // given
+    vi.mocked(useIsMobile).mockReturnValue(false)
+    const { result } = setup()
+    const rect = { left: 0, top: 0, right: 0, bottom: 0 } as DOMRect
+
+    // when
+    act(() => result.current(rect, 'todo'))
+
+    // then
+    expect(openFormMock).toHaveBeenCalled()
+  })
+
+  it('모바일이고 type=todo이면 /todos/new로 이동한다', () => {
+    // given
+    vi.mocked(useIsMobile).mockReturnValue(true)
+    const { result, getPath } = setup()
+
+    // when
+    act(() => result.current(null, 'todo'))
+
+    // then
+    expect(getPath()).toBe('/todos/new')
+    expect(openFormMock).not.toHaveBeenCalled()
+  })
+
+  it('모바일이고 type=schedule이면 /schedules/new로 이동한다', () => {
+    // given
+    vi.mocked(useIsMobile).mockReturnValue(true)
+    const { result, getPath } = setup()
+
+    // when
+    act(() => result.current(null, 'schedule'))
+
+    // then
+    expect(getPath()).toBe('/schedules/new')
+  })
+})


### PR DESCRIPTION
## 문제

웹 클라이언트가 데스크톱 3분할(TopToolbar / [LeftSidebar | MainCalendar | RightEventPanel])에 최적화되어 있어, 모바일(< 768px)에선 다음이 깨졌다:

- `LeftSidebar`가 `hidden md:flex` — md 미만에선 영영 안 보이고 햄버거 토글이 무동작.
- `RightEventPanel`이 408px 인라인 — 폰 너비에 안 맞음.
- `EventDetailPopover`(좌표 anchored) / `EventFormPopover`(드래그 카드)가 모바일에서 어색.

(이미 일부는 분기 처리되어 있었음: `MainCalendarGrid` dot 모드, `SettingsPage` master-detail.)

## 접근

큰 틀을 바꾸지 않고 배치만 모바일에 맞춰 재구성. 네이티브 앱이 RightPanel을 캘린더 아래 두는 패턴이라 웹도 동일 패턴. Tailwind `md`(768px)를 단일 분기점으로 유지.

도입한 새 primitive 4개 (`useIsMobile`, `BottomSheet`, `Drawer`, `useOpenEventForm`) 위에 기존 컴포넌트의 컨테이너 클래스만 분기. 데이터/스토어/도메인 인터페이스 무변경.

## 변경 (앵커 단위)

- **`useIsMobile`** — `matchMedia('(max-width: 767px)')` 구독 훅. JS 분기 단일화.
- **`BottomSheet`/`Drawer`** — portal + 백드롭 + slide-in + Esc + focus trap (open 시 첫 focusable로 초점 이동) primitive.
- **`useOpenEventForm`** — 모바일이면 `navigate('/todos/new'·'/schedules/new')`, 데스크톱은 `eventFormStore.openForm` 위임.
- **`MainPage`** — 가로 컨테이너 → `flex-col md:flex-row` 분기. 캘린더 wrapper `h-[50vh] md:h-auto md:flex-1`. RightPanel 인라인 width는 데스크톱(`md:`) 한정, 모바일은 `w-full`.
- **`TopToolbar`** — 모바일에서 로고/라벨 숨김, 좌측 sidebar-sync 박스 `w-12` 고정.
- **`LeftSidebar`** — 모바일이면 `Drawer` overlay로 분기. 컴포넌트 내부 콘텐츠는 `LeftSidebarContent`로 추출해 양쪽 재사용.
- **`RightEventPanel`** — 모바일에서 우상단 X 닫기 버튼 숨김. 하단 sticky 영역에 `pb-[max(1rem,env(safe-area-inset-bottom))]`.
- **`EventDetailPopover` / `DoneTodoDetailPopover`** — 모바일이면 `BottomSheet` 안에 동일 본문 렌더, `useEffect(Esc)`는 모바일에선 BottomSheet에 위임.
- **`CreateEventButton` / `useMainViewModel`** — `eventFormStore.openForm` 직접 호출 → `useOpenEventForm` 사용.
- **`useKeyboardShortcuts`** — 'n' 단축키는 데스크톱 power user용이라 분기 없이 store 직접 호출 유지(주석으로 의도 표시).
- **`TodoFormPage` / `ScheduleFormPage`** — 본문·alert bar 좌우 패딩 `px-4 md:px-6`.
- **E2E** — `e2e/mobile-layout.spec.ts` 추가 (iPhone 13 viewport, 햄버거→드로어→날짜 탭→새 이벤트 라우트). 백엔드 API emulator가 필요해 환경 의존.

그대로 유지: `SettingsPage`(이미 master-detail), `RepeatingScopeDialog`/`ConfirmDialog` 중앙 모달, `LoginPage`/`NotFoundPage` 카드 레이아웃.

## 비범위

- 디자인 시스템(토큰/컬러) 변경 없음
- 데이터/도메인/스토어 인터페이스 변경 없음

## 남은 과제

- E2E 시나리오는 spec만 작성 — 실제 PASS 확인은 백엔드 emulator(Functions, `/v1/accounts/info`) 실행 환경에서 수행 필요.
- `EventDetailPopover`/`DoneTodoDetailPopover`의 `anchorRect` prop을 향후 optional로 정리하는 follow-up 가능 (모바일에서 사용 안 함). 본 PR 범위 외.
- `BottomSheet`의 body scroll lock / `aria-labelledby` 옵션은 후속 a11y 패스에서.

Closes #116

## Test plan

- [ ] `npm test` — 875/877 PASS (2 실패는 `EventTimeDisplay` i18n 로케일 이슈, develop 시점부터 존재)
- [ ] `npm run build` — 통과
- [ ] 모바일 viewport 시각 확인 (DevTools 또는 실기기): 햄버거 드로어 / 캘린더 아래 RightPanel 스택 / 이벤트 클릭 시 bottom sheet / "+ New event" 라우트 진입
- [ ] 데스크톱 회귀: 사이드바 토글 / RightPanel 좌측 닫기 / EventDetail floating 카드 / EventForm 드래그 카드 모두 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)