### PR TITLE
[#133] 반복 할일 완료 후 UI 즉시 업데이트 + 응답값 기반 캐시 갱신 일원화

### DIFF
--- a/src/components/CurrentTodoList.tsx
+++ b/src/components/CurrentTodoList.tsx
@@ -1,13 +1,9 @@
 import { useTranslation } from 'react-i18next'
-import { todoApi } from '../api/todoApi'
-import { useCurrentTodosCache } from '../repositories/caches/currentTodosCache'
-import { useCalendarEventsCache } from '../repositories/caches/calendarEventsCache'
 import { useResolvedEventTag } from '../hooks/useResolvedEventTag'
 import { tagDisplayName } from '../domain/functions/tagDisplay'
 import type { RepeatScope } from './RepeatingScopeDialog'
-import { nextRepeatingTime } from '../domain/functions/repeating'
-import { useUncompletedTodosCache } from '../repositories/caches/uncompletedTodosCache'
 import { useSettingsCache } from '../repositories/caches/settingsCache'
+import { useRepositories } from '../composition/RepositoriesProvider'
 import type { Todo } from '../models'
 import type { CalendarEvent } from '../domain/functions/eventTime'
 import { EventTimeDisplay } from './EventTimeDisplay'
@@ -84,6 +80,8 @@ export interface CurrentTodoListProps {
 }
 
 export function CurrentTodoList({ todos, isTagHidden, onEventClick }: CurrentTodoListProps) {
+  const { eventRepo } = useRepositories()
+
   async function handleComplete(todo: Todo) {
     // 반복 할일은 차수 선택 팝업을 띄우지 않고 항상 현재 차수만 완료 + 다음 차수로 이동 (앱과 동일한 정책)
     const scope: RepeatScope | undefined = (todo.repeating && todo.event_time) ? 'this' : undefined
@@ -91,25 +89,8 @@ export function CurrentTodoList({ todos, isTagHidden, onEventClick }: CurrentTod
   }
 
   async function doComplete(todo: Todo, scope?: RepeatScope) {
-    const { removeTodo } = useCurrentTodosCache.getState()
-    const { removeEvent } = useCalendarEventsCache.getState()
     try {
-      if (scope === 'this' && todo.repeating && todo.event_time) {
-        const next = nextRepeatingTime(todo.event_time, todo.repeating_turn ?? 1, todo.repeating, todo.exclude_repeatings)
-        await todoApi.completeTodo(todo.uuid, { origin: todo, next_event_time: next?.time, next_repeating_turn: next?.turn })
-      } else {
-        await todoApi.completeTodo(todo.uuid, { origin: todo })
-      }
-
-      if (todo.repeating) {
-        await Promise.all([
-          useUncompletedTodosCache.getState().fetch(),
-          useCurrentTodosCache.getState().fetch(),
-        ]).catch(e => console.warn('Todo stores refresh failed:', e))
-      } else {
-        removeEvent(todo.uuid)
-        removeTodo(todo.uuid)
-      }
+      await eventRepo.completeTodo(todo, scope)
     } catch (e) {
       console.warn('완료 처리 실패:', e)
     }

--- a/src/components/DayEventList.tsx
+++ b/src/components/DayEventList.tsx
@@ -100,7 +100,7 @@ export function DayEventList({ selectedDate, eventsByDate, isTagHidden, onEventC
 
   async function doComplete(todo: Todo, scope?: RepeatScope) {
     try {
-      await eventRepo.completeTodo(todo, scope as 'this' | 'future' | undefined)
+      await eventRepo.completeTodo(todo, scope)
     } catch (e) {
       console.warn('완료 처리 실패:', e)
     }

--- a/src/components/DayEventList.tsx
+++ b/src/components/DayEventList.tsx
@@ -1,16 +1,12 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { todoApi } from '../api/todoApi'
-import { useCalendarEventsCache } from '../repositories/caches/calendarEventsCache'
 import { useResolvedEventTag } from '../hooks/useResolvedEventTag'
 import { tagDisplayName } from '../domain/functions/tagDisplay'
 import { TimeDescription } from './TimeDescription'
 import { RepeatingScopeDialog, type RepeatScope } from './RepeatingScopeDialog'
-import { nextRepeatingTime, getStartTimestamp } from '../domain/functions/repeating'
-import { useCurrentTodosCache } from '../repositories/caches/currentTodosCache'
-import { useUncompletedTodosCache } from '../repositories/caches/uncompletedTodosCache'
 import { formatDateKey } from '../domain/functions/eventTime'
 import { useSettingsCache } from '../repositories/caches/settingsCache'
+import { useRepositories } from '../composition/RepositoriesProvider'
 import type { CalendarEvent } from '../domain/functions/eventTime'
 import type { Todo } from '../models'
 
@@ -91,6 +87,7 @@ export interface DayEventListProps {
 
 export function DayEventList({ selectedDate, eventsByDate, isTagHidden, onEventClick }: DayEventListProps) {
   const { t } = useTranslation()
+  const { eventRepo } = useRepositories()
   const [scopeTarget, setScopeTarget] = useState<Todo | null>(null)
 
   async function handleComplete(todo: Todo) {
@@ -102,31 +99,8 @@ export function DayEventList({ selectedDate, eventsByDate, isTagHidden, onEventC
   }
 
   async function doComplete(todo: Todo, scope?: RepeatScope) {
-    const { removeEvent } = useCalendarEventsCache.getState()
     try {
-      if (scope === 'this' && todo.repeating && todo.event_time) {
-        const next = nextRepeatingTime(todo.event_time, todo.repeating_turn ?? 1, todo.repeating, todo.exclude_repeatings)
-        await todoApi.completeTodo(todo.uuid, { origin: todo, next_event_time: next?.time, next_repeating_turn: next?.turn })
-      } else if (scope === 'future') {
-        const startTs = getStartTimestamp(todo.event_time!)
-        await todoApi.patchTodo(todo.uuid, { repeating: { ...todo.repeating, end: startTs - 1 } })
-        await todoApi.completeTodo(todo.uuid, { origin: todo })
-      } else {
-        await todoApi.completeTodo(todo.uuid, { origin: todo })
-      }
-
-      if (todo.repeating) {
-        await Promise.all([
-          useUncompletedTodosCache.getState().fetch(),
-          useCurrentTodosCache.getState().fetch(),
-        ]).catch(e => console.warn('Todo stores refresh failed:', e))
-      } else {
-        removeEvent(todo.uuid)
-        await Promise.all([
-          useUncompletedTodosCache.getState().fetch(),
-          useCurrentTodosCache.getState().fetch(),
-        ]).catch(e => console.warn('Todo stores refresh failed:', e))
-      }
+      await eventRepo.completeTodo(todo, scope as 'this' | 'future' | undefined)
     } catch (e) {
       console.warn('완료 처리 실패:', e)
     }

--- a/src/components/UncompletedTodoList.tsx
+++ b/src/components/UncompletedTodoList.tsx
@@ -1,14 +1,10 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { todoApi } from '../api/todoApi'
-import { useUncompletedTodosCache } from '../repositories/caches/uncompletedTodosCache'
-import { useCalendarEventsCache } from '../repositories/caches/calendarEventsCache'
 import { useResolvedEventTag } from '../hooks/useResolvedEventTag'
 import { tagDisplayName } from '../domain/functions/tagDisplay'
 import type { RepeatScope } from './RepeatingScopeDialog'
-import { nextRepeatingTime } from '../domain/functions/repeating'
-import { useCurrentTodosCache } from '../repositories/caches/currentTodosCache'
 import { useSettingsCache } from '../repositories/caches/settingsCache'
+import { useRepositories } from '../composition/RepositoriesProvider'
 import type { Todo } from '../models'
 import type { CalendarEvent } from '../domain/functions/eventTime'
 import { EventTimeDisplay } from './EventTimeDisplay'
@@ -87,6 +83,7 @@ export interface UncompletedTodoListProps {
 
 export function UncompletedTodoList({ todos, isTagHidden, onReload, onEventClick }: UncompletedTodoListProps) {
   const { t } = useTranslation()
+  const { eventRepo } = useRepositories()
   const [isReloading, setIsReloading] = useState(false)
 
   async function handleComplete(todo: Todo) {
@@ -96,25 +93,8 @@ export function UncompletedTodoList({ todos, isTagHidden, onReload, onEventClick
   }
 
   async function doComplete(todo: Todo, scope?: RepeatScope) {
-    const { removeTodo } = useUncompletedTodosCache.getState()
-    const { removeEvent } = useCalendarEventsCache.getState()
     try {
-      if (scope === 'this' && todo.repeating && todo.event_time) {
-        const next = nextRepeatingTime(todo.event_time, todo.repeating_turn ?? 1, todo.repeating, todo.exclude_repeatings)
-        await todoApi.completeTodo(todo.uuid, { origin: todo, next_event_time: next?.time, next_repeating_turn: next?.turn })
-      } else {
-        await todoApi.completeTodo(todo.uuid, { origin: todo })
-      }
-
-      if (todo.repeating) {
-        await Promise.all([
-          useUncompletedTodosCache.getState().fetch(),
-          useCurrentTodosCache.getState().fetch(),
-        ]).catch(e => console.warn('Todo stores refresh failed:', e))
-      } else {
-        removeEvent(todo.uuid)
-        removeTodo(todo.uuid)
-      }
+      await eventRepo.completeTodo(todo, scope)
     } catch (e) {
       console.warn('완료 처리 실패:', e)
     }

--- a/src/repositories/EventRepository.ts
+++ b/src/repositories/EventRepository.ts
@@ -194,7 +194,7 @@ export class EventRepository {
     return updated
   }
 
-  async completeTodo(todo: Todo, scope?: 'this' | 'future'): Promise<DoneTodo> {
+  async completeTodo(todo: Todo, scope?: 'this' | 'future' | 'all'): Promise<DoneTodo> {
     const isRepeating = !!todo.repeating && !!todo.event_time
 
     if (scope === 'this' && isRepeating) {
@@ -208,10 +208,7 @@ export class EventRepository {
         const nextTurn = next.turn ?? (todo.repeating_turn ?? 1) + 1
         const advanced: Todo = { ...todo, event_time: next.time, repeating_turn: nextTurn }
         useCalendarEventsCache.getState().replaceEvent(todo.uuid, { type: 'todo', event: advanced })
-        const inCurrent = useCurrentTodosCache.getState().todos.some(t => t.uuid === todo.uuid)
-        if (inCurrent) {
-          useCurrentTodosCache.getState().replaceTodo(advanced)
-        }
+        useCurrentTodosCache.getState().replaceTodo(advanced)
         useUncompletedTodosCache.getState().removeTodo(todo.uuid)
       } else {
         useCalendarEventsCache.getState().removeEvent(todo.uuid)

--- a/src/repositories/EventRepository.ts
+++ b/src/repositories/EventRepository.ts
@@ -7,6 +7,7 @@ import { useCurrentTodosCache } from './caches/currentTodosCache'
 import { useUncompletedTodosCache } from './caches/uncompletedTodosCache'
 import { monthRange } from '../domain/functions/eventTime'
 import type { CalendarEvent } from '../domain/functions/eventTime'
+import { nextRepeatingTime, getStartTimestamp } from '../domain/functions/repeating'
 
 // ── API 인터페이스 명시적 정의 ────────────────────────────────────────
 // todoApi/scheduleApi 모듈의 실제 시그니처와 동기를 유지해야 한다.
@@ -191,6 +192,50 @@ export class EventRepository {
     const updated = await this.deps.scheduleApi.excludeRepeating(id, { exclude_repeatings: excludeTurns })
     useCalendarEventsCache.getState().replaceEvent(id, { type: 'schedule', event: updated })
     return updated
+  }
+
+  async completeTodo(todo: Todo, scope?: 'this' | 'future'): Promise<DoneTodo> {
+    const isRepeating = !!todo.repeating && !!todo.event_time
+
+    if (scope === 'this' && isRepeating) {
+      const next = nextRepeatingTime(todo.event_time!, todo.repeating_turn ?? 1, todo.repeating!, todo.exclude_repeatings)
+      const done = await this.deps.todoApi.completeTodo(todo.uuid, {
+        origin: todo,
+        next_event_time: next?.time,
+        next_repeating_turn: next?.turn,
+      })
+      if (next?.time) {
+        const nextTurn = next.turn ?? (todo.repeating_turn ?? 1) + 1
+        const advanced: Todo = { ...todo, event_time: next.time, repeating_turn: nextTurn }
+        useCalendarEventsCache.getState().replaceEvent(todo.uuid, { type: 'todo', event: advanced })
+        const inCurrent = useCurrentTodosCache.getState().todos.some(t => t.uuid === todo.uuid)
+        if (inCurrent) {
+          useCurrentTodosCache.getState().replaceTodo(advanced)
+        }
+        useUncompletedTodosCache.getState().removeTodo(todo.uuid)
+      } else {
+        useCalendarEventsCache.getState().removeEvent(todo.uuid)
+        useCurrentTodosCache.getState().removeTodo(todo.uuid)
+        useUncompletedTodosCache.getState().removeTodo(todo.uuid)
+      }
+      return done
+    }
+
+    if (scope === 'future' && isRepeating) {
+      const startTs = getStartTimestamp(todo.event_time!)
+      await this.deps.todoApi.patchTodo(todo.uuid, { repeating: { ...todo.repeating, end: startTs - 1 } })
+      const done = await this.deps.todoApi.completeTodo(todo.uuid, { origin: todo })
+      useCalendarEventsCache.getState().removeEvent(todo.uuid)
+      useCurrentTodosCache.getState().removeTodo(todo.uuid)
+      useUncompletedTodosCache.getState().removeTodo(todo.uuid)
+      return done
+    }
+
+    const done = await this.deps.todoApi.completeTodo(todo.uuid, { origin: todo })
+    useCalendarEventsCache.getState().removeEvent(todo.uuid)
+    useCurrentTodosCache.getState().removeTodo(todo.uuid)
+    useUncompletedTodosCache.getState().removeTodo(todo.uuid)
+    return done
   }
 
 }

--- a/tests/components/CurrentTodoList.test.tsx
+++ b/tests/components/CurrentTodoList.test.tsx
@@ -255,8 +255,6 @@ describe('CurrentTodoList — 완료', () => {
 
   it('반복 Todo 체크박스 클릭 시 RepeatingScopeDialog가 표시되지 않는다', async () => {
     // given: 반복 todo (사용자에게 차수 선택을 묻지 않아야 함)
-    const { todoApi } = await import('../../src/api/todoApi')
-    vi.mocked(todoApi.completeTodo).mockResolvedValue({ uuid: 'done-1', done_at: 1000 } as any)
     const repeatingTodo = {
       uuid: 't3',
       name: '매일 반복',
@@ -264,12 +262,14 @@ describe('CurrentTodoList — 완료', () => {
       event_time: { time_type: 'at' as const, timestamp: 1743375600 },
       repeating: { start: 1743375600, option: { optionType: 'every_day' as const, interval: 1 } },
     } as unknown as Todo
-    useCalendarEventsCache.setState({ eventsByDate: new Map(), loading: false, lastRange: { lower: 0, upper: 9999999999 } })
+    useCalendarEventsCache.setState({ eventsByDate: new Map(), loading: false, lastRange: { lower: 0, upper: 9999999999 } } as any)
 
     render(
-      <MemoryRouter>
-        <CurrentTodoList todos={[repeatingTodo]} isTagHidden={() => false} />
-      </MemoryRouter>
+      <RepositoriesProvider value={makeFakeRepos(makeFakeEventRepo())}>
+        <MemoryRouter>
+          <CurrentTodoList todos={[repeatingTodo]} isTagHidden={() => false} />
+        </MemoryRouter>
+      </RepositoriesProvider>
     )
     await userEvent.click(screen.getByRole('button', { name: '매일 반복' }))
 

--- a/tests/components/CurrentTodoList.test.tsx
+++ b/tests/components/CurrentTodoList.test.tsx
@@ -5,7 +5,10 @@ import { MemoryRouter } from 'react-router-dom'
 import { CurrentTodoList, type CurrentTodoListProps } from '../../src/components/CurrentTodoList'
 import { useCurrentTodosCache } from '../../src/repositories/caches/currentTodosCache'
 import { useCalendarEventsCache } from '../../src/repositories/caches/calendarEventsCache'
+import { RepositoriesProvider } from '../../src/composition/RepositoriesProvider'
+import type { Repositories } from '../../src/composition/container'
 import type { Todo } from '../../src/models'
+import type { EventRepository } from '../../src/repositories/EventRepository'
 
 vi.mock('../../src/api/todoApi', () => ({
   todoApi: {
@@ -44,8 +47,41 @@ vi.mock('../../src/firebase', () => ({
   getAuthInstance: vi.fn(() => ({})),
   db: {},
 }))
+vi.mock('firebase/auth', () => ({
+  onAuthStateChanged: vi.fn(() => () => {}),
+  signInWithPopup: vi.fn(),
+  signOut: vi.fn(),
+  GoogleAuthProvider: vi.fn().mockImplementation(function (this: unknown) { return this }),
+  OAuthProvider: vi.fn().mockImplementation(function (this: unknown) { return this }),
+}))
+vi.mock('../../src/api/firebaseAuthApi', () => ({ firebaseAuthApi: {} }))
+vi.mock('../../src/api/eventTagApi', () => ({ eventTagApi: { getAllTags: vi.fn(async () => []) } }))
+vi.mock('../../src/api/settingApi', () => ({ settingApi: {} }))
+vi.mock('../../src/api/doneTodoApi', () => ({ doneTodoApi: {} }))
+vi.mock('../../src/api/foremostApi', () => ({ foremostApi: {} }))
+vi.mock('../../src/api/holidayApi', () => ({ holidayApi: {} }))
+vi.mock('../../src/api/eventDetailApi', () => ({ eventDetailApi: {} }))
 
 const mockOnEventClick = vi.fn()
+
+function makeFakeEventRepo(completeTodoImpl?: (todo: Todo) => Promise<any>): EventRepository {
+  return {
+    completeTodo: completeTodoImpl ?? vi.fn(async () => ({ uuid: 'done', done_at: 0 })),
+  } as unknown as EventRepository
+}
+
+function makeFakeRepos(eventRepo: EventRepository): Repositories {
+  return {
+    eventRepo,
+    eventDetailRepo: {} as any,
+    tagRepo: {} as any,
+    holidayRepo: {} as any,
+    doneTodoRepo: {} as any,
+    foremostEventRepo: {} as any,
+    authRepo: {} as any,
+    settingsRepo: {} as any,
+  }
+}
 
 function defaultProps(overrides: Partial<CurrentTodoListProps> = {}): CurrentTodoListProps {
   return {
@@ -56,11 +92,14 @@ function defaultProps(overrides: Partial<CurrentTodoListProps> = {}): CurrentTod
   }
 }
 
-function renderComponent(props: Partial<CurrentTodoListProps> = {}) {
+function renderComponent(props: Partial<CurrentTodoListProps> = {}, eventRepo?: EventRepository) {
+  const repo = eventRepo ?? makeFakeEventRepo()
   return render(
-    <MemoryRouter>
-      <CurrentTodoList {...defaultProps(props)} />
-    </MemoryRouter>
+    <RepositoriesProvider value={makeFakeRepos(repo)}>
+      <MemoryRouter>
+        <CurrentTodoList {...defaultProps(props)} />
+      </MemoryRouter>
+    </RepositoriesProvider>
   )
 }
 
@@ -162,21 +201,25 @@ describe('CurrentTodoList — 완료', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     useCurrentTodosCache.setState({ todos: [] })
-    useCalendarEventsCache.setState({ eventsByDate: new Map(), loading: false, lastRange: null })
+    useCalendarEventsCache.setState({ eventsByDate: new Map(), loading: false, loadedYears: new Set() })
   })
 
-  it('비반복 Todo 체크박스 클릭 시 해당 Todo가 목록에서 사라진다', async () => {
-    // given: todo가 currentTodosCache에 있는 상태
-    const { todoApi } = await import('../../src/api/todoApi')
-    vi.mocked(todoApi.completeTodo).mockResolvedValue({ uuid: 'done-1', done_at: 1000 } as any)
+  it('비반복 Todo 체크박스 클릭 시 eventRepo.completeTodo 완료 후 해당 Todo가 목록에서 사라진다', async () => {
+    // given: todo가 currentTodosCache에 있는 상태, fake eventRepo가 removeTodo를 실행
     const todo = { uuid: 't1', name: '완료 할 일', is_current: true, event_time: null } as Todo
     useCurrentTodosCache.setState({ todos: [todo] })
-    useCalendarEventsCache.setState({ eventsByDate: new Map(), loading: false, lastRange: null })
+
+    const fakeEventRepo = makeFakeEventRepo(async (t) => {
+      useCurrentTodosCache.getState().removeTodo(t.uuid)
+      return { uuid: 'done-1', done_at: 1000 }
+    })
 
     render(
-      <MemoryRouter>
-        <CurrentTodoList todos={[todo]} isTagHidden={() => false} />
-      </MemoryRouter>
+      <RepositoriesProvider value={makeFakeRepos(fakeEventRepo)}>
+        <MemoryRouter>
+          <CurrentTodoList todos={[todo]} isTagHidden={() => false} />
+        </MemoryRouter>
+      </RepositoriesProvider>
     )
     await userEvent.click(screen.getByRole('button', { name: '완료 할 일' }))
 
@@ -187,8 +230,6 @@ describe('CurrentTodoList — 완료', () => {
 
   it('반복 Todo 체크박스 클릭 시 에러 없이 처리된다', async () => {
     // given: 반복 todo
-    const { todoApi } = await import('../../src/api/todoApi')
-    vi.mocked(todoApi.completeTodo).mockResolvedValue({ uuid: 'done-1', done_at: 1000 } as any)
     const repeatingTodo = {
       uuid: 't2',
       name: '반복 할 일',
@@ -196,12 +237,13 @@ describe('CurrentTodoList — 완료', () => {
       event_time: { time_type: 'at' as const, timestamp: 1743375600 },
       repeating: { start: 1743375600, option: { optionType: 'every_day' as const, interval: 1 } },
     } as unknown as Todo
-    useCalendarEventsCache.setState({ eventsByDate: new Map(), loading: false, lastRange: { lower: 0, upper: 9999999999 } })
 
     render(
-      <MemoryRouter>
-        <CurrentTodoList todos={[repeatingTodo]} isTagHidden={() => false} />
-      </MemoryRouter>
+      <RepositoriesProvider value={makeFakeRepos(makeFakeEventRepo())}>
+        <MemoryRouter>
+          <CurrentTodoList todos={[repeatingTodo]} isTagHidden={() => false} />
+        </MemoryRouter>
+      </RepositoriesProvider>
     )
     await userEvent.click(screen.getByRole('button', { name: '반복 할 일' }))
 

--- a/tests/components/DayEventList.test.tsx
+++ b/tests/components/DayEventList.test.tsx
@@ -2,11 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { DayEventList, type DayEventListProps } from '../../src/components/DayEventList'
+import { RepositoriesProvider } from '../../src/composition/RepositoriesProvider'
+import type { Repositories } from '../../src/composition/container'
+import type { EventRepository } from '../../src/repositories/EventRepository'
 import type { CalendarEvent } from '../../src/domain/functions/eventTime'
 
-vi.mock('../../src/repositories/caches/calendarEventsCache', () => ({
-  useCalendarEventsCache: { getState: vi.fn(() => ({ removeEvent: vi.fn() })) },
-}))
 vi.mock('../../src/repositories/caches/eventTagListCache', () => ({
   useEventTagListCache: vi.fn((selector: any) => selector({ tags: new Map(), defaultTagColors: null })),
   DEFAULT_TAG_ID: 'default',
@@ -29,9 +29,41 @@ vi.mock('../../src/repositories/caches/settingsCache', () => ({
   })),
 }))
 vi.mock('../../src/firebase', () => ({ getAuthInstance: vi.fn(() => ({})), db: {} }))
-vi.mock('../../src/api/todoApi', () => ({
-  todoApi: { completeTodo: vi.fn(), patchTodo: vi.fn() },
+vi.mock('firebase/auth', () => ({
+  onAuthStateChanged: vi.fn(() => () => {}),
+  signInWithPopup: vi.fn(),
+  signOut: vi.fn(),
+  GoogleAuthProvider: vi.fn().mockImplementation(function (this: unknown) { return this }),
+  OAuthProvider: vi.fn().mockImplementation(function (this: unknown) { return this }),
 }))
+vi.mock('../../src/api/todoApi', () => ({ todoApi: {} }))
+vi.mock('../../src/api/scheduleApi', () => ({ scheduleApi: {} }))
+vi.mock('../../src/api/firebaseAuthApi', () => ({ firebaseAuthApi: {} }))
+vi.mock('../../src/api/eventTagApi', () => ({ eventTagApi: { getAllTags: vi.fn(async () => []) } }))
+vi.mock('../../src/api/settingApi', () => ({ settingApi: {} }))
+vi.mock('../../src/api/doneTodoApi', () => ({ doneTodoApi: {} }))
+vi.mock('../../src/api/foremostApi', () => ({ foremostApi: {} }))
+vi.mock('../../src/api/holidayApi', () => ({ holidayApi: {} }))
+vi.mock('../../src/api/eventDetailApi', () => ({ eventDetailApi: {} }))
+
+function makeFakeEventRepo(): EventRepository {
+  return {
+    completeTodo: vi.fn(async () => ({ uuid: 'done', done_at: 0 })),
+  } as unknown as EventRepository
+}
+
+function makeFakeRepos(eventRepo: EventRepository): Repositories {
+  return {
+    eventRepo,
+    eventDetailRepo: {} as any,
+    tagRepo: {} as any,
+    holidayRepo: {} as any,
+    doneTodoRepo: {} as any,
+    foremostEventRepo: {} as any,
+    authRepo: {} as any,
+    settingsRepo: {} as any,
+  }
+}
 
 const mockOnEventClick = vi.fn()
 
@@ -46,7 +78,11 @@ function defaultProps(overrides: Partial<DayEventListProps> = {}): DayEventListP
 }
 
 function renderComponent(props: Partial<DayEventListProps> = {}) {
-  return render(<DayEventList {...defaultProps(props)} />)
+  return render(
+    <RepositoriesProvider value={makeFakeRepos(makeFakeEventRepo())}>
+      <DayEventList {...defaultProps(props)} />
+    </RepositoriesProvider>
+  )
 }
 
 describe('DayEventList', () => {

--- a/tests/components/RightEventPanel.test.tsx
+++ b/tests/components/RightEventPanel.test.tsx
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { RightEventPanel, type RightEventPanelProps } from '../../src/components/RightEventPanel'
+import { RepositoriesProvider } from '../../src/composition/RepositoriesProvider'
+import type { Repositories } from '../../src/composition/container'
+import type { EventRepository } from '../../src/repositories/EventRepository'
 
 vi.mock('../../src/repositories/caches/eventTagListCache', () => ({
   useEventTagListCache: vi.fn((selector: any) => selector({ tags: new Map() })),
@@ -14,15 +17,42 @@ vi.mock('../../src/api/todoApi', () => ({
 vi.mock('../../src/api/scheduleApi', () => ({
   scheduleApi: { getSchedules: vi.fn().mockResolvedValue([]) },
 }))
-vi.mock('../../src/repositories/caches/calendarEventsCache', () => ({
-  useCalendarEventsCache: { getState: vi.fn(() => ({ removeEvent: vi.fn(), eventsByDate: new Map() })) },
-}))
 vi.mock('../../src/firebase', () => ({
   getAuthInstance: vi.fn(() => ({})),
   db: {},
 }))
+vi.mock('firebase/auth', () => ({
+  onAuthStateChanged: vi.fn(() => () => {}),
+  signInWithPopup: vi.fn(),
+  signOut: vi.fn(),
+  GoogleAuthProvider: vi.fn().mockImplementation(function (this: unknown) { return this }),
+  OAuthProvider: vi.fn().mockImplementation(function (this: unknown) { return this }),
+}))
+vi.mock('../../src/api/firebaseAuthApi', () => ({ firebaseAuthApi: {} }))
+vi.mock('../../src/api/eventTagApi', () => ({ eventTagApi: { getAllTags: vi.fn(async () => []) } }))
+vi.mock('../../src/api/settingApi', () => ({ settingApi: {} }))
+vi.mock('../../src/api/doneTodoApi', () => ({ doneTodoApi: {} }))
+vi.mock('../../src/api/foremostApi', () => ({ foremostApi: {} }))
+vi.mock('../../src/api/holidayApi', () => ({ holidayApi: {} }))
+vi.mock('../../src/api/eventDetailApi', () => ({ eventDetailApi: {} }))
 vi.mock('../../src/hooks/useIsMobile', () => ({
   useIsMobile: vi.fn(() => false),
+}))
+vi.mock('../../src/repositories/caches/settingsCache', () => ({
+  useSettingsCache: vi.fn((selector: any) => selector({
+    calendarAppearance: {
+      weekStartDay: 0, accentDays: { holiday: true, saturday: false, sunday: true },
+      eventDisplayLevel: 'medium', rowHeight: 70, eventFontSizeWeight: 0, showEventNames: true,
+      eventListFontSizeWeight: 0, showHolidayInEventList: true, showLunarCalendar: false, showUncompletedTodos: true,
+    },
+    eventDefaults: { defaultTagId: null, defaultNotificationSeconds: null, defaultAllDayNotificationSeconds: null },
+    timezone: { timezone: 'UTC', systemTimezone: 'UTC', isCustom: false },
+    notification: { permission: 'default', fcmToken: null },
+    setAppearance: vi.fn(), resetAppearanceToDefaults: vi.fn(),
+    setEventDefaults: vi.fn(), setTimezone: vi.fn(),
+    setNotificationPermission: vi.fn(), setFcmToken: vi.fn(),
+    requestNotificationPermission: vi.fn(), reset: vi.fn(),
+  })),
 }))
 
 import { useIsMobile } from '../../src/hooks/useIsMobile'
@@ -32,6 +62,23 @@ vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom')
   return { ...actual, useNavigate: () => mockNavigate }
 })
+
+function makeFakeEventRepo(): EventRepository {
+  return { completeTodo: vi.fn(async () => ({ uuid: 'done', done_at: 0 })) } as unknown as EventRepository
+}
+
+function makeFakeRepos(): Repositories {
+  return {
+    eventRepo: makeFakeEventRepo(),
+    eventDetailRepo: {} as any,
+    tagRepo: {} as any,
+    holidayRepo: {} as any,
+    doneTodoRepo: {} as any,
+    foremostEventRepo: {} as any,
+    authRepo: {} as any,
+    settingsRepo: {} as any,
+  }
+}
 
 function defaultProps(overrides: Partial<RightEventPanelProps> = {}): RightEventPanelProps {
   return {
@@ -56,9 +103,11 @@ function defaultProps(overrides: Partial<RightEventPanelProps> = {}): RightEvent
 
 function renderComponent(props: Partial<RightEventPanelProps> = {}) {
   return render(
-    <MemoryRouter>
-      <RightEventPanel {...defaultProps(props)} />
-    </MemoryRouter>
+    <RepositoriesProvider value={makeFakeRepos()}>
+      <MemoryRouter>
+        <RightEventPanel {...defaultProps(props)} />
+      </MemoryRouter>
+    </RepositoriesProvider>
   )
 }
 

--- a/tests/components/UncompletedTodoList.test.tsx
+++ b/tests/components/UncompletedTodoList.test.tsx
@@ -3,6 +3,9 @@ import { render, screen, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { UncompletedTodoList, type UncompletedTodoListProps } from '../../src/components/UncompletedTodoList'
+import { RepositoriesProvider } from '../../src/composition/RepositoriesProvider'
+import type { Repositories } from '../../src/composition/container'
+import type { EventRepository } from '../../src/repositories/EventRepository'
 import type { Todo } from '../../src/models'
 
 vi.mock('../../src/api/todoApi', () => ({
@@ -15,6 +18,20 @@ vi.mock('../../src/api/todoApi', () => ({
 vi.mock('../../src/api/scheduleApi', () => ({
   scheduleApi: { getSchedules: vi.fn().mockResolvedValue([]) },
 }))
+vi.mock('firebase/auth', () => ({
+  onAuthStateChanged: vi.fn(() => () => {}),
+  signInWithPopup: vi.fn(),
+  signOut: vi.fn(),
+  GoogleAuthProvider: vi.fn().mockImplementation(function (this: unknown) { return this }),
+  OAuthProvider: vi.fn().mockImplementation(function (this: unknown) { return this }),
+}))
+vi.mock('../../src/api/firebaseAuthApi', () => ({ firebaseAuthApi: {} }))
+vi.mock('../../src/api/eventTagApi', () => ({ eventTagApi: { getAllTags: vi.fn(async () => []) } }))
+vi.mock('../../src/api/settingApi', () => ({ settingApi: {} }))
+vi.mock('../../src/api/doneTodoApi', () => ({ doneTodoApi: {} }))
+vi.mock('../../src/api/foremostApi', () => ({ foremostApi: {} }))
+vi.mock('../../src/api/holidayApi', () => ({ holidayApi: {} }))
+vi.mock('../../src/api/eventDetailApi', () => ({ eventDetailApi: {} }))
 vi.mock('../../src/repositories/caches/eventTagListCache', () => ({
   useEventTagListCache: vi.fn((selector: any) => selector({ tags: new Map(), defaultTagColors: null })),
   DEFAULT_TAG_ID: 'default',
@@ -59,6 +76,19 @@ vi.mock('../../src/firebase', () => ({
 const mockOnReload = vi.fn()
 const mockOnEventClick = vi.fn()
 
+function makeFakeRepos(): Repositories {
+  return {
+    eventRepo: { completeTodo: vi.fn(async () => ({ uuid: 'done', done_at: 0 })) } as unknown as EventRepository,
+    eventDetailRepo: {} as any,
+    tagRepo: {} as any,
+    holidayRepo: {} as any,
+    doneTodoRepo: {} as any,
+    foremostEventRepo: {} as any,
+    authRepo: {} as any,
+    settingsRepo: {} as any,
+  }
+}
+
 function defaultProps(overrides: Partial<UncompletedTodoListProps> = {}): UncompletedTodoListProps {
   return {
     todos: [],
@@ -71,9 +101,11 @@ function defaultProps(overrides: Partial<UncompletedTodoListProps> = {}): Uncomp
 
 function renderComponent(props: Partial<UncompletedTodoListProps> = {}) {
   return render(
-    <MemoryRouter>
-      <UncompletedTodoList {...defaultProps(props)} />
-    </MemoryRouter>
+    <RepositoriesProvider value={makeFakeRepos()}>
+      <MemoryRouter>
+        <UncompletedTodoList {...defaultProps(props)} />
+      </MemoryRouter>
+    </RepositoriesProvider>
   )
 }
 

--- a/tests/repositories/EventRepository.test.ts
+++ b/tests/repositories/EventRepository.test.ts
@@ -486,6 +486,33 @@ describe('EventRepository — completeTodo', () => {
     expect(useUncompletedTodosCache.getState().todos.some(t => t.uuid === 'rep-todo-end')).toBe(false)
   })
 
+  it("반복 todo 'all' 스코프: completeTodo 후 세 캐시 모두에서 사라진다", async () => {
+    // given: 반복 todo를 세 캐시에 넣어둔다
+    const repeating = { start: MAR_01_TS, option: { optionType: 'every_day' as const, interval: 1 } }
+    const todo = makeTodo({
+      uuid: 'rep-todo-all',
+      event_time: { time_type: 'at', timestamp: MAR_15_TS },
+      repeating,
+      repeating_turn: 15,
+    })
+    useCalendarEventsCache.getState().addEvent({ type: 'todo', event: todo })
+    useCurrentTodosCache.getState().addTodo(todo)
+    useUncompletedTodosCache.setState({ todos: [todo] })
+    const repo = new EventRepository({
+      todoApi: makeFakeTodoApi({ completeTodo: async () => ({ uuid: 'done-all', done_at: MAR_15_TS } as any) }),
+      scheduleApi: makeFakeScheduleApi(),
+    })
+
+    // when
+    await repo.completeTodo(todo, 'all')
+
+    // then: 세 캐시 모두에서 사라진다 (default 분기와 동일 동작)
+    const calSnapshot = repo.getMonthEventsSnapshot(2025, 2)
+    expect(calSnapshot.some(e => e.event.uuid === 'rep-todo-all')).toBe(false)
+    expect(useCurrentTodosCache.getState().todos.some(t => t.uuid === 'rep-todo-all')).toBe(false)
+    expect(useUncompletedTodosCache.getState().todos.some(t => t.uuid === 'rep-todo-all')).toBe(false)
+  })
+
   it("반복 todo 'future' 스코프: patchTodo 후 세 캐시 모두에서 사라진다", async () => {
     // given: 반복 todo를 세 캐시에 넣어둔다
     const repeating = { start: MAR_01_TS, option: { optionType: 'every_day' as const, interval: 1 } }

--- a/tests/repositories/EventRepository.test.ts
+++ b/tests/repositories/EventRepository.test.ts
@@ -401,3 +401,118 @@ describe('EventRepository — fetchUncompletedTodos', () => {
     expect(snapshot.some(t => t.uuid === 'unc-2')).toBe(true)
   })
 })
+
+describe('EventRepository — completeTodo', () => {
+  beforeEach(resetCaches)
+
+  it('비반복 todo 완료 시 세 캐시 모두에서 해당 todo가 사라진다', async () => {
+    // given: 비반복 todo를 세 캐시에 모두 넣어둔다
+    const todo = makeTodo({ uuid: 'simple-todo', event_time: { time_type: 'at', timestamp: MAR_15_TS } })
+    useCalendarEventsCache.getState().addEvent({ type: 'todo', event: todo })
+    useCurrentTodosCache.getState().addTodo(todo)
+    useUncompletedTodosCache.setState({ todos: [todo] })
+    const repo = new EventRepository({
+      todoApi: makeFakeTodoApi({ completeTodo: async () => ({ uuid: 'done-simple', done_at: MAR_15_TS } as any) }),
+      scheduleApi: makeFakeScheduleApi(),
+    })
+
+    // when
+    await repo.completeTodo(todo)
+
+    // then: 세 캐시 모두에서 사라진다
+    const calSnapshot = repo.getMonthEventsSnapshot(2025, 2)
+    expect(calSnapshot.some(e => e.event.uuid === 'simple-todo')).toBe(false)
+    expect(useCurrentTodosCache.getState().todos.some(t => t.uuid === 'simple-todo')).toBe(false)
+    expect(useUncompletedTodosCache.getState().todos.some(t => t.uuid === 'simple-todo')).toBe(false)
+  })
+
+  it("반복 todo 'this' 스코프 + 다음 차수 있음: calendarEventsCache의 event_time이 다음 차수로 advance되고 uncompletedTodosCache에서 사라진다", async () => {
+    // given: 매일 반복 todo (MAR_01_TS → 다음은 MAR_02 부근)
+    const repeating = { start: MAR_01_TS, option: { optionType: 'every_day' as const, interval: 1 } }
+    const todo = makeTodo({
+      uuid: 'rep-todo-this',
+      event_time: { time_type: 'at', timestamp: MAR_01_TS },
+      repeating,
+      repeating_turn: 1,
+    })
+    useCalendarEventsCache.getState().addEvent({ type: 'todo', event: todo })
+    useUncompletedTodosCache.setState({ todos: [todo] })
+    const doneTodo = { uuid: 'done-rep', done_at: MAR_01_TS }
+    const repo = new EventRepository({
+      todoApi: makeFakeTodoApi({ completeTodo: async () => doneTodo as any }),
+      scheduleApi: makeFakeScheduleApi(),
+    })
+
+    // when
+    await repo.completeTodo(todo, 'this')
+
+    // then: calendarEventsCache의 해당 uuid event_time이 다음 차수(MAR_02)로 advance됨
+    const calSnapshot = repo.getMonthEventsSnapshot(2025, 2)
+    const advanced = calSnapshot.find(e => e.event.uuid === 'rep-todo-this')
+    expect(advanced).toBeDefined()
+    const eventTime = advanced!.event.event_time
+    expect(eventTime).not.toBeNull()
+    // 다음 차수 timestamp는 MAR_01_TS보다 커야 한다 (하루 이상 이후)
+    const nextTs = eventTime!.time_type === 'at' ? eventTime!.timestamp : (eventTime as any).period_start
+    expect(nextTs).toBeGreaterThan(MAR_01_TS)
+    // uncompletedTodosCache에서는 사라진다
+    expect(useUncompletedTodosCache.getState().todos.some(t => t.uuid === 'rep-todo-this')).toBe(false)
+  })
+
+  it("반복 todo 'this' 스코프 + 다음 차수 없음(반복 종료): 세 캐시 모두에서 사라진다", async () => {
+    // given: end가 MAR_01_TS로 설정된 반복 todo (다음 차수는 MAR_01_TS 이후이므로 종료)
+    const repeating = { start: MAR_01_TS, end: MAR_01_TS, option: { optionType: 'every_day' as const, interval: 1 } }
+    const todo = makeTodo({
+      uuid: 'rep-todo-end',
+      event_time: { time_type: 'at', timestamp: MAR_01_TS },
+      repeating,
+      repeating_turn: 1,
+    })
+    useCalendarEventsCache.getState().addEvent({ type: 'todo', event: todo })
+    useCurrentTodosCache.getState().addTodo(todo)
+    useUncompletedTodosCache.setState({ todos: [todo] })
+    const repo = new EventRepository({
+      todoApi: makeFakeTodoApi({ completeTodo: async () => ({ uuid: 'done-rep-end', done_at: MAR_01_TS } as any) }),
+      scheduleApi: makeFakeScheduleApi(),
+    })
+
+    // when
+    await repo.completeTodo(todo, 'this')
+
+    // then: 세 캐시 모두에서 사라진다
+    const calSnapshot = repo.getMonthEventsSnapshot(2025, 2)
+    expect(calSnapshot.some(e => e.event.uuid === 'rep-todo-end')).toBe(false)
+    expect(useCurrentTodosCache.getState().todos.some(t => t.uuid === 'rep-todo-end')).toBe(false)
+    expect(useUncompletedTodosCache.getState().todos.some(t => t.uuid === 'rep-todo-end')).toBe(false)
+  })
+
+  it("반복 todo 'future' 스코프: patchTodo 후 세 캐시 모두에서 사라진다", async () => {
+    // given: 반복 todo를 세 캐시에 넣어둔다
+    const repeating = { start: MAR_01_TS, option: { optionType: 'every_day' as const, interval: 1 } }
+    const todo = makeTodo({
+      uuid: 'rep-todo-future',
+      event_time: { time_type: 'at', timestamp: MAR_15_TS },
+      repeating,
+      repeating_turn: 15,
+    })
+    useCalendarEventsCache.getState().addEvent({ type: 'todo', event: todo })
+    useCurrentTodosCache.getState().addTodo(todo)
+    useUncompletedTodosCache.setState({ todos: [todo] })
+    const repo = new EventRepository({
+      todoApi: makeFakeTodoApi({
+        patchTodo: async () => todo,
+        completeTodo: async () => ({ uuid: 'done-future', done_at: MAR_15_TS } as any),
+      }),
+      scheduleApi: makeFakeScheduleApi(),
+    })
+
+    // when
+    await repo.completeTodo(todo, 'future')
+
+    // then: 세 캐시 모두에서 사라진다 (호출 인자 검증 금지, cache 결과로만 검증)
+    const calSnapshot = repo.getMonthEventsSnapshot(2025, 2)
+    expect(calSnapshot.some(e => e.event.uuid === 'rep-todo-future')).toBe(false)
+    expect(useCurrentTodosCache.getState().todos.some(t => t.uuid === 'rep-todo-future')).toBe(false)
+    expect(useUncompletedTodosCache.getState().todos.some(t => t.uuid === 'rep-todo-future')).toBe(false)
+  })
+})


### PR DESCRIPTION
## 문제
반복 할일 완료 후 우측 패널·캘린더 그리드에서 해당 항목이 사라지지 않고 새로고침해야 반영됨. API 호출은 정상.

## 원인
`UncompletedTodoList.doComplete` / `CurrentTodoList.doComplete` / `DayEventList` 세 컴포넌트가 거의 동일한 todo 완료 코드를 각자 복사하고 있고, 반복 케이스에서 응답값을 무시한 채 `useUncompletedTodosCache.fetch()` + `useCurrentTodosCache.fetch()` 전체 재조회만 호출. 캘린더 그리드(`calendarEventsCache`) 는 아예 갱신 안 됨.

## 접근
세 자리에 흩어진 완료 로직을 `EventRepository.completeTodo(todo, scope?)` 단일 메서드로 추출하고, 응답값(또는 클라이언트가 자체 계산한 다음 차수 정보)으로 메모리 캐시를 직접 갱신. 전체 재조회 호출 제거. 컴포넌트는 한 줄 위임.

- scope `'this'` + 다음 차수 있음: calendarEventsCache 의 해당 이벤트를 다음 차수 시간으로 advance, currentTodos 도 동일 advance, uncompletedTodos 에서 제거
- scope `'this'` + 다음 차수 없음(반복 종료): 세 캐시 모두 제거
- scope `'future'` / 비반복 / `'all'`: 세 캐시 모두 제거

DayEventList 의 비반복 분기에 남아있던 불필요한 `fetch()` 동시 호출도 함께 제거.

## 남은 과제
별도 후속 이슈로 분리 검토:
- `completeTodo` 후 `doneTodosCache` 에 응답 prepend (현재는 ArchivePanel 새로 열어야 반영)
- `eventTagListCache.deleteTagAndEvents` 의 `currentTodos`/`uncompletedTodos` `fetch()` 도 in-memory transform 으로 변경

## 변경
- `EventRepository.completeTodo(todo, scope?)` 신규 (in-memory cache primitive 만 사용, fetch 호출 없음)
- `UncompletedTodoList` / `CurrentTodoList` / `DayEventList` `doComplete` → `eventRepo.completeTodo` 위임
- 컴포넌트 테스트 셋업을 `RepositoriesProvider` 기반 fake repo 주입 패턴으로 정리

## Test plan
- [ ] 반복 할일 완료 → 우측 패널/캘린더 그리드 즉시 반영, 새로고침 불필요
- [ ] 다음 차수가 캘린더 그리드의 다음 일자에 정확히 표시
- [ ] 반복 종료 케이스(다음 차수 없음) → 모든 표시에서 제거
- [ ] 비반복 할일 완료 → 기존과 동일
- [ ] DayEventList 캘린더 셀에서 todo 완료 → 즉시 반영

Closes #133