### PR TITLE
[#134] 미완료 할일 새로고침 진행 중 버튼 로딩 상태 표시

### DIFF
--- a/src/components/UncompletedTodoList.tsx
+++ b/src/components/UncompletedTodoList.tsx
@@ -127,6 +127,15 @@ export function UncompletedTodoList({ todos, isTagHidden, onReload, onEventClick
     await doComplete(todo, scope)
   }
 
+  const [isReloading, setIsReloading] = useState(false)
+
+  async function handleReload() {
+    if (isReloading) return
+    setIsReloading(true)
+    try { await onReload() }
+    finally { setIsReloading(false) }
+  }
+
   const visibleTodos = todos.filter(t => !isTagHidden(t.event_tag_id))
 
   if (visibleTodos.length === 0) return null
@@ -139,11 +148,13 @@ export function UncompletedTodoList({ todos, isTagHidden, onReload, onEventClick
         </span>
         <div className="flex-1 h-px bg-line" />
         <button
-          onClick={onReload}
-          className="shrink-0 text-fg-quaternary hover:text-fg-tertiary transition-colors"
+          onClick={handleReload}
+          disabled={isReloading}
+          aria-busy={isReloading}
+          className="shrink-0 text-fg-quaternary hover:text-fg-tertiary transition-colors disabled:hover:text-fg-quaternary disabled:cursor-default"
           aria-label="refresh"
         >
-          <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className={`h-3.5 w-3.5${isReloading ? ' animate-spin' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
           </svg>
         </button>

--- a/tests/components/UncompletedTodoList.test.tsx
+++ b/tests/components/UncompletedTodoList.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { UncompletedTodoList, type UncompletedTodoListProps } from '../../src/components/UncompletedTodoList'
+import type { Todo } from '../../src/models'
+
+vi.mock('../../src/api/todoApi', () => ({
+  todoApi: {
+    completeTodo: vi.fn(),
+    patchTodo: vi.fn(),
+    getTodos: vi.fn().mockResolvedValue([]),
+  },
+}))
+vi.mock('../../src/repositories/caches/eventTagListCache', () => ({
+  useEventTagListCache: vi.fn((selector: any) => selector({ tags: new Map(), defaultTagColors: null })),
+  DEFAULT_TAG_ID: 'default',
+  HOLIDAY_TAG_ID: 'holiday',
+}))
+vi.mock('../../src/repositories/caches/settingsCache', () => ({
+  useSettingsCache: vi.fn((selector: any) => selector({
+    calendarAppearance: {
+      weekStartDay: 0, accentDays: { holiday: true, saturday: false, sunday: true },
+      eventDisplayLevel: 'medium', rowHeight: 70, eventFontSizeWeight: 0, showEventNames: true,
+      eventListFontSizeWeight: 0, showHolidayInEventList: true, showLunarCalendar: false, showUncompletedTodos: true,
+    },
+    eventDefaults: { defaultTagId: null, defaultNotificationSeconds: null, defaultAllDayNotificationSeconds: null },
+    timezone: { timezone: 'UTC', systemTimezone: 'UTC', isCustom: false },
+    notification: { permission: 'default', fcmToken: null },
+    setAppearance: vi.fn(), resetAppearanceToDefaults: vi.fn(),
+    setEventDefaults: vi.fn(), setTimezone: vi.fn(),
+    setNotificationPermission: vi.fn(), setFcmToken: vi.fn(),
+    requestNotificationPermission: vi.fn(), reset: vi.fn(),
+  })),
+}))
+vi.mock('../../src/firebase', () => ({
+  getAuthInstance: vi.fn(() => ({})),
+  db: {},
+}))
+
+const mockOnReload = vi.fn()
+const mockOnEventClick = vi.fn()
+
+function defaultProps(overrides: Partial<UncompletedTodoListProps> = {}): UncompletedTodoListProps {
+  return {
+    todos: [],
+    isTagHidden: () => false,
+    onReload: mockOnReload,
+    onEventClick: mockOnEventClick,
+    ...overrides,
+  }
+}
+
+function renderComponent(props: Partial<UncompletedTodoListProps> = {}) {
+  return render(
+    <MemoryRouter>
+      <UncompletedTodoList {...defaultProps(props)} />
+    </MemoryRouter>
+  )
+}
+
+const sampleTodos: Todo[] = [
+  { uuid: 'u1', name: '미완료 할 일 A', is_current: false, event_time: null } as Todo,
+  { uuid: 'u2', name: '미완료 할 일 B', is_current: false, event_time: null } as Todo,
+]
+
+describe('UncompletedTodoList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockOnReload.mockReset()
+    mockOnEventClick.mockReset()
+  })
+
+  it('todos가 비어있을 때 → 렌더 시 → 섹션이 렌더되지 않는다', () => {
+    // given: todos = []
+    const { container } = renderComponent({ todos: [] })
+
+    // then
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('todos가 있을 때 → 렌더 시 → 새로고침 버튼이 보인다', () => {
+    // given: todos에 항목이 있음
+    renderComponent({ todos: sampleTodos })
+
+    // then
+    expect(screen.getByRole('button', { name: 'refresh' })).toBeInTheDocument()
+  })
+
+  it('onReload가 진행 중일 때 → 새로고침 클릭 직후 → 버튼이 aria-busy=true 이고 disabled 이다', async () => {
+    // given: onReload는 수동으로 resolve할 수 있는 promise
+    let resolve!: () => void
+    const controlledReload = () => new Promise<void>(r => { resolve = r })
+    mockOnReload.mockImplementation(controlledReload)
+    renderComponent({ todos: sampleTodos })
+    const button = screen.getByRole('button', { name: 'refresh' })
+
+    // when: 새로고침 버튼 클릭 (resolve 전)
+    await userEvent.click(button)
+
+    // then: 로딩 중 상태
+    expect(button).toHaveAttribute('aria-busy', 'true')
+    expect(button).toBeDisabled()
+
+    // cleanup: promise resolve
+    act(() => { resolve() })
+  })
+
+  it('onReload가 resolve된 후 → 완료 대기 → 버튼이 다시 활성화되고 aria-busy=false 이다', async () => {
+    // given: onReload를 수동 제어
+    let resolve!: () => void
+    const controlledReload = () => new Promise<void>(r => { resolve = r })
+    mockOnReload.mockImplementation(controlledReload)
+    renderComponent({ todos: sampleTodos })
+    const button = screen.getByRole('button', { name: 'refresh' })
+
+    // when: 클릭 후 resolve
+    await userEvent.click(button)
+    act(() => { resolve() })
+
+    // then: 로딩 해제
+    await waitFor(() => {
+      expect(button).toHaveAttribute('aria-busy', 'false')
+      expect(button).not.toBeDisabled()
+    })
+  })
+})


### PR DESCRIPTION
Closes #134

## 배경
미완료 할일 목록의 새로고침 버튼 클릭 시 즉시 시각 피드백이 없어 사용자가 클릭이 먹혔는지, 진행 중인지 알 수 없었음.

## 변경
- `UncompletedTodoList` — `isReloading` 로컬 상태 + `handleReload` 래퍼로 fetch 진행 동안 중복 클릭 차단
- 새로고침 버튼 — `disabled` / `aria-busy` 속성 + 아이콘에 `animate-spin` 토글로 진행 중 시각 표현
- 디자인 옵션 A 채택: 기존 refresh 아이콘 자체를 회전 (별도 spinner 아이콘 추가 없음)

## 테스트
- 신규: `tests/components/UncompletedTodoList.test.tsx` — 빈 목록 렌더 안 함 / 버튼 노출 / 진행 중 aria-busy + disabled / resolve 후 복구 (4 cases)
- 전체 회귀: 886/886 통과

## 시각 확인
로컬 dev 서버에서 새로고침 버튼 클릭 → 아이콘 회전 + 비활성 → fetch 완료 시 원복 확인 완료.