### PR TITLE
[#121] BottomSheet a11y — body scroll lock + aria-labelledby opt-in

### DIFF
--- a/src/components/DoneTodoDetail/DoneTodoDetailPopover.tsx
+++ b/src/components/DoneTodoDetail/DoneTodoDetailPopover.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from 'react-dom'
-import { useEffect, useState } from 'react'
+import { useEffect, useId, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { RotateCcw, Trash2, X, Clock, Bell, MapPin, FileText, Link2 } from 'lucide-react'
 import type { DoneTodo } from '../../models'
@@ -39,6 +39,7 @@ export function DoneTodoDetailPopover({
   const vm = useDoneTodoDetailPopoverViewModel(doneTodo)
   const resolved = useResolvedEventTag(doneTodo.event_tag_id)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const titleId = useId()
 
   // ESC 닫기 — ConfirmDialog 가 떠 있는 동안에는 dialog 자체의 ESC 핸들러가 onCancel 을 처리하도록
   // popover 측 ESC 는 showDeleteConfirm guard 로 일시 비활성. dialog 가 닫히면 다시 활성.
@@ -107,7 +108,7 @@ export function DoneTodoDetailPopover({
       </div>
 
       {/* 이름 + 태그 */}
-      <p className="pr-24 text-lg font-semibold text-fg">{doneTodo.name}</p>
+      <p id={titleId} className="pr-24 text-lg font-semibold text-fg">{doneTodo.name}</p>
       <div className="mt-1 flex items-center gap-2">
         <span className="h-2 w-2 rounded-full" style={{ backgroundColor: tagColor }} />
         <span className="text-xs text-fg-secondary">{tagName}</span>
@@ -171,7 +172,7 @@ export function DoneTodoDetailPopover({
   if (isMobile) {
     return (
       <>
-        <BottomSheet open onClose={onClose}>{body}</BottomSheet>
+        <BottomSheet open onClose={onClose} aria-labelledby={titleId}>{body}</BottomSheet>
         {showDeleteConfirm && (
           <ConfirmDialog
             message={t('todo.done_delete_confirm')}

--- a/src/components/EventDetail/EventDetailPopover.tsx
+++ b/src/components/EventDetail/EventDetailPopover.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from 'react-dom'
-import { useEffect } from 'react'
+import { useEffect, useId } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { Pencil, Trash2, X, Clock, Repeat, Bell, MapPin, FileText, Link2 } from 'lucide-react'
@@ -47,6 +47,7 @@ export function EventDetailPopover({
   const { t } = useTranslation()
   const isMobile = useIsMobile()
   const vm = useEventDetailPopoverViewModel(calEvent)
+  const titleId = useId()
 
   const event = calEvent.event
   const resolved = useResolvedEventTag(event.event_tag_id)
@@ -75,7 +76,7 @@ export function EventDetailPopover({
             style={{ backgroundColor: tagColor }}
             data-testid="tag-color-dot"
           />
-          <h3 className="text-[15px] font-semibold text-fg leading-snug break-words min-w-0">
+          <h3 id={titleId} className="text-[15px] font-semibold text-fg leading-snug break-words min-w-0">
             {event.name}
           </h3>
         </div>
@@ -178,7 +179,7 @@ export function EventDetailPopover({
 
   if (isMobile) {
     return (
-      <BottomSheet open onClose={onClose}>
+      <BottomSheet open onClose={onClose} aria-labelledby={titleId}>
         {body}
       </BottomSheet>
     )

--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -7,11 +7,13 @@ export interface BottomSheetProps {
   onClose: () => void
   children: ReactNode
   className?: string
+  /** caller 헤더의 id — 스크린리더가 dialog 의미를 announce 할 때 사용 */
+  'aria-labelledby'?: string
 }
 
 const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
 
-export function BottomSheet({ open, onClose, children, className }: BottomSheetProps) {
+export function BottomSheet({ open, onClose, children, className, 'aria-labelledby': ariaLabelledBy }: BottomSheetProps) {
   const sheetRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -19,6 +21,11 @@ export function BottomSheet({ open, onClose, children, className }: BottomSheetP
     // open 시 sheet 내부 첫 focusable로 초점 이동 — focus trap이 의미 있으려면 초점이 sheet 안에 있어야 함
     const initial = sheetRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE)
     initial?.[0]?.focus()
+
+    // body scroll lock — 시트 뒤 본문 스크롤이 모달 인지를 깨뜨리는 걸 막음.
+    // 기존 inline overflow 값을 보존했다 close 시 복원해서 다른 컴포넌트가 설정한 값을 덮지 않음.
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
 
     function handleKey(e: KeyboardEvent) {
       if (e.key === 'Escape') {
@@ -35,7 +42,10 @@ export function BottomSheet({ open, onClose, children, className }: BottomSheetP
       else if (!e.shiftKey && active === last) { first.focus(); e.preventDefault() }
     }
     document.addEventListener('keydown', handleKey)
-    return () => document.removeEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('keydown', handleKey)
+      document.body.style.overflow = previousOverflow
+    }
   }, [open, onClose])
 
   if (!open) return null
@@ -51,6 +61,7 @@ export function BottomSheet({ open, onClose, children, className }: BottomSheetP
         ref={sheetRef}
         role="dialog"
         aria-modal="true"
+        aria-labelledby={ariaLabelledBy}
         className={cn(
           'fixed inset-x-0 bottom-0 z-50 max-h-[85vh] overflow-y-auto rounded-t-2xl bg-surface-elevated shadow-2xl pb-[env(safe-area-inset-bottom)] animate-in slide-in-from-bottom duration-200',
           className,

--- a/tests/components/ui/BottomSheet.test.tsx
+++ b/tests/components/ui/BottomSheet.test.tsx
@@ -89,4 +89,54 @@ describe('BottomSheet', () => {
     // then
     expect(screen.getByRole('button', { name: 'first' })).toHaveFocus()
   })
+
+  it('open 동안 body overflow가 hidden으로 잠긴다', () => {
+    // given: 평소엔 overflow가 비어 있음
+    document.body.style.overflow = ''
+
+    // when
+    render(
+      <BottomSheet open onClose={vi.fn()}>
+        <p>body</p>
+      </BottomSheet>
+    )
+
+    // then
+    expect(document.body.style.overflow).toBe('hidden')
+  })
+
+  it('open=true → unmount 시 body overflow가 이전 값으로 복원된다', () => {
+    // given: 호출자가 overflow에 'auto'를 미리 세팅
+    document.body.style.overflow = 'auto'
+    const { unmount } = render(
+      <BottomSheet open onClose={vi.fn()}>
+        <p>body</p>
+      </BottomSheet>
+    )
+    expect(document.body.style.overflow).toBe('hidden')
+
+    // when
+    unmount()
+
+    // then
+    expect(document.body.style.overflow).toBe('auto')
+
+    // cleanup
+    document.body.style.overflow = ''
+  })
+
+  it('aria-labelledby prop을 dialog 컨테이너에 전달한다', () => {
+    // given / when
+    render(
+      <>
+        <h3 id="my-sheet-title">시트 제목</h3>
+        <BottomSheet open onClose={vi.fn()} aria-labelledby="my-sheet-title">
+          <p>body</p>
+        </BottomSheet>
+      </>
+    )
+
+    // then: dialog 가 헤더 id로 라벨링된다
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-labelledby', 'my-sheet-title')
+  })
 })


### PR DESCRIPTION
## 문제

#116 `BottomSheet` primitive 에 두 a11y 결함:

- 시트 open 동안 본문이 여전히 스크롤됨 — 모달 인지 깨짐.
- `aria-labelledby` opt-in 부재로 스크린리더가 dialog 의미를 음성으로 안내 못함.

## 접근

primitive 에 두 옵션 추가, 즉시 활용 가능하도록 두 소비자(`EventDetailPopover`, `DoneTodoDetailPopover`)에서 헤더 id를 연결.

## 변경 (앵커 단위)

- `BottomSheet.tsx` — open 동안 `document.body.style.overflow = 'hidden'`, unmount/close 시 이전 값 복원. `aria-labelledby?: string` prop 추가하여 dialog div에 forward.
- `EventDetailPopover` / `DoneTodoDetailPopover` — `useId()`로 헤더 안정 id 생성 후 `<h3>`/`<p>`(이벤트 이름 / 할 일 이름)에 부착, 모바일 BottomSheet에 같은 id를 `aria-labelledby` 로 전달.
- 테스트 — body scroll lock open/unmount 동작 + `aria-labelledby` 전달 검증 (BottomSheet 단위).

## 비범위

- `Drawer` 의 동일 a11y 처리 — 별 이슈.

Closes #121

## Test plan

- [ ] `npm test` 전체 PASS (878/880 — 2 pre-existing EventTimeDisplay 무관)
- [ ] `npm run build` 통과
- [ ] 모바일 viewport 시각 확인: 시트 열리면 뒤 페이지 스크롤 잠김, 닫히면 복원

🤖 Generated with [Claude Code](https://claude.com/claude-code)