### PR TITLE
[#127] EventTime allday: 종료일 없는 단일 일자 종일 케이스 지원

### DIFF
--- a/src/components/EventTimeDisplay.tsx
+++ b/src/components/EventTimeDisplay.tsx
@@ -39,9 +39,11 @@ export function EventTimeDisplay({ eventTime }: EventTimeDisplayProps) {
 
   // allday: offset을 더해 "원본 타임존의 자정"으로 맞춘 뒤 UTC 메서드로 날짜를 읽음
   // (브라우저 타임존과 무관하게 이벤트 생성 타임존 기준 날짜를 표시)
+  // period_end 없는 단일 일자 종일은 시작일 == 종료일로 처리
   const offset = eventTime.seconds_from_gmt
+  const periodEnd = eventTime.period_end ?? eventTime.period_start
   const start = new Date((eventTime.period_start + offset) * 1000)
-  const end = new Date((eventTime.period_end + offset) * 1000)
+  const end = new Date((periodEnd + offset) * 1000)
 
   if (isSameDayUTC(start, end)) {
     return <span>종일</span>

--- a/src/components/EventTimePicker.tsx
+++ b/src/components/EventTimePicker.tsx
@@ -103,7 +103,12 @@ export function EventTimePicker({ value, onChange, required = false }: EventTime
     let next: EventTime
     if (nextType === 'at') next = { time_type: 'at', timestamp: now }
     else if (nextType === 'period') next = { time_type: 'period', period_start: now, period_end: now + 3600 }
-    else next = { time_type: 'allday', period_start: now, period_end: now, seconds_from_gmt: localSecondsFromGmt() }
+    else {
+      const d = new Date(now * 1000)
+      d.setHours(0, 0, 0, 0)
+      const start = Math.floor(d.getTime() / 1000)
+      next = { time_type: 'allday', period_start: start, seconds_from_gmt: localSecondsFromGmt() }
+    }
     setInternal(next)
     onChange(next)
   }
@@ -243,23 +248,46 @@ export function EventTimePicker({ value, onChange, required = false }: EventTime
             onChange={e => {
               const ts = dateInputToTs(e.target.value)
               if (ts === null) return
-              handleValueChange({ ...internal, period_start: ts - internal.seconds_from_gmt })
+              const newStart = ts - internal.seconds_from_gmt
+              const period_end = internal.period_end !== undefined && internal.period_end < newStart
+                ? newStart + 86400 - 1
+                : internal.period_end
+              handleValueChange({ ...internal, period_start: newStart, period_end })
             }}
           />
-          <span className="px-3 text-sm font-medium text-fg-tertiary">{t('eventTime.to')}</span>
-          <input
-            aria-label={t('eventTime.end_date')}
-            type="date"
-            className={pillInput}
-            value={tsToDateInput(internal.period_end + internal.seconds_from_gmt)}
-            onChange={e => {
-              const ts = dateInputToTs(e.target.value)
-              if (ts === null) return
-              const newEnd = ts - internal.seconds_from_gmt
-              if (newEnd < internal.period_start) return
-              handleValueChange({ ...internal, period_end: newEnd })
-            }}
-          />
+          <label className="flex items-center gap-1 text-sm">
+            <input
+              type="checkbox"
+              checked={internal.period_end !== undefined}
+              onChange={e => {
+                if (e.target.checked) {
+                  handleValueChange({ ...internal, period_end: internal.period_start + 86400 - 1 })
+                } else {
+                  const { period_end: _removed, ...rest } = internal
+                  handleValueChange(rest as typeof internal)
+                }
+              }}
+            />
+            {t('eventTime.end_date_toggle', '종료일 지정')}
+          </label>
+          {internal.period_end !== undefined && (
+            <>
+              <span className="px-3 text-sm font-medium text-fg-tertiary">{t('eventTime.to')}</span>
+              <input
+                aria-label={t('eventTime.end_date')}
+                type="date"
+                className={pillInput}
+                value={tsToDateInput(internal.period_end + internal.seconds_from_gmt)}
+                onChange={e => {
+                  const ts = dateInputToTs(e.target.value)
+                  if (ts === null) return
+                  const newEnd = ts - internal.seconds_from_gmt
+                  if (newEnd < internal.period_start) return
+                  handleValueChange({ ...internal, period_end: newEnd })
+                }}
+              />
+            </>
+          )}
         </div>
       )}
 

--- a/src/components/EventTimePicker.tsx
+++ b/src/components/EventTimePicker.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { EventTime } from '../models'
+import { alldayWithStart, nextEventTimeForType } from './eventForm/EventTimePickerCore'
 
 type TimeType = 'none' | 'at' | 'period' | 'allday'
 
@@ -104,10 +105,7 @@ export function EventTimePicker({ value, onChange, required = false }: EventTime
     if (nextType === 'at') next = { time_type: 'at', timestamp: now }
     else if (nextType === 'period') next = { time_type: 'period', period_start: now, period_end: now + 3600 }
     else {
-      const d = new Date(now * 1000)
-      d.setHours(0, 0, 0, 0)
-      const start = Math.floor(d.getTime() / 1000)
-      next = { time_type: 'allday', period_start: start, seconds_from_gmt: localSecondsFromGmt() }
+      next = nextEventTimeForType(internal, 'allday', now, localSecondsFromGmt())
     }
     setInternal(next)
     onChange(next)
@@ -249,10 +247,7 @@ export function EventTimePicker({ value, onChange, required = false }: EventTime
               const ts = dateInputToTs(e.target.value)
               if (ts === null) return
               const newStart = ts - internal.seconds_from_gmt
-              const period_end = internal.period_end !== undefined && internal.period_end < newStart
-                ? newStart + 86400 - 1
-                : internal.period_end
-              handleValueChange({ ...internal, period_start: newStart, period_end })
+              handleValueChange(alldayWithStart(internal, newStart))
             }}
           />
           <label className="flex items-center gap-1 text-sm">

--- a/src/components/eventForm/EventTimePickerCore.tsx
+++ b/src/components/eventForm/EventTimePickerCore.tsx
@@ -30,8 +30,10 @@ function localSecondsFromGmt(): number {
 
 export function alldayWithStart(prev: EventTime, newStartTs: number): EventTime {
   if (prev.time_type !== 'allday') return prev
-  // 시작이 종료보다 뒤로 가면 종료를 시작 + 86400 - 1 (1일 종일) 로 정정
-  const period_end = prev.period_end < newStartTs ? newStartTs + 86400 - 1 : prev.period_end
+  // period_end 있고 시작보다 앞이면 시작 + 86400 - 1 (1일 종일) 로 정정. 없으면 그대로 유지.
+  const period_end = prev.period_end !== undefined && prev.period_end < newStartTs
+    ? newStartTs + 86400 - 1
+    : prev.period_end
   return { ...prev, period_start: newStartTs, period_end }
 }
 
@@ -71,11 +73,11 @@ export function nextEventTimeForType(
   if (type === 'period') {
     return { time_type: 'period', period_start: baseTs, period_end: baseTs + 3600 }
   }
-  // allday: baseTs 의 일자의 local 자정으로 정규화
+  // allday: baseTs 의 일자의 local 자정으로 정규화. 기본 OFF 정책 — period_end 생략.
   const d = new Date(baseTs * 1000)
   d.setHours(0, 0, 0, 0)
   const start = Math.floor(d.getTime() / 1000)
-  return { time_type: 'allday', period_start: start, period_end: start + 86400 - 1, seconds_from_gmt: secondsFromGMT }
+  return { time_type: 'allday', period_start: start, seconds_from_gmt: secondsFromGMT }
 }
 
 // --- Component ---
@@ -233,23 +235,43 @@ export function EventTimePickerCore({ value, onChange, allowNone }: EventTimePic
               }}
             />
           </div>
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-muted-foreground w-8 shrink-0">{t('eventTime.end')}</span>
-            <input
-              id="allday-end"
-              aria-label={t('eventTime.end_date')}
-              type="date"
-              className={inputClass}
-              value={alldayDateInputValue(value.period_end, value.seconds_from_gmt)}
-              onChange={e => {
-                const ts = dateInputToTs(e.target.value)
-                if (ts === null || value.time_type !== 'allday') return
-                const next = alldayWithEnd(value, ts)
-                if (next === null) return
-                onChange(next)
+          <div className="flex items-center gap-1.5">
+            <Checkbox
+              id="allday-end-toggle"
+              checked={value.period_end !== undefined}
+              onCheckedChange={(checked) => {
+                if (value.time_type !== 'allday') return
+                if (checked) {
+                  onChange({ ...value, period_end: value.period_start + 86400 - 1 })
+                } else {
+                  const { period_end: _removed, ...rest } = value
+                  onChange(rest)
+                }
               }}
             />
+            <Label htmlFor="allday-end-toggle" className="text-sm font-normal cursor-pointer">
+              {t('eventTime.end_date_toggle', '종료일 지정')}
+            </Label>
           </div>
+          {value.period_end !== undefined && (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted-foreground w-8 shrink-0">{t('eventTime.end')}</span>
+              <input
+                id="allday-end"
+                aria-label={t('eventTime.end_date')}
+                type="date"
+                className={inputClass}
+                value={alldayDateInputValue(value.period_end, value.seconds_from_gmt)}
+                onChange={e => {
+                  const ts = dateInputToTs(e.target.value)
+                  if (ts === null || value.time_type !== 'allday') return
+                  const next = alldayWithEnd(value, ts)
+                  if (next === null) return
+                  onChange(next)
+                }}
+              />
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/domain/functions/eventTime.ts
+++ b/src/domain/functions/eventTime.ts
@@ -19,7 +19,7 @@ export function eventTimeToEndDate(eventTime: EventTime): Date {
     case 'period':
       return new Date(eventTime.period_end * 1000)
     case 'allday':
-      return alldayLocalDate(eventTime.period_end, eventTime.seconds_from_gmt)
+      return alldayLocalDate(eventTime.period_end ?? eventTime.period_start, eventTime.seconds_from_gmt)
   }
 }
 
@@ -90,7 +90,10 @@ export function eventTimeOverlapsRange(eventTime: EventTime, lower: number, uppe
       return eventTime.period_start <= upper && eventTime.period_end >= lower
     case 'allday': {
       const adjStart = eventTime.period_start + eventTime.seconds_from_gmt
-      const adjEnd = eventTime.period_end + eventTime.seconds_from_gmt
+      // period_end가 없으면 시작일 자정 + 하루치 (86400-1) 를 종료로 간주
+      const adjEnd = eventTime.period_end !== undefined
+        ? eventTime.period_end + eventTime.seconds_from_gmt
+        : eventTime.period_start + eventTime.seconds_from_gmt + 86400 - 1
       return adjStart <= upper && adjEnd >= lower
     }
   }

--- a/src/domain/functions/repeating.ts
+++ b/src/domain/functions/repeating.ts
@@ -78,7 +78,12 @@ export function shiftEventTime(time: EventTime, intervalSeconds: number): EventT
     case 'period':
       return { time_type: 'period', period_start: time.period_start + intervalSeconds, period_end: time.period_end + intervalSeconds }
     case 'allday':
-      return { time_type: 'allday', period_start: time.period_start + intervalSeconds, period_end: time.period_end + intervalSeconds, seconds_from_gmt: time.seconds_from_gmt }
+      return {
+        time_type: 'allday',
+        period_start: time.period_start + intervalSeconds,
+        period_end: time.period_end != null ? time.period_end + intervalSeconds : undefined,
+        seconds_from_gmt: time.seconds_from_gmt,
+      }
   }
 }
 

--- a/src/domain/functions/validateScheduleForm.ts
+++ b/src/domain/functions/validateScheduleForm.ts
@@ -57,9 +57,8 @@ function isValidEventTime(t: EventTime): boolean {
     case 'allday':
       return (
         Number.isFinite(t.period_start) &&
-        Number.isFinite(t.period_end) &&
         t.period_start > 0 &&
-        t.period_end >= t.period_start
+        (t.period_end === undefined || t.period_end >= t.period_start)
       )
   }
 }

--- a/src/domain/functions/validateTodoForm.ts
+++ b/src/domain/functions/validateTodoForm.ts
@@ -56,9 +56,8 @@ function isValidEventTime(t: EventTime): boolean {
     case 'allday':
       return (
         Number.isFinite(t.period_start) &&
-        Number.isFinite(t.period_end) &&
         t.period_start > 0 &&
-        t.period_end >= t.period_start
+        (t.period_end === undefined || t.period_end >= t.period_start)
       )
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -212,6 +212,7 @@
   "eventTime.start_time": "Start time",
   "eventTime.end_time": "End time",
   "eventTime.to": "to",
+  "eventTime.end_date_toggle": "Set end date",
   "repeating.enabled": "Repeat",
   "repeating.not_repeat": "Does not repeat",
   "repeating.custom": "Custom",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -212,6 +212,7 @@
   "eventTime.start_time": "시작 시간",
   "eventTime.end_time": "종료 시간",
   "eventTime.to": "부터",
+  "eventTime.end_date_toggle": "종료일 지정",
   "repeating.enabled": "반복",
   "repeating.not_repeat": "반복 안 함",
   "repeating.custom": "사용자 정의",

--- a/src/models/EventTime.ts
+++ b/src/models/EventTime.ts
@@ -12,7 +12,7 @@ export interface EventTimePeriod {
 export interface EventTimeAllDay {
   time_type: 'allday'
   period_start: number
-  period_end: number
+  period_end?: number
   seconds_from_gmt: number
 }
 

--- a/tests/components/EventTimeDisplay.test.tsx
+++ b/tests/components/EventTimeDisplay.test.tsx
@@ -106,4 +106,19 @@ describe('EventTimeDisplay', () => {
     // then: KST 기준 날짜 범위가 표시된다
     expect(screen.getByText(/3월 15일.*–.*3월 17일/)).toBeInTheDocument()
   })
+
+  it('period_end 없는 allday(단일 일자 종일)는 "종일"을 표시한다 (#127)', () => {
+    // given: 2024-03-15 KST 종일, period_end 없음
+    const eventTime = {
+      time_type: 'allday' as const,
+      period_start: 1710428400,
+      seconds_from_gmt: 32400,
+    } as EventTime
+
+    // when: 렌더링
+    render(<EventTimeDisplay eventTime={eventTime} />)
+
+    // then: "종일" 텍스트가 표시된다
+    expect(screen.getByText('종일')).toBeInTheDocument()
+  })
 })

--- a/tests/components/EventTimePicker.test.tsx
+++ b/tests/components/EventTimePicker.test.tsx
@@ -136,3 +136,50 @@ describe('EventTimePicker — period 입력 상호작용', () => {
     expect(last.period_end - last.period_start).toBe(3 * 3600)
   })
 })
