### PR TITLE
[#132] 반복 할일 완료 시 차수 선택 팝업 미노출

### DIFF
--- a/src/components/CurrentTodoList.tsx
+++ b/src/components/CurrentTodoList.tsx
@@ -1,12 +1,11 @@
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { todoApi } from '../api/todoApi'
 import { useCurrentTodosCache } from '../repositories/caches/currentTodosCache'
 import { useCalendarEventsCache } from '../repositories/caches/calendarEventsCache'
 import { useResolvedEventTag } from '../hooks/useResolvedEventTag'
 import { tagDisplayName } from '../domain/functions/tagDisplay'
-import { RepeatingScopeDialog, type RepeatScope } from './RepeatingScopeDialog'
-import { nextRepeatingTime, getStartTimestamp } from '../domain/functions/repeating'
+import type { RepeatScope } from './RepeatingScopeDialog'
+import { nextRepeatingTime } from '../domain/functions/repeating'
 import { useUncompletedTodosCache } from '../repositories/caches/uncompletedTodosCache'
 import { useSettingsCache } from '../repositories/caches/settingsCache'
 import type { Todo } from '../models'
@@ -79,14 +78,10 @@ export interface CurrentTodoListProps {
 }
 
 export function CurrentTodoList({ todos, isTagHidden, onEventClick }: CurrentTodoListProps) {
-  const [scopeTarget, setScopeTarget] = useState<Todo | null>(null)
-
   async function handleComplete(todo: Todo) {
-    if (todo.repeating && todo.event_time) {
-      setScopeTarget(todo)
-      return
-    }
-    await doComplete(todo)
+    // 반복 할일은 차수 선택 팝업을 띄우지 않고 항상 현재 차수만 완료 + 다음 차수로 이동 (앱과 동일한 정책)
+    const scope: RepeatScope | undefined = (todo.repeating && todo.event_time) ? 'this' : undefined
+    await doComplete(todo, scope)
   }
 
   async function doComplete(todo: Todo, scope?: RepeatScope) {
@@ -96,10 +91,6 @@ export function CurrentTodoList({ todos, isTagHidden, onEventClick }: CurrentTod
       if (scope === 'this' && todo.repeating && todo.event_time) {
         const next = nextRepeatingTime(todo.event_time, todo.repeating_turn ?? 1, todo.repeating, todo.exclude_repeatings)
         await todoApi.completeTodo(todo.uuid, { origin: todo, next_event_time: next?.time, next_repeating_turn: next?.turn })
-      } else if (scope === 'future') {
-        const startTs = getStartTimestamp(todo.event_time!)
-        await todoApi.patchTodo(todo.uuid, { repeating: { ...todo.repeating, end: startTs - 1 } })
-        await todoApi.completeTodo(todo.uuid, { origin: todo })
       } else {
         await todoApi.completeTodo(todo.uuid, { origin: todo })
       }
@@ -116,13 +107,6 @@ export function CurrentTodoList({ todos, isTagHidden, onEventClick }: CurrentTod
     } catch (e) {
       console.warn('완료 처리 실패:', e)
     }
-  }
-
-  async function handleCompleteWithScope(scope: RepeatScope) {
-    if (!scopeTarget) return
-    const todo = scopeTarget
-    setScopeTarget(null)
-    await doComplete(todo, scope)
   }
 
   const visibleTodos = todos.filter(t => !isTagHidden(t.event_tag_id))
@@ -146,14 +130,6 @@ export function CurrentTodoList({ todos, isTagHidden, onEventClick }: CurrentTod
           />
         ))}
       </div>
-      {scopeTarget && (
-        <RepeatingScopeDialog
-          mode="complete"
-          eventType="todo"
-          onSelect={handleCompleteWithScope}
-          onCancel={() => setScopeTarget(null)}
-        />
-      )}
     </section>
   )
 }

