### PR TITLE
[#136] Apple 로그인 지원 — Firebase Console 연동 + email scope

### DIFF
--- a/src/api/firebaseAuthApi.ts
+++ b/src/api/firebaseAuthApi.ts
@@ -18,6 +18,7 @@ export const firebaseAuthApi: AuthFirebaseApi = {
 
   async signInWithApple(): Promise<void> {
     const provider = new OAuthProvider('apple.com')
+    provider.addScope('email')
     await signInWithPopup(getAuthInstance(), provider)
   },
 


### PR DESCRIPTION
Closes #136

## 배경
Apple 로그인 코드는 LoginPage 버튼/viewmodel/AuthRepository/firebaseAuthApi 까지 갖춰져 있었으나 web 시도 시 `auth/operation-not-allowed` 발생. 진단 결과 **Firebase Console 의 Apple provider 가 비활성/미설정** 상태였음 (iOS 는 Firebase Auth 를 거치지 않는 흐름이라 영향 없었음).

## 외부 콘솔 작업 (운영 노트)
코드 변경과 무관하지만 동일 셋업 필요할 때 참조용:

- **Apple Developer Portal**
  - web 용 **Services ID 신규 등록** + "Sign In with Apple" 활성
  - Domains: `todocalendar-1707723626269.firebaseapp.com`
  - Return URLs: `https://todocalendar-1707723626269.firebaseapp.com/__/auth/handler`
  - Sign in with Apple **Key 신규 발급** + `.p8` 다운로드 (기존 iOS 용 키는 revoke 하지 않고 별도 발급)
- **Firebase Console** → Authentication → Sign-in method → Apple
  - Services ID / Apple Team ID / Key ID / Private Key (.p8 본문) 입력 후 활성화

## 코드 변경
- `firebaseAuthApi.signInWithApple` — `provider.addScope('email')` 추가. iOS (`SignInButtonProvider.swift:83`) 가 `.email` 만 요청하는 컨벤션과 동일하게 정렬. `.fullName` 은 iOS 가 안 요청하므로 web 도 추가 안 함

## 검증
preview channel 배포 → Apple 버튼 클릭 → 메인 화면까지 정상 진입 확인. preview 채널은 검증 후 제거.