+
+describe('EventTimePicker — allday 종료일 지정 토글 (#127)', () => {
+  it('period_end 없는 allday 는 종료일 토글 OFF, 종료일 입력 미노출', () => {
+    // given
+    const value = { time_type: 'allday' as const, period_start: 1700000000, seconds_from_gmt: 32400 }
+    // when
+    render(<EventTimePicker value={value as any} onChange={vi.fn()} />)
+    // then: 종료일 지정 체크박스 unchecked, 종료일 input 없음
+    const toggle = screen.getByRole('checkbox', { name: '종료일 지정' })
+    expect(toggle).not.toBeChecked()
+    expect(screen.queryByLabelText('종료 날짜')).not.toBeInTheDocument()
+  })
+
+  it('period_end 있는 allday 는 종료일 토글 ON, 종료일 input 노출', () => {
+    // given
+    const value = {
+      time_type: 'allday' as const,
+      period_start: 1700000000,
+      period_end: 1700000000 + 86400 - 1,
+      seconds_from_gmt: 32400,
+    }
+    // when
+    render(<EventTimePicker value={value} onChange={vi.fn()} />)
+    // then
+    const toggle = screen.getByRole('checkbox', { name: '종료일 지정' })
+    expect(toggle).toBeChecked()
+    expect(screen.getByLabelText('종료 날짜')).toBeInTheDocument()
+  })
+
+  it('종료일 토글 ON 하면 onChange 에 period_end 가 초기화된 allday 가 전달된다', async () => {
+    // given
+    const value = { time_type: 'allday' as const, period_start: 1700000000, seconds_from_gmt: 32400 }
+    const onChange = vi.fn()
+    render(<EventTimePicker value={value as any} onChange={onChange} />)
+
+    // when
+    const toggle = screen.getByRole('checkbox', { name: '종료일 지정' })
+    await userEvent.click(toggle)
+
+    // then: period_end 가 있는 allday 로 emit
+    const last = onChange.mock.calls.at(-1)?.[0]
+    expect(last).toBeTruthy()
+    expect(last.time_type).toBe('allday')
+    expect(last.period_end).toBeDefined()
+    expect(last.period_end).toBeGreaterThanOrEqual(last.period_start)
+  })
+})

