### PR TITLE
[#125] EventTimeDisplay i18n 실패 정리 — toLocaleTimeString ICU 의존 제거

### DIFF
--- a/src/components/EventTimeDisplay.tsx
+++ b/src/components/EventTimeDisplay.tsx
@@ -4,8 +4,15 @@ interface EventTimeDisplayProps {
   eventTime: EventTime
 }
 
+// toLocaleTimeString('ko-KR', ...) 는 ICU 데이터에 의존해 jsdom/일부 Node 환경에서
+// 영어 fallback ("PM 2:30") 으로 떨어진다. 한국어 형식을 deterministic 하게 합성.
 function formatTime(date: Date): string {
-  return date.toLocaleTimeString('ko-KR', { hour: 'numeric', minute: '2-digit', hour12: true })
+  const hours = date.getHours()
+  const minutes = date.getMinutes()
+  const isPm = hours >= 12
+  const h12 = hours % 12 === 0 ? 12 : hours % 12
+  const mm = String(minutes).padStart(2, '0')
+  return `${isPm ? '오후' : '오전'} ${h12}:${mm}`
 }
 
 function formatDateUTC(date: Date): string {


### PR DESCRIPTION
## 문제

`tests/components/EventTimeDisplay.test.tsx` 의 2개 테스트가 pre-existing 실패 중이었다 (#116·#118·#121·#123 PR 시점부터 존재). 원인: `formatTime` 의 `date.toLocaleTimeString('ko-KR', ...)` 가 jsdom/일부 Node 환경에서 ICU 한국어 데이터 부재로 영어 fallback("PM 2:30")으로 떨어져, 테스트가 기대한 "오후 2:30" 과 mismatch.

브라우저 prod 에선 ICU full data 가 있어 정상 동작 — 사용자 경험 무관. 단 누적된 실패가 회귀 감지를 흐리게 만듦.

## 변경

- `EventTimeDisplay.formatTime` — `toLocaleTimeString` 의존 제거. `getHours()`/`getMinutes()` 직접 추출 + "오전/오후" 직접 합성. 환경 무관 deterministic.

## 결과

`npm test`: 882/882 PASS (이전 880/882). `npm run build`: 통과.

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)