--- a/src/components/RepeatingScopeDialog.tsx
+++ b/src/components/RepeatingScopeDialog.tsx
@@ -24,7 +24,7 @@ export function RepeatingScopeDialog({ mode, eventType = 'schedule', onSelect, o
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+    <div data-testid="repeating-scope-dialog" className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div className="w-full max-w-sm rounded-xl bg-surface-elevated p-6 shadow-xl">
         <h2 className="text-base font-semibold text-fg">
           {dialogTitle()}

--- a/src/components/UncompletedTodoList.tsx
+++ b/src/components/UncompletedTodoList.tsx
@@ -5,8 +5,8 @@ import { useUncompletedTodosCache } from '../repositories/caches/uncompletedTodo
 import { useCalendarEventsCache } from '../repositories/caches/calendarEventsCache'
 import { useResolvedEventTag } from '../hooks/useResolvedEventTag'
 import { tagDisplayName } from '../domain/functions/tagDisplay'
-import { RepeatingScopeDialog, type RepeatScope } from './RepeatingScopeDialog'
-import { nextRepeatingTime, getStartTimestamp } from '../domain/functions/repeating'
+import type { RepeatScope } from './RepeatingScopeDialog'
+import { nextRepeatingTime } from '../domain/functions/repeating'
 import { useCurrentTodosCache } from '../repositories/caches/currentTodosCache'
 import { useSettingsCache } from '../repositories/caches/settingsCache'
 import type { Todo } from '../models'
@@ -81,14 +81,12 @@ export interface UncompletedTodoListProps {
 
 export function UncompletedTodoList({ todos, isTagHidden, onReload, onEventClick }: UncompletedTodoListProps) {
   const { t } = useTranslation()
-  const [scopeTarget, setScopeTarget] = useState<Todo | null>(null)
+  const [isReloading, setIsReloading] = useState(false)
 
   async function handleComplete(todo: Todo) {
-    if (todo.repeating && todo.event_time) {
-      setScopeTarget(todo)
-      return
-    }
-    await doComplete(todo)
+    // 반복 할일은 차수 선택 팝업을 띄우지 않고 항상 현재 차수만 완료 + 다음 차수로 이동 (앱과 동일한 정책)
+    const scope: RepeatScope | undefined = (todo.repeating && todo.event_time) ? 'this' : undefined
+    await doComplete(todo, scope)
   }
 
   async function doComplete(todo: Todo, scope?: RepeatScope) {
@@ -98,10 +96,6 @@ export function UncompletedTodoList({ todos, isTagHidden, onReload, onEventClick
       if (scope === 'this' && todo.repeating && todo.event_time) {
         const next = nextRepeatingTime(todo.event_time, todo.repeating_turn ?? 1, todo.repeating, todo.exclude_repeatings)
         await todoApi.completeTodo(todo.uuid, { origin: todo, next_event_time: next?.time, next_repeating_turn: next?.turn })
-      } else if (scope === 'future') {
-        const startTs = getStartTimestamp(todo.event_time!)
-        await todoApi.patchTodo(todo.uuid, { repeating: { ...todo.repeating, end: startTs - 1 } })
-        await todoApi.completeTodo(todo.uuid, { origin: todo })
       } else {
         await todoApi.completeTodo(todo.uuid, { origin: todo })
       }
@@ -119,15 +113,6 @@ export function UncompletedTodoList({ todos, isTagHidden, onReload, onEventClick
       console.warn('완료 처리 실패:', e)
     }
   }
-
-  async function handleCompleteWithScope(scope: RepeatScope) {
-    if (!scopeTarget) return
-    const todo = scopeTarget
-    setScopeTarget(null)
-    await doComplete(todo, scope)
-  }
-
-  const [isReloading, setIsReloading] = useState(false)
 
   async function handleReload() {
     if (isReloading) return
@@ -170,14 +155,6 @@ export function UncompletedTodoList({ todos, isTagHidden, onReload, onEventClick
           />
         ))}
       </div>
-      {scopeTarget && (
-        <RepeatingScopeDialog
-          mode="complete"
-          eventType="todo"
-          onSelect={handleCompleteWithScope}
-          onCancel={() => setScopeTarget(null)}
-        />
-      )}
     </section>
   )
 }

--- a/tests/components/CurrentTodoList.test.tsx
+++ b/tests/components/CurrentTodoList.test.tsx
@@ -156,4 +156,30 @@ describe('CurrentTodoList — 완료', () => {
       expect(screen.queryByRole('alert')).toBeNull()
     })
   })
+
+  it('반복 Todo 체크박스 클릭 시 RepeatingScopeDialog가 표시되지 않는다', async () => {
+    // given: 반복 todo (사용자에게 차수 선택을 묻지 않아야 함)
+    const { todoApi } = await import('../../src/api/todoApi')
+    vi.mocked(todoApi.completeTodo).mockResolvedValue({ uuid: 'done-1', done_at: 1000 } as any)
+    const repeatingTodo = {
+      uuid: 't3',
+      name: '매일 반복',
+      is_current: true,
+      event_time: { time_type: 'at' as const, timestamp: 1743375600 },
+      repeating: { start: 1743375600, option: { optionType: 'every_day' as const, interval: 1 } },
+    } as unknown as Todo
+    useCalendarEventsCache.setState({ eventsByDate: new Map(), loading: false, lastRange: { lower: 0, upper: 9999999999 } })
+
+    render(
+      <MemoryRouter>
+        <CurrentTodoList todos={[repeatingTodo]} isTagHidden={() => false} />
+      </MemoryRouter>
+    )
+    await userEvent.click(screen.getByRole('button', { name: '매일 반복' }))
+
+    // then: 반복 차수 선택 다이얼로그(RepeatingScopeDialog)가 화면에 뜨지 않아야 한다
+    await waitFor(() => {
+      expect(screen.queryByTestId('repeating-scope-dialog')).toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
## 문제
반복 할일 체크박스 클릭 시 RepeatingScopeDialog ('이 일정만/이후 일정/모든 일정') 가 떠서 사용자에게 선택을 요구. 앱은 그냥 현재 차수만 완료하고 다음 차수로 넘어가는데 웹만 다른 동작.

## 접근
앱과 동일한 정책: 반복 할일 완료는 이벤트 수정이 아니라 단순 완료 → 항상 `'this'` 스코프(현재 차수만 완료 + 다음 차수로 시간 이동) 자동 적용. 차수 선택 다이얼로그는 todo 완료 흐름에서 제거 (Schedule 편집/삭제 흐름에는 그대로 유지).

## 변경
- `UncompletedTodoList.handleComplete` / `CurrentTodoList.handleComplete`: 반복 todo 면 `'this'` 스코프 자동 적용, scope state/handler/Dialog 호출 제거
- `RepeatingScopeDialog`: 테스트 셀렉터용 `data-testid` 부여
- 사용 안 하게 된 `'future'` 분기도 todo 완료 흐름에서 같이 정리

## Test plan
- [ ] 우측 패널 반복 할일 체크 → 다이얼로그 안 뜸
- [ ] 비반복 할일 체크 → 기존과 동일하게 즉시 완료
- [ ] Schedule 편집/삭제 시에는 RepeatingScopeDialog 정상 표시 (회귀 없음)

Closes #132