--- a/tests/components/eventForm/EventTimePickerCore.test.ts
+++ b/tests/components/eventForm/EventTimePickerCore.test.ts
@@ -47,6 +47,20 @@ describe('EventTimePickerCore — allday 데이터 생성 헬퍼 (#106)', () => 
       expect(v.period_start).toBe(newStart)
       expect(v.period_end).toBe(newStart + 86400 - 1)
     })
+
+    it('period_end 없는 allday(단일 일자 종일)는 시작 변경 후에도 period_end 가 undefined 를 유지한다 (#127)', () => {
+      // given: period_end 없는 단일 일자 종일
+      const prev = { time_type: 'allday' as const, period_start: 1000000, seconds_from_gmt: 9 * 3600 }
+
+      // when: 시작을 임의 일자로 변경
+      const newStart = prev.period_start + 5 * 86400
+      const v = alldayWithStart(prev as EventTime, newStart)
+
+      // then: period_end 는 여전히 undefined
+      if (v.time_type !== 'allday') throw new Error('expected allday')
+      expect(v.period_start).toBe(newStart)
+      expect(v.period_end).toBeUndefined()
+    })
   })
 
   describe('alldayWithEnd', () => {
@@ -110,15 +124,15 @@ describe('nextEventTimeForType (#108) — 타입 변경 시 기존 날짜 보존
       expect(v.period_end).toBe(NOW + 3600)
     })
 
-    it('null → allday 이면 오늘(now 의 일자) 자정 ~ 23:59:59 종일 이벤트로 시작한다', () => {
+    it('null → allday 이면 오늘(now 의 일자) 자정을 period_start 로, period_end 는 undefined(기본 OFF)로 시작한다 (#127)', () => {
       const v = nextEventTimeForType(null, 'allday', NOW, GMT)
       expect(v.time_type).toBe('allday')
       if (v.time_type !== 'allday') return
-      expect(v.period_end - v.period_start).toBe(86400 - 1)
       const d = new Date(v.period_start * 1000)
       expect(d.getHours()).toBe(0)
       expect(d.getMinutes()).toBe(0)
       expect(d.getSeconds()).toBe(0)
+      expect(v.period_end).toBeUndefined()
       expect(v.seconds_from_gmt).toBe(GMT)
     })
   })
@@ -142,7 +156,7 @@ describe('nextEventTimeForType (#108) — 타입 변경 시 기존 날짜 보존
       expect(v.period_end).toBe(selectedTs + 3600)
     })
 
