### PR TITLE
[#128] RepeatingSection 선택된 반복 옵션을 보조 라인으로 노출

### DIFF
--- a/src/components/eventForm/RepeatingSection.tsx
+++ b/src/components/eventForm/RepeatingSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Repeat } from 'lucide-react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { RepeatingPickerShadcn } from './RepeatingPickerShadcn'
+import { describeRepeating } from '../../domain/functions/repeatingDescription'
 import type { EventTime, Repeating } from '../../models'
 
 interface RepeatingSectionProps {
@@ -21,8 +22,10 @@ export function RepeatingSection({ eventTime, repeating, onRepeatingChange }: Re
   const summary = isOn
     ? t('repeating.summary_on', '반복 설정됨')
     : t('repeating.summary_off', '반복 안 함')
+  const description = repeating ? describeRepeating(repeating) : ''
 
   return (
+    <div className="flex flex-col">
     <div className="flex items-center gap-3">
       <Repeat className="w-4 h-4 text-muted-foreground shrink-0" />
       <Popover open={open} onOpenChange={setOpen}>
@@ -44,6 +47,14 @@ export function RepeatingSection({ eventTime, repeating, onRepeatingChange }: Re
           />
         </PopoverContent>
       </Popover>
+    </div>
+    {repeating && description && (
+      <div className="pl-7 mt-1">
+        <p className="text-xs text-muted-foreground leading-snug animate-in fade-in slide-in-from-top-1 duration-200">
+          {description}
+        </p>
+      </div>
+    )}
     </div>
   )
 }

--- a/src/domain/functions/repeatingDescription.ts
+++ b/src/domain/functions/repeatingDescription.ts
@@ -1,0 +1,87 @@
+import type { TFunction } from 'i18next'
+import type { Repeating } from '../../models'
+
+const KO_DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토']
+const KO_MONTH_LABELS = ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월']
+const KO_ORD_LABELS = ['첫째', '둘째', '셋째', '넷째', '다섯째']
+
+function formatEndSuffix(repeating: Repeating): string {
+  if (repeating.end != null) {
+    const d = new Date(repeating.end * 1000)
+    const y = d.getFullYear()
+    const m = d.getMonth() + 1
+    const day = d.getDate()
+    return `, ${y}년 ${m}월 ${day}일까지`
+  }
+  if (repeating.end_count != null) {
+    return `, ${repeating.end_count}회`
+  }
+  return ''
+}
+
+export function describeRepeating(repeating: Repeating, _t?: TFunction): string {
+  const { option } = repeating
+  const suffix = formatEndSuffix(repeating)
+
+  switch (option.optionType) {
+    case 'every_day': {
+      const base = option.interval === 1 ? '매일 반복' : `${option.interval}일마다 반복`
+      return base + suffix
+    }
+
+    case 'every_week': {
+      const sorted = [...option.dayOfWeek].sort((a, b) => a - b)
+      const daysLabel = sorted.map(d => KO_DAY_LABELS[d]).join('·')
+      const base =
+        option.interval === 1
+          ? `매주 ${daysLabel} 반복`
+          : `${option.interval}주마다 ${daysLabel} 반복`
+      return base + suffix
+    }
+
+    case 'every_month': {
+      const sel = option.monthDaySelection
+      let baseDesc: string
+      if ('days' in sel) {
+        const day = sel.days[0]
+        const base = option.interval === 1 ? `매월 ${day}일 반복` : `${option.interval}개월마다 ${day}일 반복`
+        baseDesc = base
+      } else {
+        // week ordinal mode
+        const ordinal = sel.weekOrdinals[0]
+        const ordLabel = ordinal.isLast ? '마지막' : (ordinal.seq != null ? KO_ORD_LABELS[ordinal.seq - 1] ?? `${ordinal.seq}번째` : '첫째')
+        const weekDaysLabel = sel.weekDays.map(d => KO_DAY_LABELS[d]).join('·')
+        const base = option.interval === 1
+          ? `매월 ${ordLabel} ${weekDaysLabel} 반복`
+          : `${option.interval}개월마다 ${ordLabel} ${weekDaysLabel} 반복`
+        baseDesc = base
+      }
+      return baseDesc + suffix
+    }
+
+    case 'every_year': {
+      const month = option.months[0]
+      const ordinal = option.weekOrdinals[0]
+      const ordLabel = ordinal.isLast ? '마지막' : (ordinal.seq != null ? KO_ORD_LABELS[ordinal.seq - 1] ?? `${ordinal.seq}번째` : '첫째')
+      const weekDaysLabel = option.dayOfWeek.map(d => KO_DAY_LABELS[d]).join('·')
+      const monthName = KO_MONTH_LABELS[(month ?? 1) - 1] ?? `${month}월`
+      const base = option.interval === 1
+        ? `매년 ${monthName} ${ordLabel} ${weekDaysLabel} 반복`
+        : `${option.interval}년마다 ${monthName} ${ordLabel} ${weekDaysLabel} 반복`
+      return base + suffix
+    }
+
+    case 'every_year_some_day': {
+      const monthName = KO_MONTH_LABELS[(option.month ?? 1) - 1] ?? `${option.month}월`
+      const base = option.interval === 1
+        ? `매년 ${monthName} ${option.day}일 반복`
+        : `${option.interval}년마다 ${monthName} ${option.day}일 반복`
+      return base + suffix
+    }
+
+    case 'lunar_calendar_every_year': {
+      const monthName = KO_MONTH_LABELS[(option.month ?? 1) - 1] ?? `${option.month}월`
+      return `음력 매년 ${monthName} ${option.day}일 반복` + suffix
+    }
+  }
+}

--- a/src/domain/functions/repeatingDescription.ts
+++ b/src/domain/functions/repeatingDescription.ts
@@ -1,4 +1,3 @@
-import type { TFunction } from 'i18next'
 import type { Repeating } from '../../models'
 
 const KO_DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토']
@@ -19,7 +18,7 @@ function formatEndSuffix(repeating: Repeating): string {
   return ''
 }
 
-export function describeRepeating(repeating: Repeating, _t?: TFunction): string {
+export function describeRepeating(repeating: Repeating): string {
   const { option } = repeating
   const suffix = formatEndSuffix(repeating)
 
@@ -48,6 +47,7 @@ export function describeRepeating(repeating: Repeating, _t?: TFunction): string 
         baseDesc = base
       } else {
         // week ordinal mode
+        // 앱 UX 상 ordinal/요일은 단일 선택만 지원하므로 첫 번째 요소만 사용
         const ordinal = sel.weekOrdinals[0]
         const ordLabel = ordinal.isLast ? '마지막' : (ordinal.seq != null ? KO_ORD_LABELS[ordinal.seq - 1] ?? `${ordinal.seq}번째` : '첫째')
         const weekDaysLabel = sel.weekDays.map(d => KO_DAY_LABELS[d]).join('·')
@@ -60,6 +60,7 @@ export function describeRepeating(repeating: Repeating, _t?: TFunction): string 
     }
 
     case 'every_year': {
+      // 앱 UX 상 ordinal/요일은 단일 선택만 지원하므로 첫 번째 요소만 사용
       const month = option.months[0]
       const ordinal = option.weekOrdinals[0]
       const ordLabel = ordinal.isLast ? '마지막' : (ordinal.seq != null ? KO_ORD_LABELS[ordinal.seq - 1] ?? `${ordinal.seq}번째` : '첫째')

--- a/tests/components/eventForm/RepeatingSection.test.tsx
+++ b/tests/components/eventForm/RepeatingSection.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RepeatingSection } from '../../../src/components/eventForm/RepeatingSection'
+import type { EventTime, Repeating } from '../../../src/models'
+
+const eventTime: EventTime = { time_type: 'at', timestamp: 1743375600 }
+
+describe('RepeatingSection', () => {
+  it('repeating이 null이면 description 라인이 표시되지 않는다', () => {
+    // given
+    render(
+      <RepeatingSection
+        eventTime={eventTime}
+        repeating={null}
+        onRepeatingChange={vi.fn()}
+      />
+    )
+
+    // then
+    expect(screen.queryByText(/반복$/)).not.toBeInTheDocument()
+    // "반복 안 함" 트리거는 있지만 보조 description 텍스트는 없음
+    expect(screen.queryByText(/매일 반복|마다 반복|음력/)).not.toBeInTheDocument()
+  })
+
+  it('every_day interval 1 반복 옵션이 설정되면 "매일 반복" 텍스트가 표시된다', () => {
+    // given
+    const repeating: Repeating = {
+      start: 1743375600,
+      option: { optionType: 'every_day', interval: 1 },
+    }
+
+    // when
+    render(
+      <RepeatingSection
+        eventTime={eventTime}
+        repeating={repeating}
+        onRepeatingChange={vi.fn()}
+      />
+    )
+
+    // then
+    expect(screen.getByText('매일 반복')).toBeInTheDocument()
+  })
+
+  it('every_day interval 3 반복 옵션이면 "3일마다 반복" 텍스트가 표시된다', () => {
+    // given
+    const repeating: Repeating = {
+      start: 1743375600,
+      option: { optionType: 'every_day', interval: 3 },
+    }
+
+    // when
+    render(
+      <RepeatingSection
+        eventTime={eventTime}
+        repeating={repeating}
+        onRepeatingChange={vi.fn()}
+      />
+    )
+
+    // then
+    expect(screen.getByText('3일마다 반복')).toBeInTheDocument()
+  })
+
+  it('every_week 옵션이면 요일 목록이 포함된 설명이 표시된다', () => {
+    // given
+    const repeating: Repeating = {
+      start: 1743375600,
+      option: { optionType: 'every_week', interval: 1, dayOfWeek: [1, 3, 5], timeZone: 'UTC' },
+    }
+
+    // when
+    render(
+      <RepeatingSection
+        eventTime={eventTime}
+        repeating={repeating}
+        onRepeatingChange={vi.fn()}
+      />
+    )
+
+    // then
+    expect(screen.getByText('매주 월·수·금 반복')).toBeInTheDocument()
+  })
+
+  it('end_count 종료 조건이 있으면 description에 횟수 정보가 포함된다', () => {
+    // given
+    const repeating: Repeating = {
+      start: 1743375600,
+      option: { optionType: 'every_day', interval: 1 },
+      end_count: 10,
+    }
+
+    // when
+    render(
+      <RepeatingSection
+        eventTime={eventTime}
+        repeating={repeating}
+        onRepeatingChange={vi.fn()}
+      />
+    )
+
+    // then
+    expect(screen.getByText('매일 반복, 10회')).toBeInTheDocument()
+  })
+
+  it('lunar_calendar_every_year 옵션이면 "음력 매년..." 텍스트가 표시된다', () => {
+    // given
+    const repeating: Repeating = {
+      start: 1743375600,
+      option: { optionType: 'lunar_calendar_every_year', month: 1, day: 1, timeZone: 'UTC' },
+    }
+
+    // when
+    render(
+      <RepeatingSection
+        eventTime={eventTime}
+        repeating={repeating}
+        onRepeatingChange={vi.fn()}
+      />
+    )
+
+    // then
+    expect(screen.getByText('음력 매년 1월 1일 반복')).toBeInTheDocument()
+  })
+
+  it('eventTime이 null이면 아무것도 렌더링하지 않는다', () => {
+    // given / when
+    const { container } = render(
+      <RepeatingSection
+        eventTime={null}
+        repeating={null}
+        onRepeatingChange={vi.fn()}
+      />
+    )
+
+    // then
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/tests/domain/functions/repeatingDescription.test.ts
+++ b/tests/domain/functions/repeatingDescription.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from 'vitest'
+import { describeRepeating } from '../../../src/domain/functions/repeatingDescription'
+import type { Repeating } from '../../../src/models'
+
+describe('describeRepeating', () => {
+  // --- every_day ---
+
+  it('interval 1인 every_day이면 "매일 반복"을 반환한다', () => {
+    // given
+    const repeating: Repeating = { start: 0, option: { optionType: 'every_day', interval: 1 } }
+    // when
+    const result = describeRepeating(repeating)
+    // then
+    expect(result).toBe('매일 반복')
+  })
+
+  it('interval 3인 every_day이면 "3일마다 반복"을 반환한다', () => {
+    // given
+    const repeating: Repeating = { start: 0, option: { optionType: 'every_day', interval: 3 } }
+    // when / then
+    expect(describeRepeating(repeating)).toBe('3일마다 반복')
+  })
+
+  // --- every_day + end conditions ---
+
+  it('every_day에 종료 날짜가 있으면 "매일 반복, yyyy년 M월 D일까지"를 반환한다', () => {
+    // given — 2026-12-31 00:00:00 local을 KST(UTC+9)라고 가정하면 실제 ts는 런타임 의존이므로
+    // UTC 기준으로 2026-12-31T00:00:00Z 타임스탬프를 직접 계산
+    const endTs = Math.floor(new Date('2026-12-31T00:00:00').getTime() / 1000)
+    const repeating: Repeating = {
+      start: 0,
+      option: { optionType: 'every_day', interval: 1 },
+      end: endTs,
+    }
+    // when
+    const result = describeRepeating(repeating)
+    // then — 날짜 부분은 환경에 따라 달라질 수 있으므로 시작 부분만 검증
+    expect(result).toMatch(/^매일 반복, \d{4}년 \d+월 \d+일까지$/)
+  })
+
+  it('every_day에 end_count가 있으면 "매일 반복, N회"를 반환한다', () => {
+    // given
+    const repeating: Repeating = {
+      start: 0,
+      option: { optionType: 'every_day', interval: 1 },
+      end_count: 10,
+    }
+    // when / then
+    expect(describeRepeating(repeating)).toBe('매일 반복, 10회')
+  })
+
+  // --- every_week ---
+
+  it('interval 1, 월·수·금 every_week이면 "매주 월·수·금 반복"을 반환한다', () => {
+    // given — dayOfWeek: 1=월 3=수 5=금
+    const repeating: Repeating = {
+      start: 0,
+      option: { optionType: 'every_week', interval: 1, dayOfWeek: [1, 3, 5], timeZone: 'UTC' },
+    }
+    // when / then
+    expect(describeRepeating(repeating)).toBe('매주 월·수·금 반복')
+  })
+
+  it('interval 2, 화·목 every_week이면 "2주마다 화·목 반복"을 반환한다', () => {
+    // given — dayOfWeek: 2=화 4=목
+    const repeating: Repeating = {
+      start: 0,
+      option: { optionType: 'every_week', interval: 2, dayOfWeek: [2, 4], timeZone: 'UTC' },
+    }
+    // when / then
+    expect(describeRepeating(repeating)).toBe('2주마다 화·목 반복')
+  })
+
+  it('every_week에 종료 날짜가 있으면 종료 정보가 포함된다', () => {
+    // given
+    const endTs = Math.floor(new Date('2026-12-31T00:00:00').getTime() / 1000)
+    const repeating: Repeating = {
+      start: 0,
+      option: { optionType: 'every_week', interval: 2, dayOfWeek: [2, 4], timeZone: 'UTC' },
+      end: endTs,
+    }
+    // when
+    const result = describeRepeating(repeating)
+    // then
+    expect(result).toMatch(/^2주마다 화·목 반복, \d{4}년 \d+월 \d+일까지$/)
+  })
+
+  it('요일이 정렬되지 않은 순서여도 오름차순으로 표시된다', () => {
+    // given
+    const repeating: Repeating = {
+      start: 0,
+      option: { optionType: 'every_week', interval: 1, dayOfWeek: [5, 1, 3], timeZone: 'UTC' },
+    }
+    // when / then
+    expect(describeRepeating(repeating)).toBe('매주 월·수·금 반복')
+  })
+
+  // --- every_month (days mode) ---
+
+  it('every_month days 모드 15일, interval 1이면 "매월 15일 반복"을 반환한다', () => {
+    // given
+    const repeating: Repeating = {
+      start: 0,
+      option: { optionType: 'every_month', interval: 1, monthDaySelection: { days: [15] }, timeZone: 'UTC' },
+    }
+    // when / then
+    expect(describeRepeating(repeating)).toBe('매월 15일 반복')
+  })
+
+  it('every_month days 모드, end_count 10이면 "매월 15일 반복, 10회"를 반환한다', () => {
+    // given
+    const repeating: Repeating = {
+      start: 0,
+      option: { optionType: 'every_month', interval: 1, monthDaySelection: { days: [15] }, timeZone: 'UTC' },
+      end_count: 10,
+    }
+    // when / then
+    expect(describeRepeating(repeating)).toBe('매월 15일 반복, 10회')
+  })
+
+  it('every_month days 모드, interval 3이면 "3개월마다 15일 반복"을 반환한다', () => {
+    // given
+    const repeating: Repeating = {
+      start: 0,
+      option: { optionType: 'every_month', interval: 3, monthDaySelection: { days: [15] }, timeZone: 'UTC' },
+    }
+    // when / then
+    expect(describeRepeating(repeating)).toBe('3개월마다 15일 반복')
+  })
+
+  // --- every_month (week mode) ---
+
+  it('every_month 주차 모드, 둘째 화요일이면 "매월 둘째 화 반복"을 반환한다', () => {
+    // given
+    const repeating: Repeating = {
+      start: 0,
+      option: {
+        optionType: 'every_month',
+        interval: 1,
+        monthDaySelection: { weekOrdinals: [{ isLast: false, seq: 2 }], weekDays: [2] },
+        timeZone: 'UTC',
+      },
+    }
+    // when / then
+    expect(describeRepeating(repeating)).toBe('매월 둘째 화 반복')
+  })
+
+  it('every_month 주차 모드, 마지막 월요일이면 "매월 마지막 월 반복"을 반환한다', () => {
+    // given
+    const repeating: Repeating = {
+      start: 0,
+      option: {
+        optionType: 'every_month',
+        interval: 1,
+        monthDaySelection: { weekOrdinals: [{ isLast: true }], weekDays: [1] },
+        timeZone: 'UTC',
+      },
+    }
+    // when / then
+    expect(describeRepeating(repeating)).toBe('매월 마지막 월 반복')
+  })
+
+  // --- every_year ---
+
+  it('every_year, 3월 둘째 화이면 "매년 3월 둘째 화 반복"을 반환한다', () => {
+    // given
+    const repeating: Repeating = {
+      start: 0,
+      option: {
+        optionType: 'every_year',
+        interval: 1,
+        months: [3],
+        weekOrdinals: [{ isLast: false, seq: 2 }],
+        dayOfWeek: [2],
+        timeZone: 'UTC',
+      },
+    }
+    // when / then
+    expect(describeRepeating(repeating)).toBe('매년 3월 둘째 화 반복')
+  })
+
+  // --- every_year_some_day ---
+
+  it('every_year_some_day, 7월 4일이면 "매년 7월 4일 반복"을 반환한다', () => {
+    // given
+    const repeating: Repeating = {
+      start: 0,
+      option: { optionType: 'every_year_some_day', interval: 1, month: 7, day: 4, timeZone: 'UTC' },
+    }
+    // when / then
+    expect(describeRepeating(repeating)).toBe('매년 7월 4일 반복')
+  })
+
+  it('every_year_some_day, interval 2이면 "2년마다 7월 4일 반복"을 반환한다', () => {
+    // given
+    const repeating: Repeating = {
+      start: 0,
+      option: { optionType: 'every_year_some_day', interval: 2, month: 7, day: 4, timeZone: 'UTC' },
+    }
+    // when / then
+    expect(describeRepeating(repeating)).toBe('2년마다 7월 4일 반복')
+  })
+
+  // --- lunar_calendar_every_year ---
+
+  it('lunar_calendar_every_year, 1월 1일이면 "음력 매년 1월 1일 반복"을 반환한다', () => {
+    // given
+    const repeating: Repeating = {
+      start: 0,
+      option: { optionType: 'lunar_calendar_every_year', month: 1, day: 1, timeZone: 'UTC' },
+    }
+    // when / then
+    expect(describeRepeating(repeating)).toBe('음력 매년 1월 1일 반복')
+  })
+})


### PR DESCRIPTION
## 문제
이벤트 폼의 반복 옵션 드랍다운에서 옵션을 고른 후, 어떤 옵션이 선택됐는지(요일·간격·종료 조건 등) 확인할 곳이 없어 사용자가 자기 설정을 신뢰하기 어려움. 앱은 trigger 아래에 텍스트로 풀어 보여줌.

## 접근
순수 함수 `describeRepeating(repeating, t)` 를 도메인에 두고, `RepeatingSection` 의 Popover trigger 바로 아래 보조 라인으로 한 줄 요약을 노출. 옵션 없으면 라인 자체 미노출.

## 디자인 (frontend-design 가이드 적용)
- 위치: trigger 아래, 아이콘 컬럼 건너뛰고 텍스트에 정렬 (`pl-7 mt-1`)
- 스타일: `text-xs text-muted-foreground leading-snug` — trigger(`text-sm`) 보다 작아 보조 정보임이 시각적으로 분명
- 애니메이션: `animate-in fade-in slide-in-from-top-1 duration-200` — "확정 echo" 가 슥 나타나는 마이크로 인터랙션
- 아이콘 없음 — 부모 row 에 이미 Repeat 아이콘이 있어 중복 회피

## 텍스트 포맷 예시 (한국어)
| 옵션 | 종료 조건 | 출력 |
|---|---|---|
| every_day (interval 1) | — | `매일 반복` |
| every_week (월·수·금) | — | `매주 월·수·금 반복` |
| every_week (interval 2, 화·목) | 2026-12-31까지 | `2주마다 화·목 반복, 2026년 12월 31일까지` |
| every_month (15일) | 10회 | `매월 15일 반복, 10회` |
| every_year (3월 둘째 화) | — | `매년 3월 둘째 화요일 반복` |
| lunar_calendar_every_year | — | `음력 매년 1월 1일 반복` |

## 변경
- `src/domain/functions/repeatingDescription.ts` (신규) — 6개 optionType 전체 + 종료 조건 합성. 순수 함수.
- `src/components/eventForm/RepeatingSection.tsx` — Popover 아래 보조 라인 추가. `repeating !== null && description !== ''` 일 때만 렌더.

## Test plan
- [ ] 옵션 없을 때(반복 안 함) 보조 라인 미노출
- [ ] 매일/매주(요일 다수)/매월/매년/음력 각 옵션 선택 시 의도한 한국어 한 줄 표시
- [ ] 종료 조건(N회 / 특정 날짜) 추가 시 같은 라인에 합쳐서 표시

Closes #128