### PR TITLE
[#135] 로그아웃 확인 다이얼로그 + 재로그인 후 메인 복귀

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -96,6 +96,8 @@
   "settings.colors_load_failed": "Failed to load colors",
   "settings.colors_saved": "Colors saved",
   "settings.colors_save_failed": "Failed to save colors",
+  "settings.logout_confirm_title": "Log Out",
+  "settings.logout_confirm_message": "Are you sure you want to log out?",
   "settings.account_deleted": "Account deleted",
   "settings.account_delete_failed": "Failed to delete account",
   "settings.delete_account_confirm": "Deleting your account will erase all data. Continue?",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -96,6 +96,8 @@
   "settings.colors_load_failed": "색상 로드에 실패했습니다",
   "settings.colors_saved": "색상이 저장되었습니다",
   "settings.colors_save_failed": "색상 저장에 실패했습니다",
+  "settings.logout_confirm_title": "로그아웃",
+  "settings.logout_confirm_message": "로그아웃 하시겠습니까?",
   "settings.account_deleted": "계정이 삭제되었습니다",
   "settings.account_delete_failed": "계정 삭제에 실패했습니다",
   "settings.delete_account_confirm": "계정을 삭제하면 모든 데이터가 사라집니다. 계속할까요?",

--- a/src/pages/settings/sections/AccountSection.tsx
+++ b/src/pages/settings/sections/AccountSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useToastStore } from '../../../stores/toastStore'
 import { accountApi } from '../../../api/accountApi'
@@ -13,9 +14,17 @@ interface Props {
 
 export function AccountSection({ account, signOut }: Props) {
   const { t } = useTranslation()
+  const navigate = useNavigate()
 
+  const [showLogoutConfirm, setShowLogoutConfirm] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [deleting, setDeleting] = useState(false)
+
+  const handleLogout = async () => {
+    setShowLogoutConfirm(false)
+    navigate('/', { replace: true })
+    await signOut()
+  }
 
   const handleDeleteAccount = async () => {
     setDeleting(true)
@@ -38,7 +47,7 @@ export function AccountSection({ account, signOut }: Props) {
           <p className="text-sm text-fg-secondary">{account.email ?? account.uid}</p>
         )}
         <div>
-          <button className={settingsBtnSecondary} onClick={() => signOut()}>
+          <button className={settingsBtnSecondary} onClick={() => setShowLogoutConfirm(true)}>
             {t('settings.logout')}
           </button>
         </div>
@@ -55,6 +64,17 @@ export function AccountSection({ account, signOut }: Props) {
           </button>
         </div>
       </SettingsSection>
+
+      {showLogoutConfirm && (
+        <ConfirmDialog
+          title={t('settings.logout_confirm_title')}
+          message={t('settings.logout_confirm_message')}
+          confirmLabel={t('settings.logout')}
+          danger
+          onConfirm={handleLogout}
+          onCancel={() => setShowLogoutConfirm(false)}
+        />
+      )}
 
       {showDeleteConfirm && (
         <ConfirmDialog

--- a/tests/pages/settings/SettingsPage.test.tsx
+++ b/tests/pages/settings/SettingsPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { SettingsPage } from '../../../src/pages/settings/SettingsPage'
@@ -40,6 +40,7 @@ describe('SettingsPage', () => {
     return render(
       <MemoryRouter initialEntries={[initialPath]}>
         <Routes>
+          <Route path="/" element={<div data-testid="main-page">main</div>} />
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="/settings/:categoryId" element={<SettingsPage />} />
           <Route path="/settings/:categoryId/:subView" element={<SettingsPage />} />
@@ -84,7 +85,7 @@ describe('SettingsPage', () => {
     await waitFor(() => expect(screen.getByText('test@example.com')).toBeInTheDocument())
   })
 
-  it('계정 섹션에서 로그아웃 버튼 클릭 시 signOut이 호출된다', async () => {
+  it('계정 섹션에서 로그아웃 버튼 클릭 시 확인 다이얼로그가 노출된다', async () => {
     // given
     renderPage('/settings/account')
     await waitFor(() => screen.getByText('test@example.com'))
@@ -92,8 +93,40 @@ describe('SettingsPage', () => {
     // when
     await userEvent.click(screen.getByRole('button', { name: '로그아웃' }))
 
-    // then: authRepo.signOut이 실행되어 mockSignOut이 호출됨
+    // then: 확인 다이얼로그가 표시되고 signOut은 아직 호출되지 않는다
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+    expect(mockSignOut).not.toHaveBeenCalled()
+  })
+
+  it('로그아웃 확인 다이얼로그에서 확인 클릭 시 로그아웃 실행 후 메인 경로로 이동한다', async () => {
+    // given
+    mockSignOut.mockResolvedValue(undefined)
+    renderPage('/settings/account')
+    await waitFor(() => screen.getByText('test@example.com'))
+
+    // when
+    await userEvent.click(screen.getByRole('button', { name: '로그아웃' }))
+    const dialog = await waitFor(() => screen.getByRole('dialog'))
+    await userEvent.click(within(dialog).getByRole('button', { name: '로그아웃' }))
+
+    // then: signOut이 실행되고 메인 페이지로 이동한다
     await waitFor(() => expect(mockSignOut).toHaveBeenCalled())
+    await waitFor(() => expect(screen.getByTestId('main-page')).toBeInTheDocument())
+  })
+
+  it('로그아웃 확인 다이얼로그에서 취소 클릭 시 로그아웃이 실행되지 않는다', async () => {
+    // given
+    renderPage('/settings/account')
+    await waitFor(() => screen.getByText('test@example.com'))
+
+    // when
+    await userEvent.click(screen.getByRole('button', { name: '로그아웃' }))
+    await waitFor(() => screen.getByRole('dialog'))
+    await userEvent.click(screen.getByRole('button', { name: '취소' }))
+
+    // then: 다이얼로그가 닫히고 signOut은 호출되지 않는다
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    expect(mockSignOut).not.toHaveBeenCalled()
   })
 
   it('계정 삭제 실패 시 에러 토스트가 표시된다', async () => {


### PR DESCRIPTION
## 문제
1. 설정 화면 로그아웃 버튼이 즉시 `signOut()`을 호출해 의도치 않은 로그아웃 가능
2. 설정에서 로그아웃 후 재로그인 시 설정 화면으로 복귀 (메인 화면이 자연스러움)

## 접근
- `AccountSection.handleLogout` — 로그아웃 버튼은 ConfirmDialog 노출, 확인 시 `navigate('/', { replace: true })` 후 `signOut()` 호출
  - AuthGuard가 미인증 상태로 리다이렉트할 때 `from='/'`이 되도록 의도 → 재로그인 후 메인 복귀
  - `LoginPage`의 일반 deep-link `from` 동작은 변경하지 않음 (의도를 호출자에서 표현)
- ConfirmDialog `danger=true`, 기존 `delete_account_confirm`과 일관된 패턴
- i18n: `settings.logout_confirm_title`, `settings.logout_confirm_message` 신규 (en/ko)

## 검증
- TDD 신규 3케이스 (다이얼로그 노출, 확인→로그아웃+메인이동, 취소→로그아웃 없음)
- 풀 테스트 942/942 통과, 빌드 성공

Closes #135