-    it('at → allday 시 기존 timestamp 의 local 일자(자정) 이 period_start 가 된다', () => {
+    it('at → allday 시 기존 timestamp 의 local 일자(자정) 이 period_start 가 되고 period_end 는 undefined(기본 OFF) (#127)', () => {
       const v = nextEventTimeForType(prevAt, 'allday', NOW, GMT)
       expect(v.time_type).toBe('allday')
       if (v.time_type !== 'allday') return
@@ -152,7 +166,7 @@ describe('nextEventTimeForType (#108) — 타입 변경 시 기존 날짜 보존
         return Math.floor(d.getTime() / 1000)
       })()
       expect(v.period_start).toBe(expectedStart)
-      expect(v.period_end).toBe(expectedStart + 86400 - 1)
+      expect(v.period_end).toBeUndefined()
       expect(v.seconds_from_gmt).toBe(GMT)
     })
 
@@ -175,7 +189,7 @@ describe('nextEventTimeForType (#108) — 타입 변경 시 기존 날짜 보존
       expect(v.timestamp).toBe(periodStart)
     })
 
-    it('period → allday 시 period_start 의 일자 자정이 새 period_start', () => {
+    it('period → allday 시 period_start 의 일자 자정이 새 period_start, period_end 는 undefined(기본 OFF) (#127)', () => {
       const v = nextEventTimeForType(prevPeriod, 'allday', NOW, GMT)
       expect(v.time_type).toBe('allday')
       if (v.time_type !== 'allday') return
@@ -185,7 +199,7 @@ describe('nextEventTimeForType (#108) — 타입 변경 시 기존 날짜 보존
         return Math.floor(d.getTime() / 1000)
       })()
       expect(v.period_start).toBe(expectedStart)
-      expect(v.period_end).toBe(expectedStart + 86400 - 1)
+      expect(v.period_end).toBeUndefined()
     })
   })
 

