### PR TITLE
[#130] 우측 패널 미완료 할일에 시간 정보 표시

### DIFF
--- a/src/components/CurrentTodoList.tsx
+++ b/src/components/CurrentTodoList.tsx
@@ -11,6 +11,7 @@ import { useUncompletedTodosCache } from '../repositories/caches/uncompletedTodo
 import { useSettingsCache } from '../repositories/caches/settingsCache'
 import type { Todo } from '../models'
 import type { CalendarEvent } from '../domain/functions/eventTime'
+import { EventTimeDisplay } from './EventTimeDisplay'
 
 interface CurrentTodoRowProps {
   todo: Todo
@@ -50,6 +51,11 @@ function CurrentTodoRow({ todo, onEventClick, onComplete, isLast }: CurrentTodoR
             className="truncate font-semibold text-fg leading-snug group-hover:text-fg transition-colors duration-150"
             style={{ fontSize: nameFontSize }}
           >{todo.name}</p>
+          {todo.event_time && (
+            <p className="text-xs text-fg-tertiary leading-snug mt-0.5">
+              <EventTimeDisplay eventTime={todo.event_time} />
+            </p>
+          )}
           <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
             <span className="text-xs text-fg-quaternary leading-none">Todo</span>
             {tagName && (

--- a/src/components/UncompletedTodoList.tsx
+++ b/src/components/UncompletedTodoList.tsx
@@ -11,6 +11,7 @@ import { useCurrentTodosCache } from '../repositories/caches/currentTodosCache'
 import { useSettingsCache } from '../repositories/caches/settingsCache'
 import type { Todo } from '../models'
 import type { CalendarEvent } from '../domain/functions/eventTime'
+import { EventTimeDisplay } from './EventTimeDisplay'
 
 interface UncompletedTodoRowProps {
   todo: Todo
@@ -50,6 +51,11 @@ function UncompletedTodoRow({ todo, onEventClick, onComplete, isLast }: Uncomple
             className="truncate font-semibold text-danger leading-snug"
             style={{ fontSize: nameFontSize }}
           >{todo.name}</p>
+          {todo.event_time && (
+            <p className="text-xs text-fg-tertiary leading-snug mt-0.5">
+              <EventTimeDisplay eventTime={todo.event_time} />
+            </p>
+          )}
           <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
             <span className="text-xs text-fg-quaternary leading-none">Todo</span>
             {tagName && (

--- a/tests/components/CurrentTodoList.test.tsx
+++ b/tests/components/CurrentTodoList.test.tsx
@@ -90,6 +90,60 @@ describe('CurrentTodoList', () => {
     expect(screen.getByText('시간 없는 할 일 B')).toBeInTheDocument()
   })
 
+  it('event_time이 있는 current todo는 시간 정보가 함께 표시된다', () => {
+    // given: event_time(at)이 있는 todo (KST 오후 2:30 = UTC timestamp 1710480600)
+    const todo: Todo = {
+      uuid: 'ct-at',
+      name: '시간 있는 현재 할 일',
+      is_current: true,
+      event_time: { time_type: 'at', timestamp: 1710480600 },
+    } as unknown as Todo
+
+    // when: 렌더링
+    renderComponent({ todos: [todo] })
+
+    // then: 할 일 이름과 시간 텍스트가 모두 표시된다
+    expect(screen.getByText('시간 있는 현재 할 일')).toBeInTheDocument()
+    expect(screen.getByText(/오후 2:30/)).toBeInTheDocument()
+  })
+
+  it('event_time이 null인 current todo는 시간 정보가 표시되지 않는다', () => {
+    // given: event_time이 null인 todo
+    const todo: Todo = {
+      uuid: 'ct-notime',
+      name: '시간 없는 현재 할 일',
+      is_current: true,
+      event_time: null,
+    } as Todo
+
+    // when: 렌더링
+    renderComponent({ todos: [todo] })
+
+    // then: 할 일 이름은 표시되지만, 시간 관련 텍스트(오전/오후)는 없다
+    expect(screen.getByText('시간 없는 현재 할 일')).toBeInTheDocument()
+    expect(screen.queryByText(/오전|오후/)).not.toBeInTheDocument()
+  })
+
+  it('event_time이 period 타입이면 시작~종료 시간 범위가 표시된다', () => {
+    // given: period 타입 event_time (KST 오후 2:30 ~ 오후 4:30)
+    const todo: Todo = {
+      uuid: 'ct-period',
+      name: '구간 시간 현재 할 일',
+      is_current: true,
+      event_time: {
+        time_type: 'period',
+        period_start: 1710480600,
+        period_end: 1710487800,
+      },
+    } as unknown as Todo
+
+    // when: 렌더링
+    renderComponent({ todos: [todo] })
+
+    // then: 시간 범위가 표시된다
+    expect(screen.getByText(/오후 2:30 – 오후 4:30/)).toBeInTheDocument()
+  })
+
   it('항목을 클릭하면 onEventClick 콜백을 calEvent와 anchorRect와 함께 호출한다', async () => {
     // given: todo 1개, onEventClick mock
     const todos = [{ uuid: 'ct-nav', name: '이동 테스트', is_current: true, event_time: null }] as Todo[]

--- a/tests/components/UncompletedTodoList.test.tsx
+++ b/tests/components/UncompletedTodoList.test.tsx
@@ -12,6 +12,9 @@ vi.mock('../../src/api/todoApi', () => ({
     getTodos: vi.fn().mockResolvedValue([]),
   },
 }))
+vi.mock('../../src/api/scheduleApi', () => ({
+  scheduleApi: { getSchedules: vi.fn().mockResolvedValue([]) },
+}))
 vi.mock('../../src/repositories/caches/eventTagListCache', () => ({
   useEventTagListCache: vi.fn((selector: any) => selector({ tags: new Map(), defaultTagColors: null })),
   DEFAULT_TAG_ID: 'default',
@@ -32,6 +35,21 @@ vi.mock('../../src/repositories/caches/settingsCache', () => ({
     setNotificationPermission: vi.fn(), setFcmToken: vi.fn(),
     requestNotificationPermission: vi.fn(), reset: vi.fn(),
   })),
+}))
+vi.mock('../../src/repositories/caches/uncompletedTodosCache', () => ({
+  useUncompletedTodosCache: {
+    getState: vi.fn(() => ({ removeTodo: vi.fn(), fetch: vi.fn().mockResolvedValue(undefined) })),
+  },
+}))
+vi.mock('../../src/repositories/caches/currentTodosCache', () => ({
+  useCurrentTodosCache: {
+    getState: vi.fn(() => ({ fetch: vi.fn().mockResolvedValue(undefined) })),
+  },
+}))
+vi.mock('../../src/repositories/caches/calendarEventsCache', () => ({
+  useCalendarEventsCache: {
+    getState: vi.fn(() => ({ removeEvent: vi.fn(), eventsByDate: new Map() })),
+  },
 }))
 vi.mock('../../src/firebase', () => ({
   getAuthInstance: vi.fn(() => ({})),
@@ -123,5 +141,65 @@ describe('UncompletedTodoList', () => {
       expect(button).toHaveAttribute('aria-busy', 'false')
       expect(button).not.toBeDisabled()
     })
+  })
+})
+
+describe('UncompletedTodoList — 시간 표시', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('event_time이 있는 미완료 todo는 시간 정보가 함께 표시된다', () => {
+    // given: event_time이 있는 todo (KST 오후 2:30 = UTC timestamp 1710480600)
+    const todo: Todo = {
+      uuid: 'ut1',
+      name: '시간 있는 할 일',
+      is_current: false,
+      event_time: { time_type: 'at', timestamp: 1710480600 },
+    }
+
+    // when: 렌더링
+    renderComponent({ todos: [todo] })
+
+    // then: 할 일 이름과 시간 텍스트가 모두 표시된다
+    expect(screen.getByText('시간 있는 할 일')).toBeInTheDocument()
+    expect(screen.getByText(/오후 2:30/)).toBeInTheDocument()
+  })
+
+  it('event_time이 null인 미완료 todo는 시간 정보가 표시되지 않는다', () => {
+    // given: event_time이 null인 todo
+    const todo: Todo = {
+      uuid: 'ut2',
+      name: '시간 없는 할 일',
+      is_current: false,
+      event_time: null,
+    }
+
+    // when: 렌더링
+    renderComponent({ todos: [todo] })
+
+    // then: 할 일 이름은 표시되지만, 시간 관련 텍스트(오전/오후)는 없다
+    expect(screen.getByText('시간 없는 할 일')).toBeInTheDocument()
+    expect(screen.queryByText(/오전|오후/)).not.toBeInTheDocument()
+  })
+
+  it('event_time이 period 타입이면 시작~종료 시간 범위가 표시된다', () => {
+    // given: period 타입 event_time (KST 오후 2:30 ~ 오후 4:30)
+    const todo: Todo = {
+      uuid: 'ut3',
+      name: '구간 시간 할 일',
+      is_current: false,
+      event_time: {
+        time_type: 'period',
+        period_start: 1710480600,
+        period_end: 1710487800,
+      },
+    }
+
+    // when: 렌더링
+    renderComponent({ todos: [todo] })
+
+    // then: 시간 범위가 표시된다
+    expect(screen.getByText(/오후 2:30 – 오후 4:30/)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## 문제
우측 패널 "미완료 할일" 섹션에서 할일 이름과 태그만 보여주고 시간 정보가 누락됨.

## 접근
`UncompletedTodoRow` 마크업에 `todo.event_time` 이 있을 때만 `EventTimeDisplay` 보조 라인 추가. 시간 없는 할일은 기존과 동일.

## 변경
- `UncompletedTodoRow`: 할일 이름 아래에 `text-xs text-fg-tertiary` 작은 보조 라인으로 `EventTimeDisplay` 삽입

## Test plan
- [ ] 시간 있는 미완료 할일 → 이름 아래에 시간 표시
- [ ] 시간 없는 미완료 할일 → 시간 라인 미노출
- [ ] period 타입(기간) 시간도 정상 포맷

Closes #130