### PR TITLE
[#131] EventDetail place 응답 객체 렌더 에러 #31 해결

### DIFF
--- a/src/components/DoneTodoDetail/DoneTodoDetailPopover.tsx
+++ b/src/components/DoneTodoDetail/DoneTodoDetailPopover.tsx
@@ -3,6 +3,7 @@ import { useEffect, useId, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { RotateCcw, Trash2, X, Clock, Bell, MapPin, FileText, Link2 } from 'lucide-react'
 import type { DoneTodo } from '../../models'
+import { displayPlace } from '../../models/EventDetail'
 import { useDoneTodoDetailPopoverViewModel } from './useDoneTodoDetailPopoverViewModel'
 import { useResolvedEventTag } from '../../hooks/useResolvedEventTag'
 import { tagDisplayName } from '../../domain/functions/tagDisplay'
@@ -160,12 +161,15 @@ export function DoneTodoDetailPopover({
             <p className="whitespace-pre-wrap">{vm.detail.memo}</p>
           </div>
         )}
-        {vm.detail?.place && (
-          <div className={INFO_ROW}>
-            <MapPin className={INFO_ICON} />
-            <p>{vm.detail.place}</p>
-          </div>
-        )}
+        {(() => {
+          const placeText = displayPlace(vm.detail?.place)
+          return placeText ? (
+            <div className={INFO_ROW}>
+              <MapPin className={INFO_ICON} />
+              <p>{placeText}</p>
+            </div>
+          ) : null
+        })()}
       </div>
     </>
   )

--- a/src/components/DoneTodoDetail/DoneTodoDetailPopover.tsx
+++ b/src/components/DoneTodoDetail/DoneTodoDetailPopover.tsx
@@ -72,6 +72,7 @@ export function DoneTodoDetailPopover({
 
   const tagColor = resolved.color
   const tagName = tagDisplayName(resolved, t)
+  const placeText = displayPlace(vm.detail?.place)
 
   const body = (
     <>
@@ -161,15 +162,12 @@ export function DoneTodoDetailPopover({
             <p className="whitespace-pre-wrap">{vm.detail.memo}</p>
           </div>
         )}
-        {(() => {
-          const placeText = displayPlace(vm.detail?.place)
-          return placeText ? (
-            <div className={INFO_ROW}>
-              <MapPin className={INFO_ICON} />
-              <p>{placeText}</p>
-            </div>
-          ) : null
-        })()}
+        {placeText && (
+          <div className={INFO_ROW}>
+            <MapPin className={INFO_ICON} />
+            <p>{placeText}</p>
+          </div>
+        )}
       </div>
     </>
   )

--- a/src/components/EventDetail/EventDetailPopover.tsx
+++ b/src/components/EventDetail/EventDetailPopover.tsx
@@ -5,6 +5,7 @@ import type { TFunction } from 'i18next'
 import { Pencil, Trash2, X, Clock, Repeat, Bell, MapPin, FileText, Link2 } from 'lucide-react'
 import type { CalendarEvent } from '../../domain/functions/eventTime'
 import type { Repeating } from '../../models'
+import { displayPlace } from '../../models/EventDetail'
 import { useResolvedEventTag } from '../../hooks/useResolvedEventTag'
 import { tagDisplayName } from '../../domain/functions/tagDisplay'
 import { EventTimeDisplay } from '../EventTimeDisplay'
@@ -147,12 +148,15 @@ export function EventDetailPopover({
           </div>
         )}
 
-        {vm.eventDetail?.place && (
-          <div className={INFO_ROW}>
-            <MapPin className={INFO_ICON} />
-            <span className="min-w-0 break-words">{vm.eventDetail.place}</span>
-          </div>
-        )}
+        {(() => {
+          const placeText = displayPlace(vm.eventDetail?.place)
+          return placeText ? (
+            <div className={INFO_ROW}>
+              <MapPin className={INFO_ICON} />
+              <span className="min-w-0 break-words">{placeText}</span>
+            </div>
+          ) : null
+        })()}
 
         {vm.eventDetail?.url && (
           <div className={INFO_ROW}>

--- a/src/components/EventDetail/EventDetailPopover.tsx
+++ b/src/components/EventDetail/EventDetailPopover.tsx
@@ -58,6 +58,7 @@ export function EventDetailPopover({
   const eventTime = event.event_time ?? null
   const repeating = event.repeating ?? null
   const notifications = event.notification_options ?? null
+  const placeText = displayPlace(vm.eventDetail?.place)
 
   useEffect(() => {
     if (isMobile) return  // BottomSheet가 처리
@@ -148,15 +149,12 @@ export function EventDetailPopover({
           </div>
         )}
 
-        {(() => {
-          const placeText = displayPlace(vm.eventDetail?.place)
-          return placeText ? (
-            <div className={INFO_ROW}>
-              <MapPin className={INFO_ICON} />
-              <span className="min-w-0 break-words">{placeText}</span>
-            </div>
-          ) : null
-        })()}
+        {placeText && (
+          <div className={INFO_ROW}>
+            <MapPin className={INFO_ICON} />
+            <span className="min-w-0 break-words">{placeText}</span>
+          </div>
+        )}
 
         {vm.eventDetail?.url && (
           <div className={INFO_ROW}>

--- a/src/models/EventDetail.ts
+++ b/src/models/EventDetail.ts
@@ -1,5 +1,23 @@
+/**
+ * 다른 클라이언트(예: iOS 앱)가 저장한 장소는 좌표를 포함한 객체 형태로 응답된다.
+ * 웹은 입력은 문자열만 지원하지만, 응답에서 객체를 받았을 때도 안전하게 표시할 수 있어야 한다.
+ */
+export interface Place {
+  name?: string | null
+  address?: string | null
+  coordinate?: { latitude: number; longitude: number } | null
+}
+
+export type EventDetailPlace = string | Place
+
 export interface EventDetail {
-  place?: string | null
+  place?: EventDetailPlace | null
   url?: string | null
   memo?: string | null
+}
+
+export function displayPlace(place: EventDetailPlace | null | undefined): string {
+  if (!place) return ''
+  if (typeof place === 'string') return place
+  return place.name ?? place.address ?? ''
 }

--- a/src/pages/ScheduleForm/useScheduleFormViewModel.ts
+++ b/src/pages/ScheduleForm/useScheduleFormViewModel.ts
@@ -9,6 +9,7 @@ import { useEventFormDirty, type EventFormSnapshot } from '../../hooks/useEventF
 import { defaultNotificationsForEventTime } from '../../stores/eventFormStore'
 import { useSettingsCache } from '../../repositories/caches/settingsCache'
 import type { Schedule, EventTime, Repeating, NotificationOption, EventDetail } from '../../models'
+import { displayPlace } from '../../models/EventDetail'
 import type { RepeatScope } from '../../components/RepeatingScopeDialog'
 
 // MARK: - Interface
@@ -133,7 +134,7 @@ export function useScheduleFormViewModel(
       const loadedEventTime = schedule.event_time
       const loadedRepeating = schedule.repeating ?? null
       const loadedNotifications = schedule.notification_options ?? []
-      const loadedPlace = detail?.place ?? ''
+      const loadedPlace = displayPlace(detail?.place)
       const loadedUrl = detail?.url ?? ''
       const loadedMemo = detail?.memo ?? ''
       setOriginal(schedule)

--- a/src/pages/TodoForm/useTodoFormViewModel.ts
+++ b/src/pages/TodoForm/useTodoFormViewModel.ts
@@ -9,6 +9,7 @@ import { useEventFormDirty, type EventFormSnapshot } from '../../hooks/useEventF
 import { defaultNotificationsForEventTime } from '../../stores/eventFormStore'
 import { useSettingsCache } from '../../repositories/caches/settingsCache'
 import type { Todo, EventTime, Repeating, NotificationOption, EventDetail } from '../../models'
+import { displayPlace } from '../../models/EventDetail'
 import type { RepeatScope } from '../../components/RepeatingScopeDialog'
 
 // MARK: - Interface
@@ -134,7 +135,7 @@ export function useTodoFormViewModel(
       const loadedEventTime = todo.event_time ?? null
       const loadedRepeating = todo.repeating ?? null
       const loadedNotifications = todo.notification_options ?? []
-      const loadedPlace = detail?.place ?? ''
+      const loadedPlace = displayPlace(detail?.place)
       const loadedUrl = detail?.url ?? ''
       const loadedMemo = detail?.memo ?? ''
       setOriginal(todo)

--- a/tests/components/EventDetail/EventDetailPopover.test.tsx
+++ b/tests/components/EventDetail/EventDetailPopover.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { EventDetailPopover } from '../../../src/components/EventDetail/EventDetailPopover'
 import { useEventTagListCache } from '../../../src/repositories/caches/eventTagListCache'
 import type { CalendarEvent } from '../../../src/domain/functions/eventTime'
-import type { EventTime, Repeating, NotificationOption } from '../../../src/models'
+import type { EventTime, Repeating, NotificationOption, EventDetail } from '../../../src/models'
 import type { EventDetailRepository } from '../../../src/repositories/EventDetailRepository'
 import type { Repositories } from '../../../src/composition/container'
 import { RepositoriesProvider } from '../../../src/composition/RepositoriesProvider'
@@ -89,7 +89,7 @@ function makeScheduleEvent(overrides: {
   }
 }
 
-function createFakeDetailRepo(detail: { place?: string | null; url?: string | null; memo?: string | null } = {}): EventDetailRepository {
+function createFakeDetailRepo(detail: { place?: EventDetail['place']; url?: string | null; memo?: string | null } = {}): EventDetailRepository {
   return {
     get: vi.fn(async () => ({ place: detail.place ?? null, url: detail.url ?? null, memo: detail.memo ?? null })),
     save: vi.fn(async (_, d) => d),
@@ -112,7 +112,7 @@ function createFakeRepos(detailRepo?: EventDetailRepository): Repositories {
 
 interface RenderOpts {
   handlers?: { onClose?: () => void; onEdit?: () => void; onDelete?: () => void }
-  detailData?: { place?: string | null; url?: string | null; memo?: string | null }
+  detailData?: { place?: EventDetail['place']; url?: string | null; memo?: string | null }
   /** anchorRect 부재 (모바일 또는 fallback 검증용)를 표현하려면 noAnchor: true */
   noAnchor?: boolean
 }
@@ -214,6 +214,60 @@ describe('EventDetailPopover', () => {
       expect(screen.getByText('서울 카페')).toBeInTheDocument()
       expect(screen.getByText('https://example.com')).toBeInTheDocument()
       expect(screen.getByText('미팅 메모')).toBeInTheDocument()
+    })
+  })
+
+  it('place가 객체(name/address/coordinate) 형태로 응답되어도 렌더 에러 없이 name이 표시된다', async () => {
+    // given: 다른 클라이언트(앱)가 저장하여 place 가 객체로 오는 케이스
+    const calEvent = makeTodoEvent({ name: '카페 모임' })
+
+    // when
+    renderPopover(calEvent, {}, {
+      place: {
+        name: '스타벅스 강남점',
+        address: '서울 강남구 테헤란로 1',
+        coordinate: { latitude: 37.5, longitude: 127.0 },
+      },
+    })
+
+    // then: name 이 화면에 표시되고 React 에러가 발생하지 않는다
+    await waitFor(() => {
+      expect(screen.getByText('스타벅스 강남점')).toBeInTheDocument()
+    })
+  })
+
+  it('place가 객체이고 name 이 없으면 address 가 표시된다', async () => {
+    // given
+    const calEvent = makeTodoEvent({ name: '약속' })
+
+    // when
+    renderPopover(calEvent, {}, {
+      place: {
+        name: null,
+        address: '서울 종로구 종로 1',
+        coordinate: { latitude: 37.57, longitude: 126.98 },
+      },
+    })
+
+    // then
+    await waitFor(() => {
+      expect(screen.getByText('서울 종로구 종로 1')).toBeInTheDocument()
+    })
+  })
+
+  it('place가 객체인데 name/address 둘 다 비어 있으면 장소 행을 표시하지 않는다', async () => {
+    // given
+    const calEvent = makeTodoEvent({ name: '약속' })
+
+    // when
+    renderPopover(calEvent, {}, {
+      place: { name: null, address: null, coordinate: { latitude: 1, longitude: 2 } },
+    })
+
+    // then: MapPin 아이콘 행이 그려지지 않는다 (장소 텍스트가 없으므로 행 자체 미노출)
+    // place 표시 영역의 정체성을 확인하기 위해 known 다른 텍스트가 안 들어왔는지 검증
+    await waitFor(() => {
+      expect(screen.queryByText('[object Object]')).not.toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## 문제
특정 할일 클릭 → 상세 팝업 표시 직후 React error #31 (`object with keys {name, address, coordinate}`) 발생, ErrorBoundary 폴백 화면으로 전환.

## 원인
다른 클라이언트(앱)가 저장한 `place` 는 `{name, address, coordinate}` 객체로 응답되는데 웹은 `string` 만 가정하고 객체를 그대로 렌더링 → React 가 객체 자식 노드를 거부.

## 접근
표시·폼 hydrate 자리 모두 `displayPlace` 정규화 함수로 일괄 통과시켜 string 으로 안전 변환. 객체일 때는 `name → address` 순으로 표시 문자열 추출, 둘 다 비면 행 자체 미노출.

## 변경
- `EventDetail` 모델: `Place` 인터페이스 신설 + `place` 타입을 `string | Place` union 으로 확장
- `displayPlace` 헬퍼 추가
- `EventDetailPopover`, `DoneTodoDetailPopover`, `useTodoFormViewModel`, `useScheduleFormViewModel` 네 곳에 일괄 적용

## Test plan
- [ ] 앱에서 만든 place(객체) 가진 일정·할일을 웹에서 클릭 → 상세 팝업이 깨지지 않고 장소명 표시
- [ ] 웹에서 만든 place(string) 가진 일정 → 기존과 동일 표시
- [ ] 객체이지만 name/address 둘 다 비면 장소 행 미노출
- [ ] 폼 편집 진입 시 객체 place 가 string 입력란에 안전 hydrate

Closes #131