--- a/tests/components/eventForm/EventTimePickerCoreUI.test.tsx
+++ b/tests/components/eventForm/EventTimePickerCoreUI.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { EventTimePickerCore } from '../../../src/components/eventForm/EventTimePickerCore'
+import type { EventTime } from '../../../src/models'
+
+// 종일(allday) 모드에서 "종료일 지정" 토글 동작 검증 (#127)
+
+describe('EventTimePickerCore — allday 종료일 지정 토글 (#127)', () => {
+  it('기본 allday 모드(period_end undefined)는 종료일 토글 OFF, 종료일 입력 미노출', () => {
+    // given: period_end 없는 allday
+    const value: EventTime = { time_type: 'allday', period_start: 1700000000, seconds_from_gmt: 32400 } as EventTime
+    const onChange = vi.fn()
+
+    // when
+    render(<EventTimePickerCore value={value} onChange={onChange} allowNone={false} />)
+
+    // then: 토글 체크박스가 unchecked, 종료일 input 없음
+    const toggle = screen.getByRole('checkbox', { name: '종료일 지정' })
+    expect(toggle).not.toBeChecked()
+    expect(screen.queryByLabelText('종료 날짜')).not.toBeInTheDocument()
+  })
+
+  it('종료일 토글 ON 하면 종료일 input 이 노출되고 onChange 에 period_end 가 초기화된다', async () => {
+    // given: period_end 없는 allday
+    const value: EventTime = { time_type: 'allday', period_start: 1700000000, seconds_from_gmt: 32400 } as EventTime
+    const onChange = vi.fn()
+
+    render(<EventTimePickerCore value={value} onChange={onChange} allowNone={false} />)
+
+    // when: 종료일 토글 클릭
+    const toggle = screen.getByRole('checkbox', { name: '종료일 지정' })
+    await userEvent.click(toggle)
+
+    // then: onChange 가 period_end 있는 allday 로 호출됨
+    const lastCall = onChange.mock.calls.at(-1)?.[0] as EventTime
+    expect(lastCall).toBeTruthy()
+    expect(lastCall.time_type).toBe('allday')
+    if (lastCall.time_type === 'allday') {
+      expect(lastCall.period_end).toBeDefined()
+      expect(lastCall.period_end).toBeGreaterThanOrEqual(lastCall.period_start)
+    }
+  })
+
+  it('기존 period_end 있는 allday 는 종료일 토글이 ON 상태로 시작, 종료일 input 노출', () => {
+    // given: period_end 있는 allday
+    const value: EventTime = {
+      time_type: 'allday',
+      period_start: 1700000000,
+      period_end: 1700000000 + 86400 - 1,
+      seconds_from_gmt: 32400,
+    }
+    const onChange = vi.fn()
+
+    // when
+    render(<EventTimePickerCore value={value} onChange={onChange} allowNone={false} />)
+
+    // then: 토글이 checked, 종료일 input 존재
+    const toggle = screen.getByRole('checkbox', { name: '종료일 지정' })
+    expect(toggle).toBeChecked()
+    expect(screen.getByLabelText('종료 날짜')).toBeInTheDocument()
+  })
+
+  it('종료일 토글 OFF 하면 종료일 input 이 사라지고 onChange 에 period_end 가 undefined', async () => {
+    // given: period_end 있는 allday
+    const value: EventTime = {
+      time_type: 'allday',
+      period_start: 1700000000,
+      period_end: 1700000000 + 86400 - 1,
+      seconds_from_gmt: 32400,
+    }
+    const onChange = vi.fn()
+
+    render(<EventTimePickerCore value={value} onChange={onChange} allowNone={false} />)
+
+    // when: 토글 OFF 클릭
+    const toggle = screen.getByRole('checkbox', { name: '종료일 지정' })
+    await userEvent.click(toggle)
+
+    // then: onChange 에서 period_end 가 사라진 allday 로 호출
+    const lastCall = onChange.mock.calls.at(-1)?.[0] as EventTime
+    expect(lastCall).toBeTruthy()
+    expect(lastCall.time_type).toBe('allday')
+    if (lastCall.time_type === 'allday') {
+      expect(lastCall.period_end).toBeUndefined()
+    }
+  })
+})

--- a/tests/domain/functions/eventTime.test.ts
+++ b/tests/domain/functions/eventTime.test.ts
@@ -397,4 +397,48 @@ describe('eventTimeOverlapsRange', () => {
     const et: EventTime = { time_type: 'at', timestamp: 500 }
     expect(eventTimeOverlapsRange(et, 900, 1100)).toBe(false)
   })
+
+  it('period_end 없는 allday(단일 일자 종일)는 시작 월 범위와 겹치면 true를 반환한다 (#127)', () => {
+    // given: 2026-05-15 KST 종일, period_end 없음
+    const offset = 9 * 3600
+    const periodStart = Math.floor(Date.UTC(2026, 4, 14, 15, 0, 0) / 1000) // KST 5/15 00:00
+    const et: EventTime = { time_type: 'allday', period_start: periodStart, seconds_from_gmt: offset } as any
+
+    // when: 2026-05 월 범위 안에서 조회
+    const lower = Math.floor(Date.UTC(2026, 4, 0, 15, 0, 0) / 1000)   // KST 5/1 00:00
+    const upper = Math.floor(Date.UTC(2026, 4, 30, 14, 59, 59) / 1000) // KST 5/31 23:59:59
+
+    // then: 겹쳐야 한다
+    expect(eventTimeOverlapsRange(et, lower, upper)).toBe(true)
+  })
+
+  it('period_end 없는 allday는 전혀 다른 월 범위에서는 false를 반환한다 (#127)', () => {
+    // given: 2026-05-15 KST 종일, period_end 없음
+    const offset = 9 * 3600
+    const periodStart = Math.floor(Date.UTC(2026, 4, 14, 15, 0, 0) / 1000) // KST 5/15 00:00
+    const et: EventTime = { time_type: 'allday', period_start: periodStart, seconds_from_gmt: offset } as any
+
+    // when: 2026-06 월 범위 조회
+    const lower = Math.floor(Date.UTC(2026, 4, 31, 15, 0, 0) / 1000)  // KST 6/1 00:00
+    const upper = Math.floor(Date.UTC(2026, 5, 29, 14, 59, 59) / 1000) // KST 6/30 23:59:59
+
+    // then: 겹치지 않아야 한다
+    expect(eventTimeOverlapsRange(et, lower, upper)).toBe(false)
+  })
+})
+
+describe('eventTimeToEndDate — allday no period_end (#127)', () => {
+  it('period_end 없는 allday는 period_start 기준 종료일을 반환한다', () => {
+    // given: KST 2026-05-15 단일 종일, period_end 없음
+    const offset = 9 * 3600
+    const periodStart = Math.floor(Date.UTC(2026, 4, 14, 15, 0, 0) / 1000) // KST 5/15 00:00
+    const et: EventTime = { time_type: 'allday', period_start: periodStart, seconds_from_gmt: offset } as any
+
+    // when
+    const date = eventTimeToEndDate(et)
+
+    // then: 종료일 == 시작일 (5/15)
+    expect([date.getFullYear(), date.getMonth(), date.getDate()]).toEqual([2026, 4, 15])
+    expect([date.getHours(), date.getMinutes(), date.getSeconds()]).toEqual([0, 0, 0])
+  })
 })

--- a/tests/domain/functions/repeating.test.ts
+++ b/tests/domain/functions/repeating.test.ts
@@ -38,6 +38,19 @@ describe('shiftEventTime', () => {
     // then
     expect(result).toEqual({ time_type: 'allday', period_start: 87400, period_end: 88400, seconds_from_gmt: 32400 })
   })
+
+  it('period_end 없는 allday를 시프트하면 결과의 period_end도 undefined다 (#127)', () => {
+    // given: 단일 일자 종일 (period_end 없음)
+    const time: EventTime = { time_type: 'allday', period_start: 1000, seconds_from_gmt: 32400 } as any
+    // when
+    const result = shiftEventTime(time, 86400)
+    // then
+    expect(result.time_type).toBe('allday')
+    if (result.time_type === 'allday') {
+      expect(result.period_start).toBe(87400)
+      expect(result.period_end).toBeUndefined()
+    }
+  })
 })
 
 describe('nextRepeatingTime - every_day', () => {

--- a/tests/domain/functions/validateScheduleForm.test.ts
+++ b/tests/domain/functions/validateScheduleForm.test.ts
@@ -83,6 +83,15 @@ describe('validateScheduleForm', () => {
       expect(result.ok).toBe(true)
       if (result.ok) expect(result.input.event_time).toEqual(eventTime)
     })
+
+    it('period_end 없는 allday(단일 일자 종일)도 valid로 판정한다 (#127)', () => {
+      // given
+      const eventTime: EventTime = { time_type: 'allday', period_start: 1700000000, seconds_from_gmt: 32400 } as any
+      // when
+      const result = validateScheduleForm({ name: '종일 일정', eventTime })
+      // then
+      expect(result.ok).toBe(true)
+    })
   })
 
   describe('선택 필드 매핑', () => {

--- a/tests/domain/functions/validateTodoForm.test.ts
+++ b/tests/domain/functions/validateTodoForm.test.ts
@@ -75,6 +75,16 @@ describe('validateTodoForm', () => {
       expect(result.ok).toBe(true)
       if (result.ok) expect(result.input.event_time).toBeUndefined()
     })
+
+    it('period_end 없는 allday(단일 일자 종일)도 valid로 판정한다 (#127)', () => {
+      // given
+      const eventTime: EventTime = { time_type: 'allday', period_start: 1700000000, seconds_from_gmt: 32400 } as any
+      // when
+      const result = validateTodoForm({ name: '할일', eventTime })
+      // then
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.input.event_time).toEqual(eventTime)
+    })
   })
 
   describe('선택 필드 매핑', () => {


### PR DESCRIPTION
## 문제
앱은 종일(allday) 이벤트 중 시작일만 있는(= 단일 일자 종일) 케이스를 지원하는데 웹은 항상 종료일을 강제. 폼에서도 종료일 입력 필수, 도메인 함수도 `period_end` 가 number 라고 가정.

## 접근
`EventTimeAllDay.period_end` 를 `optional` 로 변경하고 도메인/검증/표시 함수에 `period_end ?? period_start` fallback. 폼에는 "종료일 지정" 토글 체크박스를 추가해 OFF 일 때는 단일 일자 종일, ON 일 때는 기존처럼 기간 종일을 입력.

## 변경
- 모델 — `EventTimeAllDay.period_end?: number` 로 union 변경
- 도메인:
  - `eventTimeToEndDate` — `period_end ?? period_start` fallback
  - `eventTimeOverlapsRange` allday 분기 — undefined 시 시작일과 같은 날 범위로 처리 (단일 일자 이벤트가 누락되지 않도록)
  - `shiftEventTime` — `period_end` undefined 보존
- 검증 — `validateScheduleForm`/`validateTodoForm` allday 분기에서 `period_end === undefined` 또는 `period_end >= period_start` 이면 valid
- 표시 — `EventTimeDisplay` allday 분기에 fallback 추가
- 입력 UI — `EventTimePickerCore`(신) / `EventTimePicker`(레거시) 에 "종료일 지정" 체크박스 추가. OFF: 종료일 input 미노출 + `period_end` undefined. ON: 종료일 input + `period_start + 86400 - 1` 로 초기화. 기존 이벤트가 `period_end` 가지면 ON 으로 시작.
- i18n — `eventTime.end_date_toggle` 키 추가 (ko/en)

## Test plan
- [ ] 새 일정/할일 종일 모드에서 종료일 토글 OFF → 시작일 1일짜리로 저장
- [ ] 토글 ON → 종료일 입력 노출, 저장 시 기간 종일로 저장
- [ ] 기존 종료일 있는 종일 일정 편집 → 토글 ON 으로 hydrate
- [ ] 단일 일자 종일 일정이 캘린더 그리드/우측 패널에 정상 표시
- [ ] 반복 종일 이벤트 시프트 시 다음 차수도 단일 일자 유지

Closes #127