### PR TITLE
[#129] PR3: Write LocalStorage Sync — mutation 흐름 동기화

### DIFF
--- a/src/components/ArchivePanel.tsx
+++ b/src/components/ArchivePanel.tsx
@@ -4,6 +4,7 @@ import { ChevronLeft, RotateCcw, Trash2 } from 'lucide-react'
 import { useDoneTodosCache } from '../repositories/caches/doneTodosCache'
 import { useToastStore } from '../stores/toastStore'
 import { useUiStore } from '../stores/uiStore'
+import { useRepositories } from '../composition/RepositoriesProvider'
 import { ConfirmDialog } from './ConfirmDialog'
 import { useResolvedEventTag } from '../hooks/useResolvedEventTag'
 import type { DoneTodo } from '../models'
@@ -72,7 +73,8 @@ export function ArchivePanel({ onDoneTodoClick }: ArchivePanelProps = {}) {
   const { t, i18n } = useTranslation()
   const exitArchivePanel = useUiStore(s => s.exitArchivePanel)
   const toggleRightPanel = useUiStore(s => s.toggleRightPanel)
-  const { items, hasMore, fetchNext, revert, remove, reset } = useDoneTodosCache()
+  const { doneTodoRepo } = useRepositories()
+  const { items, hasMore, reset } = useDoneTodosCache()
   const sentinelRef = useRef<HTMLDivElement>(null)
   const [confirmId, setConfirmId] = useState<string | null>(null)
 
@@ -91,7 +93,7 @@ export function ArchivePanel({ onDoneTodoClick }: ArchivePanelProps = {}) {
 
   useEffect(() => {
     reset()
-    fetchNext()
+    doneTodoRepo.fetchNextPage()
     return () => { reset() }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -99,17 +101,15 @@ export function ArchivePanel({ onDoneTodoClick }: ArchivePanelProps = {}) {
     const el = sentinelRef.current
     if (!el) return
     const observer = new IntersectionObserver(entries => {
-      if (entries[0].isIntersecting) fetchNext()
+      if (entries[0].isIntersecting) doneTodoRepo.fetchNextPage()
     })
     observer.observe(el)
     return () => observer.disconnect()
-  }, [fetchNext])
+  }, [doneTodoRepo])
 
   const handleRevert = async (id: string) => {
     try {
-      // cache.revert 가 응답 todo 를 currentTodosCache 에 직접 addTodo — fetchCurrentTodos 의존 제거.
-      // BFF 일관성 의존으로 빈 todo 가 노출되던 회귀 차단.
-      await revert(id)
+      await doneTodoRepo.revert(id)
     } catch (e) {
       console.warn('되돌리기 실패:', e)
       useToastStore.getState().show('todo.revert_failed', 'error')
@@ -178,7 +178,7 @@ export function ArchivePanel({ onDoneTodoClick }: ArchivePanelProps = {}) {
           danger
           onConfirm={async () => {
             try {
-              await remove(confirmId)
+              await doneTodoRepo.remove(confirmId)
             } catch (e) {
               console.warn('삭제 실패:', e)
               useToastStore.getState().show('todo.delete_failed', 'error')

--- a/src/components/DoneTodoDetail/useDoneTodoDetailPopoverViewModel.ts
+++ b/src/components/DoneTodoDetail/useDoneTodoDetailPopoverViewModel.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { doneTodoApi } from '../../api/doneTodoApi'
-import { useDoneTodosCache } from '../../repositories/caches/doneTodosCache'
+import { useRepositories } from '../../composition/RepositoriesProvider'
 import { useToastStore } from '../../stores/toastStore'
 import type { DoneTodo, EventDetail } from '../../models'
 
@@ -20,8 +20,7 @@ export function useDoneTodoDetailPopoverViewModel(
   const [isReverting, setIsReverting] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
 
-  const cacheRevert = useDoneTodosCache(s => s.revert)
-  const cacheRemove = useDoneTodosCache(s => s.remove)
+  const { doneTodoRepo } = useRepositories()
 
   // useCallback deps 의 isReverting/isDeleting 으로 매 렌더마다 reference 가 깨지지 않도록
   // useRef 로 in-flight 플래그를 관리한다.
@@ -48,8 +47,7 @@ export function useDoneTodoDetailPopoverViewModel(
     revertingRef.current = true
     setIsReverting(true)
     try {
-      // cache.revert 가 응답 todo 를 currentTodosCache 에 직접 addTodo 한다 — 빈 todo 회귀 차단.
-      await cacheRevert(doneTodo.uuid)
+      await doneTodoRepo.revert(doneTodo.uuid)
       return true
     } catch (e) {
       console.warn('Done todo 되돌리기 실패:', e)
@@ -59,14 +57,14 @@ export function useDoneTodoDetailPopoverViewModel(
       revertingRef.current = false
       setIsReverting(false)
     }
-  }, [cacheRevert, doneTodo.uuid])
+  }, [doneTodoRepo, doneTodo.uuid])
 
   const remove = useCallback(async (): Promise<boolean> => {
     if (deletingRef.current) return false
     deletingRef.current = true
     setIsDeleting(true)
     try {
-      await cacheRemove(doneTodo.uuid)
+      await doneTodoRepo.remove(doneTodo.uuid)
       return true
     } catch (e) {
       console.warn('Done todo 삭제 실패:', e)
@@ -76,7 +74,7 @@ export function useDoneTodoDetailPopoverViewModel(
       deletingRef.current = false
       setIsDeleting(false)
     }
-  }, [cacheRemove, doneTodo.uuid])
+  }, [doneTodoRepo, doneTodo.uuid])
 
   return { detail, revert, remove, isReverting, isDeleting }
 }

--- a/src/components/dev/TestDataSeederButton.tsx
+++ b/src/components/dev/TestDataSeederButton.tsx
@@ -7,7 +7,7 @@ import { useToastStore } from '../../stores/toastStore'
 
 export default function TestDataSeederButton() {
   const [running, setRunning] = useState(false)
-  const { tagRepo, eventRepo, foremostEventRepo } = useRepositories()
+  const { tagRepo, eventRepo, foremostEventRepo, doneTodoRepo } = useRepositories()
 
   async function handleClick() {
     if (running) return
@@ -35,8 +35,8 @@ export default function TestDataSeederButton() {
       ])
 
       // Done todos는 페이지네이션 상태 초기화 후 첫 페이지 재로딩
-      useDoneTodosCache.setState({ items: [], cursor: null, hasMore: true, isLoading: false })
-      await useDoneTodosCache.getState().fetchNext().catch(() => {})
+      useDoneTodosCache.getState().reset()
+      await doneTodoRepo.fetchNextPage().catch(() => {})
 
       const totalErrors = cleanupErrors.length + result.errors.length
       const summary =

--- a/src/composition/container.ts
+++ b/src/composition/container.ts
@@ -51,7 +51,7 @@ const tagRepo = new TagRepository({ eventTagApi, settingApi, localStorageContain
 
 export const repositories: Repositories = {
   eventRepo,
-  eventDetailRepo: new EventDetailRepository({ api: eventDetailApi }),
+  eventDetailRepo: new EventDetailRepository({ api: eventDetailApi, localStorageContainer }),
   tagRepo,
   holidayRepo,
   doneTodoRepo: new DoneTodoRepository({ api: doneTodoApi, localStorageContainer }),

--- a/src/repositories/DoneTodoRepository.ts
+++ b/src/repositories/DoneTodoRepository.ts
@@ -3,6 +3,8 @@ import type { Todo } from '../models/Todo'
 import type { RevertDoneTodoResponse } from '../api/doneTodoApi'
 import type { LocalStorageContainer } from './local-storage/LocalStorageContainer'
 import { useDoneTodosCache } from './caches/doneTodosCache'
+import { useCalendarEventsCache } from './caches/calendarEventsCache'
+import { useCurrentTodosCache } from './caches/currentTodosCache'
 
 const PAGE_SIZE = 20
 
@@ -81,9 +83,20 @@ export class DoneTodoRepository {
     const response = await this.deps.api.revertDoneTodo(id)
     const local = this.deps.localStorageContainer
     if (local?.isInitialized()) {
-      try { await local.doneTodo().removeDoneTodos([id]) } catch (e) { console.warn('LocalStorage doneTodo revert 실패:', e) }
+      try {
+        await local.doneTodo().removeDoneTodos([id])
+        // 복원된 todo 도 LocalStorage 에 저장
+        await local.todo().saveTodos([response.todo])
+      } catch (e) { console.warn('LocalStorage doneTodo revert 실패:', e) }
     }
+    // 메모리: doneTodos 에서 제거 + 관련 todo 캐시들에 추가
     useDoneTodosCache.getState().removeItem(id)
+    if (response.todo.event_time) {
+      useCalendarEventsCache.getState().addEvent({ type: 'todo', event: response.todo })
+    }
+    if (response.todo.is_current) {
+      useCurrentTodosCache.getState().addTodo(response.todo)
+    }
     return response.todo
   }
 

--- a/src/repositories/DoneTodoRepository.ts
+++ b/src/repositories/DoneTodoRepository.ts
@@ -79,12 +79,20 @@ export class DoneTodoRepository {
 
   async revert(id: string): Promise<Todo> {
     const response = await this.deps.api.revertDoneTodo(id)
+    const local = this.deps.localStorageContainer
+    if (local?.isInitialized()) {
+      try { await local.doneTodo().removeDoneTodos([id]) } catch (e) { console.warn('LocalStorage doneTodo revert 실패:', e) }
+    }
     useDoneTodosCache.getState().removeItem(id)
     return response.todo
   }
 
   async remove(id: string): Promise<void> {
     await this.deps.api.deleteDoneTodo(id)
+    const local = this.deps.localStorageContainer
+    if (local?.isInitialized()) {
+      try { await local.doneTodo().removeDoneTodos([id]) } catch (e) { console.warn('LocalStorage doneTodo remove 실패:', e) }
+    }
     useDoneTodosCache.getState().removeItem(id)
   }
 }

--- a/src/repositories/DoneTodoRepository.ts
+++ b/src/repositories/DoneTodoRepository.ts
@@ -32,7 +32,7 @@ export class DoneTodoRepository {
   // ── fetch: 서버 → 캐시 ────────────────────────────────────────────
 
   async fetchNextPage(): Promise<void> {
-    const { hasMore, cursor } = useDoneTodosCache.getState()
+    const { hasMore, cursor, generation: startGen } = useDoneTodosCache.getState()
     if (!hasMore) return
     const local = this.deps.localStorageContainer
     const isFirstPage = cursor === null || cursor === undefined
@@ -41,7 +41,7 @@ export class DoneTodoRepository {
     if (isFirstPage && local?.isInitialized()) {
       try {
         const cached = await local.doneTodo().loadRecent(PAGE_SIZE)
-        if (cached.length > 0) {
+        if (cached.length > 0 && useDoneTodosCache.getState().generation === startGen) {
           const last = cached[cached.length - 1]
           const nextCursor = last?.done_at ?? null
           useDoneTodosCache.getState().appendPage(cached, nextCursor, cached.length === PAGE_SIZE && nextCursor !== null)
@@ -51,8 +51,14 @@ export class DoneTodoRepository {
       }
     }
 
-    // 2. Remote 호출 — cursor は첫 페이지라면 undefined, 이후엔 캐시가 보유한 cursor 사용
+    // 2. Remote 호출 — cursor 는 첫 페이지라면 undefined, 이후엔 캐시가 보유한 cursor 사용
     const fetched = await this.deps.api.getDoneTodos(PAGE_SIZE, cursor ?? undefined)
+
+    // generation 이 변경됐다면 stale 응답 — 무시
+    if (useDoneTodosCache.getState().generation !== startGen) {
+      return
+    }
+
     const last = fetched[fetched.length - 1]
     const nextCursor = last?.done_at ?? null
     const newHasMore = fetched.length === PAGE_SIZE && nextCursor !== null
@@ -63,6 +69,7 @@ export class DoneTodoRepository {
     }
 
     // 4. 첫 페이지면 cache-first 로 임시 채운 메모리를 reset 후 Remote 데이터로 교체
+    //    reset() 이 generation 을 bump 하지만 이는 의도된 reset 이므로 이후 appendPage 를 그대로 적용한다.
     if (isFirstPage) {
       useDoneTodosCache.getState().reset()
     }

--- a/src/repositories/EventDetailRepository.ts
+++ b/src/repositories/EventDetailRepository.ts
@@ -83,9 +83,9 @@ export class EventDetailRepository {
   }
 
   async save(eventId: string, detail: EventDetail): Promise<EventDetail> {
-    const saved = await this.deps.api.updateEventDetail(eventId, detail)
-    // bg refresh 가 save 보다 나중에 완료되어도 stale Remote 로 덮어쓰지 않도록 generation bump
+    // bg refresh 가 save 의 await 동안 시작/완료되어도 stale Remote 로 덮어쓰지 않도록 먼저 bump
     this.bumpGeneration(eventId)
+    const saved = await this.deps.api.updateEventDetail(eventId, detail)
     const local = this.deps.localStorageContainer
     if (local?.isInitialized()) {
       try { await local.eventDetail().saveDetail(eventId, saved) } catch (e) { console.warn('LocalStorage event detail save 실패:', e) }

--- a/src/repositories/EventDetailRepository.ts
+++ b/src/repositories/EventDetailRepository.ts
@@ -16,9 +16,20 @@ interface Deps {
 export class EventDetailRepository {
   private readonly deps: Deps
   private readonly cache: Map<string, EventDetail | null> = new Map()
+  private readonly generations: Map<string, number> = new Map()
 
   constructor(deps: Deps) {
     this.deps = deps
+  }
+
+  private currentGeneration(id: string): number {
+    return this.generations.get(id) ?? 0
+  }
+
+  private bumpGeneration(id: string): number {
+    const next = (this.generations.get(id) ?? 0) + 1
+    this.generations.set(id, next)
+    return next
   }
 
   async get(eventId: string): Promise<EventDetail | null> {
@@ -34,11 +45,13 @@ export class EventDetailRepository {
         const cached = await local.eventDetail().loadDetail(eventId)
         if (cached) {
           this.cache.set(eventId, cached)
+          // generation 캡처: bg refresh 가 save/invalidate 이후 완료되면 무시한다
+          const refreshGen = this.currentGeneration(eventId)
           // 백그라운드 refresh — Remote 응답이 다르면 in-memory + LocalStorage 갱신
           ;(async () => {
             try {
               const remote = await this.deps.api.getEventDetail(eventId)
-              if (remote) {
+              if (remote && this.currentGeneration(eventId) === refreshGen) {
                 this.cache.set(eventId, remote)
                 if (local.isInitialized()) {
                   try { await local.eventDetail().saveDetail(eventId, remote) } catch {}
@@ -71,6 +84,8 @@ export class EventDetailRepository {
 
   async save(eventId: string, detail: EventDetail): Promise<EventDetail> {
     const saved = await this.deps.api.updateEventDetail(eventId, detail)
+    // bg refresh 가 save 보다 나중에 완료되어도 stale Remote 로 덮어쓰지 않도록 generation bump
+    this.bumpGeneration(eventId)
     const local = this.deps.localStorageContainer
     if (local?.isInitialized()) {
       try { await local.eventDetail().saveDetail(eventId, saved) } catch (e) { console.warn('LocalStorage event detail save 실패:', e) }
@@ -79,7 +94,12 @@ export class EventDetailRepository {
     return saved
   }
 
-  invalidate(eventId: string): void {
+  async invalidate(eventId: string): Promise<void> {
+    this.bumpGeneration(eventId)
     this.cache.delete(eventId)
+    const local = this.deps.localStorageContainer
+    if (local?.isInitialized()) {
+      try { await local.eventDetail().removeDetail(eventId) } catch (e) { console.warn('LocalStorage invalidate 실패:', e) }
+    }
   }
 }

--- a/src/repositories/EventDetailRepository.ts
+++ b/src/repositories/EventDetailRepository.ts
@@ -1,4 +1,5 @@
 import type { EventDetail } from '../models/EventDetail'
+import type { LocalStorageContainer } from './local-storage/LocalStorageContainer'
 
 // ── API 인터페이스 명시적 정의 ────────────────────────────────────────
 // eventDetailApi 모듈의 실제 시그니처와 동기를 유지해야 한다.
@@ -9,6 +10,7 @@ export interface EventDetailApi {
 
 interface Deps {
   api: EventDetailApi
+  localStorageContainer?: LocalStorageContainer
 }
 
 export class EventDetailRepository {
@@ -20,12 +22,46 @@ export class EventDetailRepository {
   }
 
   async get(eventId: string): Promise<EventDetail | null> {
+    // 1. In-memory cache 적중 — 즉시 반환
     if (this.cache.has(eventId)) {
       return this.cache.get(eventId) ?? null
     }
+
+    // 2. LocalStorage cache-first — 즉시 반환 + 백그라운드 Remote 갱신
+    const local = this.deps.localStorageContainer
+    if (local?.isInitialized()) {
+      try {
+        const cached = await local.eventDetail().loadDetail(eventId)
+        if (cached) {
+          this.cache.set(eventId, cached)
+          // 백그라운드 refresh — Remote 응답이 다르면 in-memory + LocalStorage 갱신
+          ;(async () => {
+            try {
+              const remote = await this.deps.api.getEventDetail(eventId)
+              if (remote) {
+                this.cache.set(eventId, remote)
+                if (local.isInitialized()) {
+                  try { await local.eventDetail().saveDetail(eventId, remote) } catch {}
+                }
+              }
+            } catch {
+              // 백그라운드 실패는 cached 그대로 유지
+            }
+          })()
+          return cached
+        }
+      } catch (e) {
+        console.warn('LocalStorage event detail cache read 실패:', e)
+      }
+    }
+
+    // 3. Remote
     try {
       const detail = await this.deps.api.getEventDetail(eventId)
       this.cache.set(eventId, detail)
+      if (local?.isInitialized() && detail) {
+        try { await local.eventDetail().saveDetail(eventId, detail) } catch {}
+      }
       return detail
     } catch {
       this.cache.set(eventId, null)
@@ -35,6 +71,10 @@ export class EventDetailRepository {
 
   async save(eventId: string, detail: EventDetail): Promise<EventDetail> {
     const saved = await this.deps.api.updateEventDetail(eventId, detail)
+    const local = this.deps.localStorageContainer
+    if (local?.isInitialized()) {
+      try { await local.eventDetail().saveDetail(eventId, saved) } catch (e) { console.warn('LocalStorage event detail save 실패:', e) }
+    }
     this.cache.set(eventId, saved)
     return saved
   }

--- a/src/repositories/EventRepository.ts
+++ b/src/repositories/EventRepository.ts
@@ -257,8 +257,22 @@ export class EventRepository {
 
   // ── mutate: api 호출 + 캐시 갱신 ──────────────────────────────────
 
+  // LocalStorage 작업을 silent fail 로 감싸는 헬퍼 — IDB 실패가 mutation 흐름을 깨지 않게
+  private async writeLocal(label: string, fn: () => Promise<unknown>): Promise<void> {
+    const local = this.deps.localStorageContainer
+    if (!local?.isInitialized()) return
+    try {
+      await fn()
+    } catch (e) {
+      console.warn(`LocalStorage ${label} 실패:`, e)
+    }
+  }
+
   async createTodo(input: TodoCreateInput): Promise<Todo> {
     const created = await this.deps.todoApi.createTodo(input)
+    await this.writeLocal('createTodo', () =>
+      this.deps.localStorageContainer!.todo().saveTodos([created]),
+    )
     if (created.event_time) {
       useCalendarEventsCache.getState().addEvent({ type: 'todo', event: created })
     }
@@ -270,6 +284,9 @@ export class EventRepository {
 
   async updateTodo(id: string, patch: TodoPatch): Promise<Todo> {
     const updated = await this.deps.todoApi.patchTodo(id, patch)
+    await this.writeLocal('updateTodo', () =>
+      this.deps.localStorageContainer!.todo().updateTodo(updated),
+    )
     useCalendarEventsCache.getState().replaceEvent(id, { type: 'todo', event: updated })
     if (updated.is_current) {
       // 이미 목록에 있으면 교체, 없으면 추가 (is_current가 새로 true가 된 경우)
@@ -287,6 +304,9 @@ export class EventRepository {
 
   async deleteTodo(id: string): Promise<void> {
     await this.deps.todoApi.deleteTodo(id)
+    await this.writeLocal('deleteTodo', () =>
+      this.deps.localStorageContainer!.todo().removeTodos([id]),
+    )
     useCalendarEventsCache.getState().removeEvent(id)
     useCurrentTodosCache.getState().removeTodo(id)
   }
@@ -296,6 +316,9 @@ export class EventRepository {
       event_time: nextEventTime,
       repeating_turn: nextTurn,
     })
+    await this.writeLocal('patchTodoNextOccurrence', () =>
+      this.deps.localStorageContainer!.todo().updateTodo(updated),
+    )
     useCalendarEventsCache.getState().replaceEvent(id, { type: 'todo', event: updated })
     return updated
   }
@@ -306,6 +329,13 @@ export class EventRepository {
     body: Parameters<TodoApi['replaceTodo']>[1],
   ): Promise<{ new_todo: Todo; next_repeating: Todo | undefined }> {
     const result = await this.deps.todoApi.replaceTodo(id, body)
+    await this.writeLocal('replaceTodoThisScope', async () => {
+      const local = this.deps.localStorageContainer!
+      await local.todo().removeTodos([id])
+      const toSave: Todo[] = [result.new_todo]
+      if (result.next_repeating) toSave.push(result.next_repeating)
+      await local.todo().saveTodos(toSave)
+    })
     useCalendarEventsCache.getState().removeEvent(id)
     if (result.new_todo.event_time) {
       useCalendarEventsCache.getState().addEvent({ type: 'todo', event: result.new_todo })
@@ -320,23 +350,35 @@ export class EventRepository {
 
   async createSchedule(input: ScheduleCreateInput): Promise<Schedule> {
     const created = await this.deps.scheduleApi.createSchedule(input)
+    await this.writeLocal('createSchedule', () =>
+      this.deps.localStorageContainer!.schedule().saveSchedules([created]),
+    )
     useCalendarEventsCache.getState().addEvent({ type: 'schedule', event: created })
     return created
   }
 
   async updateSchedule(id: string, patch: SchedulePatch): Promise<Schedule> {
     const updated = await this.deps.scheduleApi.updateSchedule(id, patch)
+    await this.writeLocal('updateSchedule', () =>
+      this.deps.localStorageContainer!.schedule().updateSchedule(updated),
+    )
     useCalendarEventsCache.getState().replaceEvent(id, { type: 'schedule', event: updated })
     return updated
   }
 
   async deleteSchedule(id: string): Promise<void> {
     await this.deps.scheduleApi.deleteSchedule(id)
+    await this.writeLocal('deleteSchedule', () =>
+      this.deps.localStorageContainer!.schedule().removeSchedules([id]),
+    )
     useCalendarEventsCache.getState().removeEvent(id)
   }
 
   async excludeScheduleRepeating(id: string, excludeTurns: number[]): Promise<Schedule> {
     const updated = await this.deps.scheduleApi.excludeRepeating(id, { exclude_repeatings: excludeTurns })
+    await this.writeLocal('excludeScheduleRepeating', () =>
+      this.deps.localStorageContainer!.schedule().updateSchedule(updated),
+    )
     useCalendarEventsCache.getState().replaceEvent(id, { type: 'schedule', event: updated })
     return updated
   }
@@ -354,10 +396,20 @@ export class EventRepository {
       if (next?.time) {
         const nextTurn = next.turn ?? (todo.repeating_turn ?? 1) + 1
         const advanced: Todo = { ...todo, event_time: next.time, repeating_turn: nextTurn }
+        await this.writeLocal('completeTodo (this+next)', async () => {
+          const local = this.deps.localStorageContainer!
+          await local.todo().updateTodo(advanced)
+          await local.doneTodo().saveDoneTodos([done])
+        })
         useCalendarEventsCache.getState().replaceEvent(todo.uuid, { type: 'todo', event: advanced })
         useCurrentTodosCache.getState().replaceTodo(advanced)
         useUncompletedTodosCache.getState().removeTodo(todo.uuid)
       } else {
+        await this.writeLocal('completeTodo (this+end)', async () => {
+          const local = this.deps.localStorageContainer!
+          await local.todo().removeTodos([todo.uuid])
+          await local.doneTodo().saveDoneTodos([done])
+        })
         useCalendarEventsCache.getState().removeEvent(todo.uuid)
         useCurrentTodosCache.getState().removeTodo(todo.uuid)
         useUncompletedTodosCache.getState().removeTodo(todo.uuid)
@@ -369,6 +421,11 @@ export class EventRepository {
       const startTs = getStartTimestamp(todo.event_time!)
       await this.deps.todoApi.patchTodo(todo.uuid, { repeating: { ...todo.repeating, end: startTs - 1 } })
       const done = await this.deps.todoApi.completeTodo(todo.uuid, { origin: todo })
+      await this.writeLocal('completeTodo (future)', async () => {
+        const local = this.deps.localStorageContainer!
+        await local.todo().removeTodos([todo.uuid])
+        await local.doneTodo().saveDoneTodos([done])
+      })
       useCalendarEventsCache.getState().removeEvent(todo.uuid)
       useCurrentTodosCache.getState().removeTodo(todo.uuid)
       useUncompletedTodosCache.getState().removeTodo(todo.uuid)
@@ -376,6 +433,11 @@ export class EventRepository {
     }
 
     const done = await this.deps.todoApi.completeTodo(todo.uuid, { origin: todo })
+    await this.writeLocal('completeTodo (all)', async () => {
+      const local = this.deps.localStorageContainer!
+      await local.todo().removeTodos([todo.uuid])
+      await local.doneTodo().saveDoneTodos([done])
+    })
     useCalendarEventsCache.getState().removeEvent(todo.uuid)
     useCurrentTodosCache.getState().removeTodo(todo.uuid)
     useUncompletedTodosCache.getState().removeTodo(todo.uuid)

--- a/src/repositories/ForemostEventRepository.ts
+++ b/src/repositories/ForemostEventRepository.ts
@@ -57,11 +57,19 @@ export class ForemostEventRepository {
 
   async set(eventId: string, isTodo: boolean): Promise<void> {
     const event = await this.deps.api.setForemostEvent({ event_id: eventId, is_todo: isTodo })
+    const local = this.deps.localStorageContainer
+    if (local?.isInitialized()) {
+      try { await local.foremost().save(event) } catch (e) { console.warn('LocalStorage foremost set 실패:', e) }
+    }
     useForemostEventCache.getState().setEvent(event)
   }
 
   async clear(): Promise<void> {
     await this.deps.api.removeForemostEvent()
+    const local = this.deps.localStorageContainer
+    if (local?.isInitialized()) {
+      try { await local.foremost().remove() } catch (e) { console.warn('LocalStorage foremost clear 실패:', e) }
+    }
     useForemostEventCache.getState().setEvent(null)
   }
 

--- a/src/repositories/TagRepository.ts
+++ b/src/repositories/TagRepository.ts
@@ -82,8 +82,22 @@ export class TagRepository {
 
   // ── mutate: api 호출 + 캐시 갱신 ──────────────────────────────────
 
+  // LocalStorage write 를 silent fail 로 감싸는 헬퍼
+  private async writeLocal(label: string, fn: () => Promise<unknown>): Promise<void> {
+    const local = this.deps.localStorageContainer
+    if (!local?.isInitialized()) return
+    try {
+      await fn()
+    } catch (e) {
+      console.warn(`LocalStorage ${label} 실패:`, e)
+    }
+  }
+
   async createTag(name: string, color_hex?: string): Promise<EventTag> {
     const created = await this.deps.eventTagApi.createTag({ name, color_hex })
+    await this.writeLocal('createTag', () =>
+      this.deps.localStorageContainer!.eventTag().saveTags([created]),
+    )
     useEventTagListCache.getState().add(created)
     return created
   }
@@ -95,6 +109,9 @@ export class TagRepository {
       name: patch.name ?? existing.name,
       color_hex: patch.color_hex ?? existing.color_hex ?? undefined,
     })
+    await this.writeLocal('updateTag', () =>
+      this.deps.localStorageContainer!.eventTag().updateTag(updated),
+    )
     useEventTagListCache.getState().replace(updated)
     return updated
   }
@@ -106,6 +123,9 @@ export class TagRepository {
 
   async deleteTag(id: string): Promise<void> {
     await this.deps.eventTagApi.deleteTag(id)
+    await this.writeLocal('deleteTag', () =>
+      this.deps.localStorageContainer!.eventTag().removeTag(id),
+    )
     useEventTagListCache.getState().remove(id)
   }
 

--- a/src/repositories/caches/doneTodosCache.ts
+++ b/src/repositories/caches/doneTodosCache.ts
@@ -13,11 +13,12 @@ interface DoneTodosCacheState {
   hasMore: boolean
   isLoading: boolean
   /**
-   * reset / revert / remove 가 발생할 때마다 +1. fetchNext 가 시작 시점의 generation 을 캡처해
-   * 응답 도착 시 generation 이 바뀌었다면 stale 응답으로 간주하고 무시한다.
+   * reset / revert / remove 가 발생할 때마다 +1. DoneTodoRepository.fetchNextPage 가
+   * fetch 시작 시점의 generation 을 캡처해 응답 도착 시 generation 이 바뀌었다면 stale 응답으로
+   * 간주하고 무시한다.
    *
-   * 필요한 이유: 컴포넌트(ArchivePanel) 의 dev StrictMode 더블 useEffect 로 fetchNext 가 두 번
-   * 발사되거나, fetchNext 진행 중에 revert/remove 가 일어나면, in-flight 응답이 cache 를 다시
+   * 필요한 이유: 컴포넌트(ArchivePanel) 의 dev StrictMode 더블 useEffect 로 fetchNextPage 가 두 번
+   * 발사되거나, fetchNextPage 진행 중에 revert/remove 가 일어나면, in-flight 응답이 cache 를 다시
    * 채워 (1) 항목이 중복 표시되거나 (2) 사용자가 막 지운 항목이 되살아나는 회귀가 발생한다.
    */
   generation: number

--- a/src/repositories/caches/doneTodosCache.ts
+++ b/src/repositories/caches/doneTodosCache.ts
@@ -3,10 +3,7 @@
  * Repository 클래스를 통해서만 노출한다.
  */
 import { create } from 'zustand'
-import { doneTodoApi } from '../../api/doneTodoApi'
-import { useCurrentTodosCache } from './currentTodosCache'
-import { useCalendarEventsCache } from './calendarEventsCache'
-import type { DoneTodo, Todo } from '../../models'
+import type { DoneTodo } from '../../models'
 
 const PAGE_SIZE = 20
 
@@ -29,14 +26,9 @@ interface DoneTodosCacheState {
   appendPage: (items: DoneTodo[], nextCursor: number | null, hasMore: boolean) => void
   removeItem: (id: string) => void
   reset: () => void
-  // ── legacy business operations (callers migrated to DoneTodoRepository in T14+) ──
-  fetchNext: () => Promise<void>
-  /** 복원된 todo 를 반환. 호출자가 currentTodos 갱신 등 후속 동선에 사용할 수 있다. */
-  revert: (id: string) => Promise<Todo>
-  remove: (id: string) => Promise<void>
 }
 
-export const useDoneTodosCache = create<DoneTodosCacheState>((set, get) => ({
+export const useDoneTodosCache = create<DoneTodosCacheState>((set, _get) => ({
   items: [],
   cursor: null,
   hasMore: true,
@@ -71,69 +63,4 @@ export const useDoneTodosCache = create<DoneTodosCacheState>((set, get) => ({
     isLoading: false,
     generation: s.generation + 1,
   })),
-
-  // ── legacy business operations (to be removed after T14+ page migration) ──
-
-  fetchNext: async () => {
-    const { isLoading, hasMore, cursor, generation: startGen } = get()
-    if (isLoading || !hasMore) return
-    set({ isLoading: true })
-    try {
-      const fetched = await doneTodoApi.getDoneTodos(PAGE_SIZE, cursor ?? undefined)
-      set(state => {
-        // stale 응답: 시작 시점 이후 reset/revert/remove 가 일어났다면 무시
-        if (state.generation !== startGen) return { isLoading: false }
-        const last = fetched[fetched.length - 1]
-        const nextCursor = last?.done_at ?? null
-        return {
-          items: [...state.items, ...fetched],
-          cursor: nextCursor,
-          hasMore: fetched.length === PAGE_SIZE && nextCursor !== null,
-          isLoading: false,
-        }
-      })
-    } catch (e) {
-      console.warn('Done todos 로드 실패:', e)
-      set({ isLoading: false })
-    }
-  },
-
-  revert: async (id: string) => {
-    try {
-      // iOS TodoEventUsecaseImple.revertCompleteTodo 와 동일 — plain revert 호출 후 응답의 todo 를 그대로 신뢰.
-      //   POST /v2/todos/dones/{id}/revert  (body 없음)
-      //   응답: { todo, detail } — RevertTodoResultMapper 와 정합
-      //
-      // iOS 는 응답 todo 를 sharedDataStore.todos[uuid] 에 그대로 저장하고, 화면에서 is_current / event_time 으로
-      // current/scheduled 노출 여부를 결정한다. 웹은 cache 가 분리(currentTodosCache / calendarEventsCache) 되어
-      // 있으니 응답 todo 의 is_current, event_time 을 그대로 신뢰해 양쪽에 적절히 add — 추측 분기 없이
-      // BFF 응답이 담은 형태가 진실의 원천(iOS 와 동일 시맨틱).
-      const response = await doneTodoApi.revertDoneTodo(id)
-      const restored = response?.todo
-      set(state => ({ items: state.items.filter(i => i.uuid !== id), generation: state.generation + 1 }))
-
-      if (restored) {
-        if (restored.event_time) {
-          useCalendarEventsCache.getState().addEvent({ type: 'todo', event: restored })
-        }
-        if (restored.is_current) {
-          useCurrentTodosCache.getState().addTodo(restored)
-        }
-      }
-      return restored as Todo
-    } catch (e) {
-      console.warn('Todo 되돌리기 실패:', e)
-      throw e
-    }
-  },
-
-  remove: async (id: string) => {
-    try {
-      await doneTodoApi.deleteDoneTodo(id)
-      set(state => ({ items: state.items.filter(i => i.uuid !== id), generation: state.generation + 1 }))
-    } catch (e) {
-      console.warn('Done todo 삭제 실패:', e)
-      throw e
-    }
-  },
 }))

--- a/tests/components/ArchivePanel.test.tsx
+++ b/tests/components/ArchivePanel.test.tsx
@@ -3,6 +3,9 @@ import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ArchivePanel } from '../../src/components/ArchivePanel'
 import { useDoneTodosCache } from '../../src/repositories/caches/doneTodosCache'
+import { RepositoriesProvider } from '../../src/composition/RepositoriesProvider'
+import type { Repositories } from '../../src/composition/container'
+import type { DoneTodoRepository } from '../../src/repositories/DoneTodoRepository'
 
 const sampleItems = [
   { uuid: 'd-1', name: '완료된 일 A', done_at: 1714000000, event_tag_id: null },
@@ -10,7 +13,6 @@ const sampleItems = [
 
 vi.mock('../../src/api/doneTodoApi', () => ({
   doneTodoApi: {
-    // ArchivePanel mount 시 reset + fetchNext 가 실제로 흘러 들어가도록 응답을 보유 형태로 모킹
     getDoneTodos: vi.fn(async () => sampleItems),
     deleteDoneTodo: vi.fn(async () => ({ status: 'ok' })),
     revertDoneTodo: vi.fn(async () => ({})),
@@ -34,6 +36,44 @@ class MockIntersectionObserver {
   constructor(_cb: IntersectionObserverCallback) {}
 }
 
+function makeFakeDoneTodoRepo(overrides: Partial<DoneTodoRepository> = {}): DoneTodoRepository {
+  return {
+    fetchNextPage: overrides.fetchNextPage ?? vi.fn(async () => {
+      // mount 시 fetchNextPage 가 실제로 cache 를 채우도록 appendPage 호출
+      useDoneTodosCache.getState().appendPage(sampleItems as any, null, false)
+    }),
+    revert: overrides.revert ?? vi.fn(async () => ({ uuid: 'd-1', name: 't-1', is_current: true })),
+    remove: overrides.remove ?? vi.fn(async () => {}),
+    getSnapshot: vi.fn(() => []),
+  } as unknown as DoneTodoRepository
+}
+
+function makeFakeRepos(doneTodoRepo: DoneTodoRepository): Repositories {
+  return {
+    eventRepo: {} as any,
+    eventDetailRepo: {} as any,
+    tagRepo: {} as any,
+    holidayRepo: {} as any,
+    doneTodoRepo,
+    foremostEventRepo: {} as any,
+    authRepo: {} as any,
+    settingsRepo: {} as any,
+    localStorageContainer: {} as any,
+  }
+}
+
+function renderArchivePanel(overrides: Partial<{
+  doneTodoRepo: DoneTodoRepository
+  onDoneTodoClick: (...args: any[]) => void
+}> = {}) {
+  const doneTodoRepo = overrides.doneTodoRepo ?? makeFakeDoneTodoRepo()
+  return render(
+    <RepositoriesProvider value={makeFakeRepos(doneTodoRepo)}>
+      <ArchivePanel onDoneTodoClick={overrides.onDoneTodoClick} />
+    </RepositoriesProvider>
+  )
+}
+
 beforeEach(() => {
   vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
   useDoneTodosCache.getState().reset()
@@ -43,9 +83,9 @@ describe('ArchivePanel', () => {
   it('done todo 행을 클릭하면 onDoneTodoClick 이 done todo 와 anchorRect 와 함께 호출된다', async () => {
     const onDoneTodoClick = vi.fn()
     const user = userEvent.setup()
-    render(<ArchivePanel onDoneTodoClick={onDoneTodoClick} />)
+    renderArchivePanel({ onDoneTodoClick })
 
-    // mount 시 fetchNext 가 흘러 들어와 행이 노출될 때까지 대기
+    // mount 시 fetchNextPage 가 흘러 들어와 행이 노출될 때까지 대기
     const row = await screen.findByText('완료된 일 A')
     await user.click(row)
 
@@ -58,7 +98,7 @@ describe('ArchivePanel', () => {
   it('되돌리기 아이콘 버튼 클릭은 행 onClick 과 분리되어 onDoneTodoClick 이 호출되지 않는다', async () => {
     const onDoneTodoClick = vi.fn()
     const user = userEvent.setup()
-    render(<ArchivePanel onDoneTodoClick={onDoneTodoClick} />)
+    renderArchivePanel({ onDoneTodoClick })
 
     await screen.findByText('완료된 일 A')
     await user.click(screen.getByRole('button', { name: '되돌리기' }))
@@ -68,7 +108,7 @@ describe('ArchivePanel', () => {
   it('삭제 아이콘 버튼 클릭은 행 onClick 과 분리되어 onDoneTodoClick 이 호출되지 않는다', async () => {
     const onDoneTodoClick = vi.fn()
     const user = userEvent.setup()
-    render(<ArchivePanel onDoneTodoClick={onDoneTodoClick} />)
+    renderArchivePanel({ onDoneTodoClick })
 
     await screen.findByText('완료된 일 A')
     await user.click(screen.getByRole('button', { name: '삭제' }))
@@ -76,7 +116,7 @@ describe('ArchivePanel', () => {
   })
 
   it('onDoneTodoClick prop 없이도 정상 렌더된다 (콜백 미주입 호환)', async () => {
-    render(<ArchivePanel />)
+    renderArchivePanel()
     await waitFor(() => expect(screen.getByText('완료된 일 A')).toBeInTheDocument())
   })
 })

--- a/tests/components/DoneTodoDetail/DoneTodoDetailPopover.test.tsx
+++ b/tests/components/DoneTodoDetail/DoneTodoDetailPopover.test.tsx
@@ -4,6 +4,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { DoneTodoDetailPopover } from '../../../src/components/DoneTodoDetail/DoneTodoDetailPopover'
 import { useDoneTodosCache } from '../../../src/repositories/caches/doneTodosCache'
 import { useCurrentTodosCache } from '../../../src/repositories/caches/currentTodosCache'
+import { RepositoriesProvider } from '../../../src/composition/RepositoriesProvider'
+import type { Repositories } from '../../../src/composition/container'
+import type { DoneTodoRepository } from '../../../src/repositories/DoneTodoRepository'
 import type { DoneTodo } from '../../../src/models'
 import { useIsMobile } from '../../../src/hooks/useIsMobile'
 
@@ -57,6 +60,34 @@ beforeEach(() => {
   useCurrentTodosCache.getState().reset()
 })
 
+function makeFakeDoneTodoRepo(): DoneTodoRepository {
+  return {
+    fetchNextPage: vi.fn(async () => {}),
+    revert: vi.fn(async (id: string) => {
+      useDoneTodosCache.getState().removeItem(id)
+      return { uuid: 'todo-1', name: '완료된 일', is_current: true } as any
+    }),
+    remove: vi.fn(async (id: string) => {
+      useDoneTodosCache.getState().removeItem(id)
+    }),
+    getSnapshot: vi.fn(() => []),
+  } as unknown as DoneTodoRepository
+}
+
+function makeFakeRepos(doneTodoRepo: DoneTodoRepository): Repositories {
+  return {
+    eventRepo: {} as any,
+    eventDetailRepo: {} as any,
+    tagRepo: {} as any,
+    holidayRepo: {} as any,
+    doneTodoRepo,
+    foremostEventRepo: {} as any,
+    authRepo: {} as any,
+    settingsRepo: {} as any,
+    localStorageContainer: {} as any,
+  }
+}
+
 function renderPopover(overrides: Partial<{
   doneTodo: DoneTodo
   onClose: () => void
@@ -66,13 +97,15 @@ function renderPopover(overrides: Partial<{
 }> = {}) {
   const anchor = 'anchorRect' in overrides ? overrides.anchorRect : anchorRect
   return render(
-    <DoneTodoDetailPopover
-      doneTodo={overrides.doneTodo ?? sample}
-      anchorRect={anchor}
-      onClose={overrides.onClose ?? vi.fn()}
-      onReverted={overrides.onReverted ?? vi.fn()}
-      onDeleted={overrides.onDeleted ?? vi.fn()}
-    />,
+    <RepositoriesProvider value={makeFakeRepos(makeFakeDoneTodoRepo())}>
+      <DoneTodoDetailPopover
+        doneTodo={overrides.doneTodo ?? sample}
+        anchorRect={anchor}
+        onClose={overrides.onClose ?? vi.fn()}
+        onReverted={overrides.onReverted ?? vi.fn()}
+        onDeleted={overrides.onDeleted ?? vi.fn()}
+      />
+    </RepositoriesProvider>,
   )
 }
 

--- a/tests/components/DoneTodoDetail/useDoneTodoDetailPopoverViewModel.test.tsx
+++ b/tests/components/DoneTodoDetail/useDoneTodoDetailPopoverViewModel.test.tsx
@@ -3,6 +3,9 @@ import { renderHook, waitFor, act } from '@testing-library/react'
 import { useDoneTodoDetailPopoverViewModel } from '../../../src/components/DoneTodoDetail/useDoneTodoDetailPopoverViewModel'
 import { useDoneTodosCache } from '../../../src/repositories/caches/doneTodosCache'
 import { useCurrentTodosCache } from '../../../src/repositories/caches/currentTodosCache'
+import { RepositoriesProvider } from '../../../src/composition/RepositoriesProvider'
+import type { Repositories } from '../../../src/composition/container'
+import type { DoneTodoRepository } from '../../../src/repositories/DoneTodoRepository'
 import type { DoneTodo } from '../../../src/models'
 
 const mockGetDoneTodoDetail = vi.fn()
@@ -30,6 +33,43 @@ const sample: DoneTodo = {
   notification_options: null,
 }
 
+function makeFakeDoneTodoRepo(overrides: Partial<DoneTodoRepository> = {}): DoneTodoRepository {
+  return {
+    fetchNextPage: vi.fn(async () => {}),
+    revert: overrides.revert ?? vi.fn(async (id: string) => {
+      // 실제 revert 처럼 cache 에서 제거
+      useDoneTodosCache.getState().removeItem(id)
+      return { uuid: 'todo-1', name: '완료된 일', is_current: true } as any
+    }),
+    remove: overrides.remove ?? vi.fn(async (id: string) => {
+      useDoneTodosCache.getState().removeItem(id)
+    }),
+    getSnapshot: vi.fn(() => []),
+  } as unknown as DoneTodoRepository
+}
+
+function makeFakeRepos(doneTodoRepo: DoneTodoRepository): Repositories {
+  return {
+    eventRepo: {} as any,
+    eventDetailRepo: {} as any,
+    tagRepo: {} as any,
+    holidayRepo: {} as any,
+    doneTodoRepo,
+    foremostEventRepo: {} as any,
+    authRepo: {} as any,
+    settingsRepo: {} as any,
+    localStorageContainer: {} as any,
+  }
+}
+
+function makeWrapper(doneTodoRepo: DoneTodoRepository) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <RepositoriesProvider value={makeFakeRepos(doneTodoRepo)}>
+      {children}
+    </RepositoriesProvider>
+  )
+}
+
 beforeEach(() => {
   mockGetDoneTodoDetail.mockReset()
   mockRevertDoneTodo.mockReset().mockResolvedValue({
@@ -45,7 +85,9 @@ describe('useDoneTodoDetailPopoverViewModel', () => {
   it('mount 시 done todo uuid 로 detail 을 조회해 노출한다', async () => {
     mockGetDoneTodoDetail.mockResolvedValueOnce({ url: 'https://x', memo: 'm', place: null })
 
-    const { result } = renderHook(() => useDoneTodoDetailPopoverViewModel(sample))
+    const { result } = renderHook(() => useDoneTodoDetailPopoverViewModel(sample), {
+      wrapper: makeWrapper(makeFakeDoneTodoRepo()),
+    })
 
     await waitFor(() => expect(result.current.detail).toEqual({ url: 'https://x', memo: 'm', place: null }))
   })
@@ -53,7 +95,9 @@ describe('useDoneTodoDetailPopoverViewModel', () => {
   it('detail 조회가 실패하면 detail 은 null 로 떨어져도 hook 자체는 정상 사용 가능하다', async () => {
     mockGetDoneTodoDetail.mockRejectedValueOnce(new Error('404'))
 
-    const { result } = renderHook(() => useDoneTodoDetailPopoverViewModel(sample))
+    const { result } = renderHook(() => useDoneTodoDetailPopoverViewModel(sample), {
+      wrapper: makeWrapper(makeFakeDoneTodoRepo()),
+    })
 
     // 실패 시에도 detail 은 null 로 안정화되고 revert/remove 는 사용 가능
     await waitFor(() => expect(result.current.detail).toBeNull())
@@ -64,7 +108,9 @@ describe('useDoneTodoDetailPopoverViewModel', () => {
   it('revert 호출 시 cache 에서 항목이 사라진다', async () => {
     mockGetDoneTodoDetail.mockResolvedValueOnce(null)
 
-    const { result } = renderHook(() => useDoneTodoDetailPopoverViewModel(sample))
+    const { result } = renderHook(() => useDoneTodoDetailPopoverViewModel(sample), {
+      wrapper: makeWrapper(makeFakeDoneTodoRepo()),
+    })
 
     await act(async () => {
       await result.current.revert()
@@ -76,7 +122,9 @@ describe('useDoneTodoDetailPopoverViewModel', () => {
   it('remove 호출 시 cache 에서 항목이 사라진다', async () => {
     mockGetDoneTodoDetail.mockResolvedValueOnce(null)
 
-    const { result } = renderHook(() => useDoneTodoDetailPopoverViewModel(sample))
+    const { result } = renderHook(() => useDoneTodoDetailPopoverViewModel(sample), {
+      wrapper: makeWrapper(makeFakeDoneTodoRepo()),
+    })
 
     await act(async () => {
       await result.current.remove()

--- a/tests/pages/DoneTodosPage.test.tsx
+++ b/tests/pages/DoneTodosPage.test.tsx
@@ -3,23 +3,12 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { ArchivePanel } from '../../src/components/ArchivePanel'
-import { doneTodoApi } from '../../src/api/doneTodoApi'
 import { useDoneTodosCache } from '../../src/repositories/caches/doneTodosCache'
 import { useEventTagListCache } from '../../src/repositories/caches/eventTagListCache'
-import { todoApi } from '../../src/api/todoApi'
 import { useToastStore } from '../../src/stores/toastStore'
-
-vi.mock('../../src/api/doneTodoApi', () => ({
-  doneTodoApi: {
-    getDoneTodos: vi.fn(),
-    deleteDoneTodo: vi.fn(),
-    revertDoneTodo: vi.fn(),
-  },
-}))
-
-vi.mock('../../src/api/todoApi', () => ({
-  todoApi: { getCurrentTodos: vi.fn() },
-}))
+import { RepositoriesProvider } from '../../src/composition/RepositoriesProvider'
+import type { Repositories } from '../../src/composition/container'
+import type { DoneTodoRepository } from '../../src/repositories/DoneTodoRepository'
 
 vi.mock('../../src/api/settingApi', () => ({
   settingApi: { getDefaultTagColors: async () => null },
@@ -44,6 +33,29 @@ const makeDone = (id: string) => ({
   event_time: null, event_tag_id: null,
 })
 
+function makeFakeDoneTodoRepo(overrides: Partial<DoneTodoRepository> = {}): DoneTodoRepository {
+  return {
+    fetchNextPage: overrides.fetchNextPage ?? vi.fn(async () => {}),
+    revert: overrides.revert ?? vi.fn(async () => { throw new Error('not configured') }),
+    remove: overrides.remove ?? vi.fn(async () => { throw new Error('not configured') }),
+    getSnapshot: vi.fn(() => []),
+  } as unknown as DoneTodoRepository
+}
+
+function makeFakeRepos(doneTodoRepo: DoneTodoRepository): Repositories {
+  return {
+    eventRepo: {} as any,
+    eventDetailRepo: {} as any,
+    tagRepo: {} as any,
+    holidayRepo: {} as any,
+    doneTodoRepo,
+    foremostEventRepo: {} as any,
+    authRepo: {} as any,
+    settingsRepo: {} as any,
+    localStorageContainer: {} as any,
+  }
+}
+
 describe('DoneTodosPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -53,16 +65,23 @@ describe('DoneTodosPage', () => {
     vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
   })
 
-  function renderPage() {
-    return render(<MemoryRouter><ArchivePanel /></MemoryRouter>)
+  function renderPage(doneTodoRepo: DoneTodoRepository) {
+    return render(
+      <RepositoriesProvider value={makeFakeRepos(doneTodoRepo)}>
+        <MemoryRouter><ArchivePanel /></MemoryRouter>
+      </RepositoriesProvider>
+    )
   }
 
   it('마운트 시 done todos를 불러와 목록을 렌더한다', async () => {
     // given
-    vi.mocked(doneTodoApi.getDoneTodos).mockResolvedValue([makeDone('d1'), makeDone('d2')])
+    const fetchNextPage = vi.fn(async () => {
+      useDoneTodosCache.getState().appendPage([makeDone('d1'), makeDone('d2')] as any, null, false)
+    })
+    const doneTodoRepo = makeFakeDoneTodoRepo({ fetchNextPage })
 
     // when
-    renderPage()
+    renderPage(doneTodoRepo)
 
     // then
     await waitFor(() => {
@@ -72,11 +91,14 @@ describe('DoneTodosPage', () => {
   })
 
   it('모든 항목을 불러오면 "모두 표시됨" 텍스트가 나타난다', async () => {
-    // given: PAGE_SIZE(20)보다 적게 반환
-    vi.mocked(doneTodoApi.getDoneTodos).mockResolvedValue([makeDone('d1')])
+    // given: 1개만 반환 → hasMore = false
+    const fetchNextPage = vi.fn(async () => {
+      useDoneTodosCache.getState().appendPage([makeDone('d1')] as any, null, false)
+    })
+    const doneTodoRepo = makeFakeDoneTodoRepo({ fetchNextPage })
 
     // when
-    renderPage()
+    renderPage(doneTodoRepo)
 
     // then
     await waitFor(() => {
@@ -86,10 +108,15 @@ describe('DoneTodosPage', () => {
 
   it('삭제 버튼 클릭 → 확인 다이얼로그 → 확인 시 항목이 제거된다', async () => {
     // given
-    vi.mocked(doneTodoApi.getDoneTodos).mockResolvedValue([makeDone('d1')])
-    vi.mocked(doneTodoApi.deleteDoneTodo).mockResolvedValue({ status: 'ok' })
+    const fetchNextPage = vi.fn(async () => {
+      useDoneTodosCache.getState().appendPage([makeDone('d1')] as any, null, false)
+    })
+    const remove = vi.fn(async (id: string) => {
+      useDoneTodosCache.getState().removeItem(id)
+    })
+    const doneTodoRepo = makeFakeDoneTodoRepo({ fetchNextPage, remove })
 
-    renderPage()
+    renderPage(doneTodoRepo)
     await waitFor(() => screen.getByText('완료-d1'))
 
     // when: 삭제 버튼 → 다이얼로그 확인
@@ -104,11 +131,14 @@ describe('DoneTodosPage', () => {
 
   it('되돌리기 실패 시 에러 토스트가 표시된다', async () => {
     // given
-    vi.mocked(doneTodoApi.getDoneTodos).mockResolvedValue([makeDone('d1')])
-    vi.mocked(doneTodoApi.revertDoneTodo).mockRejectedValue(new Error('fail'))
+    const fetchNextPage = vi.fn(async () => {
+      useDoneTodosCache.getState().appendPage([makeDone('d1')] as any, null, false)
+    })
+    const revert = vi.fn(async () => { throw new Error('fail') })
+    const doneTodoRepo = makeFakeDoneTodoRepo({ fetchNextPage, revert })
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    renderPage()
+    renderPage(doneTodoRepo)
     await waitFor(() => screen.getByText('완료-d1'))
 
     // when
@@ -124,11 +154,14 @@ describe('DoneTodosPage', () => {
 
   it('삭제 실패 시 에러 토스트가 표시된다', async () => {
     // given
-    vi.mocked(doneTodoApi.getDoneTodos).mockResolvedValue([makeDone('d1')])
-    vi.mocked(doneTodoApi.deleteDoneTodo).mockRejectedValue(new Error('fail'))
+    const fetchNextPage = vi.fn(async () => {
+      useDoneTodosCache.getState().appendPage([makeDone('d1')] as any, null, false)
+    })
+    const remove = vi.fn(async () => { throw new Error('fail') })
+    const doneTodoRepo = makeFakeDoneTodoRepo({ fetchNextPage, remove })
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    renderPage()
+    renderPage(doneTodoRepo)
     await waitFor(() => screen.getByText('완료-d1'))
 
     // when: 삭제 버튼 → 다이얼로그 확인
@@ -144,15 +177,17 @@ describe('DoneTodosPage', () => {
   })
 
   it('되돌리기 버튼 클릭 시 항목이 목록에서 제거된다', async () => {
-    // given — iOS RevertTodoResultMapper 와 정합한 { todo, detail } 응답
-    vi.mocked(doneTodoApi.getDoneTodos).mockResolvedValue([makeDone('d1')])
-    vi.mocked(doneTodoApi.revertDoneTodo).mockResolvedValue({
-      todo: { uuid: 'todo-1', name: '완료-d1', is_current: true } as any,
-      detail: null,
+    // given
+    const fetchNextPage = vi.fn(async () => {
+      useDoneTodosCache.getState().appendPage([makeDone('d1')] as any, null, false)
     })
-    vi.mocked(todoApi.getCurrentTodos).mockResolvedValue([])
+    const revert = vi.fn(async (id: string) => {
+      useDoneTodosCache.getState().removeItem(id)
+      return { uuid: 'todo-1', name: '완료-d1', is_current: true } as any
+    })
+    const doneTodoRepo = makeFakeDoneTodoRepo({ fetchNextPage, revert })
 
-    renderPage()
+    renderPage(doneTodoRepo)
     await waitFor(() => screen.getByText('완료-d1'))
 
     // when

--- a/tests/repositories/DoneTodoRepository.race.test.ts
+++ b/tests/repositories/DoneTodoRepository.race.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { DoneTodoRepository } from '../../src/repositories/DoneTodoRepository'
+import { LocalStorageContainer } from '../../src/repositories/local-storage/LocalStorageContainer'
+import { useDoneTodosCache } from '../../src/repositories/caches/doneTodosCache'
+import type { DoneTodo } from '../../src/models/DoneTodo'
+
+const TEST_UID = 'done-race'
+async function deleteDb(uid: string) {
+  await new Promise<void>((r) => {
+    const req = indexedDB.deleteDatabase(`todocal-cache:${uid}`)
+    req.onsuccess = req.onerror = req.onblocked = () => r()
+  })
+}
+
+const doneOf = (uuid: string, done_at = 1000): DoneTodo =>
+  ({ uuid, origin_event_id: 'o-' + uuid, name: 'd-' + uuid, done_at } as DoneTodo)
+
+describe('DoneTodoRepository.fetchNextPage — generation 보호 (race condition)', () => {
+  let container: LocalStorageContainer
+  let doneApi: { getDoneTodos: ReturnType<typeof vi.fn>; deleteDoneTodo: ReturnType<typeof vi.fn>; revertDoneTodo: ReturnType<typeof vi.fn> }
+
+  beforeEach(async () => {
+    container = new LocalStorageContainer()
+    await container.init(TEST_UID)
+    useDoneTodosCache.getState().reset()
+    doneApi = { getDoneTodos: vi.fn(), deleteDoneTodo: vi.fn(), revertDoneTodo: vi.fn() }
+  })
+
+  afterEach(async () => {
+    await container.dispose()
+    await deleteDb(TEST_UID)
+    useDoneTodosCache.getState().reset()
+  })
+
+  it('fetchNextPage 도중 removeItem 이 일어나면 stale 응답이 무시된다 (C1.1)', async () => {
+    // given: LocalStorage 에 기존 항목 저장
+    await container.doneTodo().saveDoneTodos([doneOf('d-existing')])
+
+    // Remote 가 응답 대기 상태로 고정 — 'd-stale' 을 반환 예정
+    const fetchedItems = [doneOf('d-stale')]
+    let resolveFetch!: (v: DoneTodo[]) => void
+    doneApi.getDoneTodos.mockImplementation(
+      () => new Promise<DoneTodo[]>(r => { resolveFetch = r })
+    )
+
+    const repo = new DoneTodoRepository({ api: doneApi as any, localStorageContainer: container })
+
+    // when: fetchNextPage 시작 — Remote 응답 대기 중
+    const fetchPromise = repo.fetchNextPage()
+    // cache-first 단계(LocalStorage read)가 완료될 때까지 대기
+    await new Promise(r => setTimeout(r, 20))
+
+    // 그 사이 removeItem 으로 generation bump
+    useDoneTodosCache.getState().removeItem('d-existing')
+
+    // 이제 Remote 응답 도착
+    resolveFetch(fetchedItems)
+    await fetchPromise
+
+    // then: stale 응답이 무시되어 'd-stale' 이 메모리에 없음
+    const items = useDoneTodosCache.getState().items
+    expect(items.find(i => i.uuid === 'd-stale')).toBeUndefined()
+  })
+
+  it('fetchNextPage 도중 reset 이 일어나면 stale 응답이 무시된다 (C1.1 — reset 경로)', async () => {
+    // given: Remote 응답 대기 상태
+    const fetchedItems = [doneOf('d-from-server')]
+    let resolveFetch!: (v: DoneTodo[]) => void
+    doneApi.getDoneTodos.mockImplementation(
+      () => new Promise<DoneTodo[]>(r => { resolveFetch = r })
+    )
+
+    const repo = new DoneTodoRepository({ api: doneApi as any, localStorageContainer: container })
+
+    // when: fetchNextPage 시작
+    const fetchPromise = repo.fetchNextPage()
+    await new Promise(r => setTimeout(r, 20))
+
+    // 진행 중에 reset (generation bump)
+    useDoneTodosCache.getState().reset()
+
+    // Remote 응답 도착
+    resolveFetch(fetchedItems)
+    await fetchPromise
+
+    // then: stale 응답이 무시됨
+    const items = useDoneTodosCache.getState().items
+    expect(items.find(i => i.uuid === 'd-from-server')).toBeUndefined()
+  })
+})

--- a/tests/repositories/DoneTodoRepository.test.ts
+++ b/tests/repositories/DoneTodoRepository.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 // Firebase 연쇄 초기화 차단
 vi.mock('../../src/firebase', () => ({ getAuthInstance: vi.fn(() => ({})) }))
-// doneTodoApi는 doneTodosCache 내부에서도 임포트되므로 차단
 vi.mock('../../src/api/doneTodoApi', () => ({ doneTodoApi: {} }))
 
 import { DoneTodoRepository } from '../../src/repositories/DoneTodoRepository'
 import { useDoneTodosCache } from '../../src/repositories/caches/doneTodosCache'
+import { useCurrentTodosCache } from '../../src/repositories/caches/currentTodosCache'
 import type { DoneTodoApi } from '../../src/repositories/DoneTodoRepository'
 import type { DoneTodo } from '../../src/models'
 import type { Todo } from '../../src/models'
@@ -31,6 +31,7 @@ function makeFakeApi(overrides: Partial<DoneTodoApi> = {}): DoneTodoApi {
 
 function resetCache() {
   useDoneTodosCache.getState().reset()
+  useCurrentTodosCache.getState().reset()
 }
 
 // ──────────────────────── fetchNextPage ────────────────────────
@@ -101,6 +102,21 @@ describe('DoneTodoRepository — revert', () => {
     expect(result.uuid).toBe('d1')
     expect(repo.getSnapshot().find(i => i.uuid === 'd1')).toBeUndefined()
     expect(repo.getSnapshot().find(i => i.uuid === 'd2')).toBeDefined()
+  })
+
+  it('revert 된 todo 가 is_current 이면 currentTodosCache 에 추가된다', async () => {
+    // given
+    useDoneTodosCache.setState({ items: [makeDone('d3')] })
+    const restored: Todo = { ...makeTodo('d3'), is_current: true }
+    const repo = new DoneTodoRepository({
+      api: makeFakeApi({ revertDoneTodo: vi.fn(async () => ({ todo: restored, detail: null })) }),
+    })
+
+    // when
+    await repo.revert('d3')
+
+    // then: currentTodosCache 에 추가됨
+    expect(useCurrentTodosCache.getState().todos.find(t => t.uuid === restored.uuid)).toBeDefined()
   })
 })
 

--- a/tests/repositories/DoneTodoRepository.writeSync.test.ts
+++ b/tests/repositories/DoneTodoRepository.writeSync.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { DoneTodoRepository } from '../../src/repositories/DoneTodoRepository'
+import { LocalStorageContainer } from '../../src/repositories/local-storage/LocalStorageContainer'
+import type { DoneTodo } from '../../src/models/DoneTodo'
+import type { Todo } from '../../src/models/Todo'
+
+const TEST_UID = 'done-write'
+const doneOf = (uuid: string): DoneTodo => ({ uuid, origin_event_id: 'o-' + uuid, name: 'd-' + uuid, done_at: 1000 } as DoneTodo)
+const todoOf = (uuid: string): Todo => ({
+  uuid, name: 't-' + uuid, is_current: false, event_tag_id: null,
+  event_time: { time_type: 'at', timestamp: 1000 }, repeating: null, notification_options: null,
+} as Todo)
+
+async function deleteDb(uid: string) {
+  await new Promise<void>((r) => {
+    const req = indexedDB.deleteDatabase(`todocal-cache:${uid}`)
+    req.onsuccess = req.onerror = req.onblocked = () => r()
+  })
+}
+
+describe('DoneTodoRepository — mutation LocalStorage write sync', () => {
+  let container: LocalStorageContainer
+  let doneApi: { getDoneTodos: ReturnType<typeof vi.fn>; deleteDoneTodo: ReturnType<typeof vi.fn>; revertDoneTodo: ReturnType<typeof vi.fn> }
+
+  beforeEach(async () => {
+    container = new LocalStorageContainer()
+    await container.init(TEST_UID)
+    doneApi = { getDoneTodos: vi.fn(), deleteDoneTodo: vi.fn(), revertDoneTodo: vi.fn() }
+  })
+
+  afterEach(async () => {
+    await container.dispose()
+    await deleteDb(TEST_UID)
+  })
+
+  it('revert 후 LocalStorage 의 doneTodo 가 제거된다', async () => {
+    await container.doneTodo().saveDoneTodos([doneOf('d-1')])
+    doneApi.revertDoneTodo.mockResolvedValue({ todo: todoOf('o-d-1') })
+
+    const repo = new DoneTodoRepository({ api: doneApi as any, localStorageContainer: container })
+    await repo.revert('d-1')
+
+    expect(await container.doneTodo().loadDoneTodo('d-1')).toBeNull()
+  })
+
+  it('remove 후 LocalStorage 의 doneTodo 가 제거된다', async () => {
+    await container.doneTodo().saveDoneTodos([doneOf('d-1')])
+    doneApi.deleteDoneTodo.mockResolvedValue({ status: 'ok' })
+
+    const repo = new DoneTodoRepository({ api: doneApi as any, localStorageContainer: container })
+    await repo.remove('d-1')
+
+    expect(await container.doneTodo().loadDoneTodo('d-1')).toBeNull()
+  })
+
+  it('localStorageContainer 미주입 호환성', async () => {
+    doneApi.deleteDoneTodo.mockResolvedValue({ status: 'ok' })
+    const repo = new DoneTodoRepository({ api: doneApi as any })
+    await expect(repo.remove('d-1')).resolves.toBeUndefined()
+  })
+})

--- a/tests/repositories/DoneTodoRepository.writeSync.test.ts
+++ b/tests/repositories/DoneTodoRepository.writeSync.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { DoneTodoRepository } from '../../src/repositories/DoneTodoRepository'
 import { LocalStorageContainer } from '../../src/repositories/local-storage/LocalStorageContainer'
+import { useDoneTodosCache } from '../../src/repositories/caches/doneTodosCache'
+import { useCalendarEventsCache } from '../../src/repositories/caches/calendarEventsCache'
+import { useCurrentTodosCache } from '../../src/repositories/caches/currentTodosCache'
 import type { DoneTodo } from '../../src/models/DoneTodo'
 import type { Todo } from '../../src/models/Todo'
 
@@ -41,6 +44,60 @@ describe('DoneTodoRepository — mutation LocalStorage write sync', () => {
     await repo.revert('d-1')
 
     expect(await container.doneTodo().loadDoneTodo('d-1')).toBeNull()
+  })
+
+  it('revert 후 복원된 todo 가 LocalStorage todo 에 저장된다 (I2)', async () => {
+    // given
+    await container.doneTodo().saveDoneTodos([doneOf('d-1')])
+    const restored = todoOf('o-d-1')
+    doneApi.revertDoneTodo.mockResolvedValue({ todo: restored })
+
+    const repo = new DoneTodoRepository({ api: doneApi as any, localStorageContainer: container })
+
+    // when
+    await repo.revert('d-1')
+
+    // then: 복원된 todo 가 LocalStorage todo store 에 저장됐는지 확인
+    expect(await container.todo().loadTodo(restored.uuid)).not.toBeNull()
+  })
+
+  it('revert 된 todo 가 event_time 을 가지면 calendarEventsCache 에 추가된다 (I2)', async () => {
+    // given: event_time 을 보유한 todo
+    const todoWithTime: Todo = {
+      ...todoOf('o-d-2'),
+      event_time: { time_type: 'at', timestamp: 1000 },
+      is_current: false,
+    }
+    await container.doneTodo().saveDoneTodos([doneOf('d-2')])
+    doneApi.revertDoneTodo.mockResolvedValue({ todo: todoWithTime })
+
+    useCalendarEventsCache.getState().reset()
+    const repo = new DoneTodoRepository({ api: doneApi as any, localStorageContainer: container })
+
+    // when
+    await repo.revert('d-2')
+
+    // then: calendarEventsCache 에 해당 todo 가 포함됨
+    const events = useCalendarEventsCache.getState().eventsByDate
+    const found = Array.from(events.values()).flat().find(e => e.type === 'todo' && e.event.uuid === todoWithTime.uuid)
+    expect(found).toBeDefined()
+  })
+
+  it('revert 된 todo 가 is_current 이면 currentTodosCache 에 추가된다 (I2)', async () => {
+    // given: is_current 인 todo
+    const currentTodo: Todo = { ...todoOf('o-d-3'), is_current: true, event_time: null }
+    await container.doneTodo().saveDoneTodos([doneOf('d-3')])
+    doneApi.revertDoneTodo.mockResolvedValue({ todo: currentTodo })
+
+    useCurrentTodosCache.getState().reset()
+    const repo = new DoneTodoRepository({ api: doneApi as any, localStorageContainer: container })
+
+    // when
+    await repo.revert('d-3')
+
+    // then: currentTodosCache 에 해당 todo 가 포함됨
+    const todos = useCurrentTodosCache.getState().todos
+    expect(todos.find(t => t.uuid === currentTodo.uuid)).toBeDefined()
   })
 
   it('remove 후 LocalStorage 의 doneTodo 가 제거된다', async () => {

--- a/tests/repositories/EventDetailRepository.test.ts
+++ b/tests/repositories/EventDetailRepository.test.ts
@@ -106,7 +106,7 @@ describe('EventDetailRepository', () => {
 
     // when: 1차 get → invalidate → 2차 get
     await repo.get('e5')
-    repo.invalidate('e5')
+    await repo.invalidate('e5')
     const result = await repo.get('e5')
 
     // then: invalidate 이후 서버에서 새 응답을 받아 반환

--- a/tests/repositories/EventDetailRepository.writeSync.test.ts
+++ b/tests/repositories/EventDetailRepository.writeSync.test.ts
@@ -65,4 +65,54 @@ describe('EventDetailRepository — read cache-first + write sync', () => {
 
     expect(result?.memo).toBe('r')
   })
+
+  it('invalidate 후 LocalStorage 에서도 제거된다 (C2)', async () => {
+    // given: LocalStorage 에 저장된 상태
+    const detail: EventDetail = { place: 'home', url: null, memo: 'cached' } as EventDetail
+    await container.eventDetail().saveDetail('e-inv', detail)
+    api.getEventDetail.mockResolvedValue({ place: 'remote', url: null, memo: 'remote' } as EventDetail)
+
+    const repo = new EventDetailRepository({ api: api as any, localStorageContainer: container })
+
+    // when: invalidate
+    await repo.invalidate('e-inv')
+
+    // then: LocalStorage 에서 제거됐는지 확인
+    expect(await container.eventDetail().loadDetail('e-inv')).toBeNull()
+  })
+
+  it('get 도중 save 가 완료되면 bg refresh 가 stale Remote 로 덮어쓰지 않는다 (I1)', async () => {
+    // given: LocalStorage 에 cached 값이 있어 bg refresh 가 시작되도록 설정
+    const cachedDetail: EventDetail = { place: 'cached', url: null, memo: 'cached' } as EventDetail
+    await container.eventDetail().saveDetail('e-race', cachedDetail)
+
+    // bg refresh 가 완료되기 전에 save 가 먼저 끝나도록 bg refresh 를 지연
+    let bgRefreshResolve!: () => void
+    const remoteAfterBg: EventDetail = { place: 'remote-stale', url: null, memo: 'remote-stale' } as EventDetail
+    api.getEventDetail.mockReturnValueOnce(
+      new Promise<EventDetail>(resolve => { bgRefreshResolve = () => resolve(remoteAfterBg) })
+    )
+    const savedDetail: EventDetail = { place: 'saved-fresh', url: null, memo: 'saved-fresh' } as EventDetail
+    api.updateEventDetail.mockResolvedValue(savedDetail)
+
+    const repo = new EventDetailRepository({ api: api as any, localStorageContainer: container })
+
+    // when: get 을 먼저 호출 (LocalStorage cache-hit → bg refresh 시작)
+    const result = await repo.get('e-race')
+    expect(result?.memo).toBe('cached')
+
+    // save 완료 (generation bump)
+    await repo.save('e-race', { memo: 'x' } as EventDetail)
+
+    // 이제 bg refresh 완료시킴 (generation 이 올라간 상태라 적용되지 않아야 함)
+    bgRefreshResolve()
+    // bg refresh task 가 완료될 때까지 microtask 소진
+    await new Promise(r => setTimeout(r, 10))
+
+    // then: 여전히 save 응답값이 get 에서 반환됨 (stale Remote 로 덮어쓰지 않음)
+    const afterRace = await repo.get('e-race')
+    expect(afterRace?.memo).toBe('saved-fresh')
+    // LocalStorage 에도 saved 값이 유지됨
+    expect((await container.eventDetail().loadDetail('e-race'))?.memo).toBe('saved-fresh')
+  })
 })

--- a/tests/repositories/EventDetailRepository.writeSync.test.ts
+++ b/tests/repositories/EventDetailRepository.writeSync.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { EventDetailRepository } from '../../src/repositories/EventDetailRepository'
+import { LocalStorageContainer } from '../../src/repositories/local-storage/LocalStorageContainer'
+import type { EventDetail } from '../../src/models/EventDetail'
+
+const TEST_UID = 'detail-write'
+async function deleteDb(uid: string) {
+  await new Promise<void>((r) => {
+    const req = indexedDB.deleteDatabase(`todocal-cache:${uid}`)
+    req.onsuccess = req.onerror = req.onblocked = () => r()
+  })
+}
+
+describe('EventDetailRepository — read cache-first + write sync', () => {
+  let container: LocalStorageContainer
+  let api: { getEventDetail: ReturnType<typeof vi.fn>; updateEventDetail: ReturnType<typeof vi.fn> }
+
+  beforeEach(async () => {
+    container = new LocalStorageContainer()
+    await container.init(TEST_UID)
+    api = { getEventDetail: vi.fn(), updateEventDetail: vi.fn() }
+  })
+
+  afterEach(async () => {
+    await container.dispose()
+    await deleteDb(TEST_UID)
+  })
+
+  it('get 은 LocalStorage 의 cached 가 있으면 그것을 즉시 반환 (cache-hit)', async () => {
+    const cached: EventDetail = { place: 'home', url: null, memo: 'cached' } as EventDetail
+    await container.eventDetail().saveDetail('e-1', cached)
+    api.getEventDetail.mockResolvedValue({ place: 'remote', url: null, memo: 'remote' } as EventDetail)
+
+    const repo = new EventDetailRepository({ api: api as any, localStorageContainer: container })
+    const result = await repo.get('e-1')
+
+    expect(result?.memo).toBe('cached')
+  })
+
+  it('cache miss 면 Remote 만으로 동작', async () => {
+    api.getEventDetail.mockResolvedValue({ place: 'remote', url: null, memo: 'remote' } as EventDetail)
+
+    const repo = new EventDetailRepository({ api: api as any, localStorageContainer: container })
+    const result = await repo.get('e-1')
+
+    expect(result?.memo).toBe('remote')
+    expect((await container.eventDetail().loadDetail('e-1'))?.memo).toBe('remote')
+  })
+
+  it('save 응답값이 LocalStorage 에 저장된다', async () => {
+    const detail: EventDetail = { place: 'a', url: null, memo: 'm' } as EventDetail
+    api.updateEventDetail.mockResolvedValue(detail)
+
+    const repo = new EventDetailRepository({ api: api as any, localStorageContainer: container })
+    await repo.save('e-1', detail)
+
+    expect((await container.eventDetail().loadDetail('e-1'))?.place).toBe('a')
+  })
+
+  it('localStorageContainer 미주입 호환성', async () => {
+    api.getEventDetail.mockResolvedValue({ place: 'r', url: null, memo: 'r' } as EventDetail)
+
+    const repo = new EventDetailRepository({ api: api as any })
+    const result = await repo.get('e-1')
+
+    expect(result?.memo).toBe('r')
+  })
+})

--- a/tests/repositories/EventRepository.writeSync.test.ts
+++ b/tests/repositories/EventRepository.writeSync.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { EventRepository } from '../../src/repositories/EventRepository'
+import { LocalStorageContainer } from '../../src/repositories/local-storage/LocalStorageContainer'
+import type { Todo } from '../../src/models/Todo'
+import type { Schedule } from '../../src/models/Schedule'
+
+const TEST_UID = 'write-sync-test'
+
+function todoOf(uuid: string, overrides: Partial<Todo> = {}): Todo {
+  return {
+    uuid, name: `t-${uuid}`,
+    is_current: false,
+    event_tag_id: null,
+    event_time: { time_type: 'at', timestamp: 1000 },
+    repeating: null,
+    notification_options: null,
+    ...overrides,
+  } as Todo
+}
+
+function scheduleOf(uuid: string, overrides: Partial<Schedule> = {}): Schedule {
+  return {
+    uuid, name: `s-${uuid}`,
+    event_tag_id: null,
+    event_time: { time_type: 'at', timestamp: 1000 },
+    repeating: null,
+    notification_options: null,
+    ...overrides,
+  } as Schedule
+}
+
+async function deleteDb(uid: string) {
+  await new Promise<void>((r) => {
+    const req = indexedDB.deleteDatabase(`todocal-cache:${uid}`)
+    req.onsuccess = req.onerror = req.onblocked = () => r()
+  })
+}
+
+function makeFakeApis() {
+  return {
+    todoApi: {
+      getTodos: vi.fn().mockResolvedValue([]),
+      getCurrentTodos: vi.fn().mockResolvedValue([]),
+      getUncompletedTodos: vi.fn().mockResolvedValue([]),
+      getTodo: vi.fn(),
+      createTodo: vi.fn(), updateTodo: vi.fn(), patchTodo: vi.fn(),
+      completeTodo: vi.fn(), replaceTodo: vi.fn(), deleteTodo: vi.fn(),
+    },
+    scheduleApi: {
+      getSchedules: vi.fn().mockResolvedValue([]),
+      getSchedule: vi.fn(),
+      createSchedule: vi.fn(), updateSchedule: vi.fn(),
+      excludeRepeating: vi.fn(), deleteSchedule: vi.fn(),
+    },
+  }
+}
+
+describe('EventRepository — Todo mutation LocalStorage write sync', () => {
+  let container: LocalStorageContainer
+
+  beforeEach(async () => {
+    container = new LocalStorageContainer()
+    await container.init(TEST_UID)
+  })
+
+  afterEach(async () => {
+    await container.dispose()
+    await deleteDb(TEST_UID)
+  })
+
+  it('createTodo 응답값이 LocalStorage 에 저장된다', async () => {
+    const created = todoOf('new-1', { is_current: true })
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.createTodo.mockResolvedValue(created)
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+
+    await repo.createTodo({ name: 'new-1' } as any)
+
+    expect(await container.todo().loadTodo('new-1')).toEqual(created)
+  })
+
+  it('updateTodo 응답값이 LocalStorage 의 동일 uuid 를 덮어쓴다', async () => {
+    await container.todo().saveTodos([todoOf('a', { name: 'old' })])
+    const updated = todoOf('a', { name: 'new' })
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.patchTodo.mockResolvedValue(updated)
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+
+    await repo.updateTodo('a', { name: 'new' })
+
+    expect((await container.todo().loadTodo('a'))?.name).toBe('new')
+  })
+
+  it('deleteTodo 응답 후 LocalStorage 에서도 제거된다', async () => {
+    await container.todo().saveTodos([todoOf('a')])
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.deleteTodo.mockResolvedValue({ status: 'ok' })
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+
+    await repo.deleteTodo('a')
+
+    expect(await container.todo().loadTodo('a')).toBeNull()
+  })
+
+  it('localStorageContainer 미주입이면 LocalStorage 작업 없이 Remote + 메모리만 동작 (호환성)', async () => {
+    const created = todoOf('only-remote', { is_current: true })
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.createTodo.mockResolvedValue(created)
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+    })
+
+    await expect(repo.createTodo({ name: 'only-remote' } as any)).resolves.toEqual(created)
+  })
+
+  it('LocalStorage 작업 실패가 mutation 흐름을 깨지 않는다 (silent fail)', async () => {
+    await container.dispose()
+
+    const created = todoOf('a', { is_current: true })
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.createTodo.mockResolvedValue(created)
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+
+    await expect(repo.createTodo({ name: 'a' } as any)).resolves.toEqual(created)
+  })
+})
+
+describe('EventRepository — Schedule mutation LocalStorage write sync', () => {
+  let container: LocalStorageContainer
+
+  beforeEach(async () => {
+    container = new LocalStorageContainer()
+    await container.init(TEST_UID)
+  })
+
+  afterEach(async () => {
+    await container.dispose()
+    await deleteDb(TEST_UID)
+  })
+
+  it('createSchedule 응답값이 LocalStorage 에 저장된다', async () => {
+    const created = scheduleOf('s-1')
+    const { todoApi, scheduleApi } = makeFakeApis()
+    scheduleApi.createSchedule.mockResolvedValue(created)
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+    await repo.createSchedule({ name: 's-1' } as any)
+
+    expect(await container.schedule().loadSchedule('s-1')).toEqual(created)
+  })
+
+  it('updateSchedule 응답값이 LocalStorage 의 동일 uuid 를 덮어쓴다', async () => {
+    await container.schedule().saveSchedules([scheduleOf('a', { name: 'old' })])
+    const updated = scheduleOf('a', { name: 'new' })
+    const { todoApi, scheduleApi } = makeFakeApis()
+    scheduleApi.updateSchedule.mockResolvedValue(updated)
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+    await repo.updateSchedule('a', { name: 'new' })
+
+    expect((await container.schedule().loadSchedule('a'))?.name).toBe('new')
+  })
+
+  it('deleteSchedule 응답 후 LocalStorage 에서도 제거된다', async () => {
+    await container.schedule().saveSchedules([scheduleOf('a')])
+    const { todoApi, scheduleApi } = makeFakeApis()
+    scheduleApi.deleteSchedule.mockResolvedValue({ status: 'ok' })
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+    await repo.deleteSchedule('a')
+
+    expect(await container.schedule().loadSchedule('a')).toBeNull()
+  })
+
+  it('excludeScheduleRepeating 응답값이 LocalStorage 의 동일 uuid 를 덮어쓴다', async () => {
+    await container.schedule().saveSchedules([scheduleOf('a')])
+    const updated = scheduleOf('a', { name: 'after-exclude' })
+    const { todoApi, scheduleApi } = makeFakeApis()
+    scheduleApi.excludeRepeating.mockResolvedValue(updated)
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+    await repo.excludeScheduleRepeating('a', [3])
+
+    expect((await container.schedule().loadSchedule('a'))?.name).toBe('after-exclude')
+  })
+})
+
+describe('EventRepository.completeTodo — LocalStorage write sync', () => {
+  let container: LocalStorageContainer
+
+  beforeEach(async () => {
+    container = new LocalStorageContainer()
+    await container.init(TEST_UID)
+  })
+
+  afterEach(async () => {
+    await container.dispose()
+    await deleteDb(TEST_UID)
+  })
+
+  it('단일(비반복) todo 완료 시 LocalStorage 의 todo 제거 + doneTodo 저장', async () => {
+    const todo = todoOf('a', { is_current: true })
+    await container.todo().saveTodos([todo])
+
+    const doneEvent = { uuid: 'done-a', origin_event_id: 'a', name: 't-a', done_at: 5000 }
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.completeTodo.mockResolvedValue(doneEvent)
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+
+    await repo.completeTodo(todo)
+
+    expect(await container.todo().loadTodo('a')).toBeNull()
+    expect(await container.doneTodo().loadDoneTodo('done-a')).toEqual(doneEvent)
+  })
+
+  it('반복 todo "이번만" 완료 시 todo 가 다음 회차로 갱신, doneTodo 저장', async () => {
+    const repeating = { option: { optionType: 'every_day' as const, interval: 1 } } as any
+    const todo = todoOf('a', {
+      is_current: true,
+      repeating,
+      repeating_turn: 1,
+      event_time: { time_type: 'at', timestamp: 1000 },
+    })
+    await container.todo().saveTodos([todo])
+
+    const doneEvent = { uuid: 'done-a', origin_event_id: 'a', name: 't-a', done_at: 1000 }
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.completeTodo.mockResolvedValue(doneEvent)
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+
+    await repo.completeTodo(todo, 'this')
+
+    const after = await container.todo().loadTodo('a')
+    expect(after).not.toBeNull()
+    expect((after?.event_time as any)?.timestamp).toBeGreaterThan(1000)
+    expect(await container.doneTodo().loadDoneTodo('done-a')).toEqual(doneEvent)
+  })
+
+  it("반복 'future' 완료 시 todo 제거 + doneTodo 저장", async () => {
+    const repeating = { option: { optionType: 'every_day' as const, interval: 1 } } as any
+    const todo = todoOf('a', {
+      is_current: true,
+      repeating,
+      repeating_turn: 1,
+      event_time: { time_type: 'at', timestamp: 1000 },
+    })
+    await container.todo().saveTodos([todo])
+
+    const doneEvent = { uuid: 'done-a', origin_event_id: 'a', name: 't-a', done_at: 1000 }
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.completeTodo.mockResolvedValue(doneEvent)
+    todoApi.patchTodo.mockResolvedValue(todo)
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+
+    await repo.completeTodo(todo, 'future')
+
+    expect(await container.todo().loadTodo('a')).toBeNull()
+    expect(await container.doneTodo().loadDoneTodo('done-a')).toEqual(doneEvent)
+  })
+})
+
+describe('EventRepository — patch/replaceThisScope LocalStorage write sync', () => {
+  let container: LocalStorageContainer
+
+  beforeEach(async () => {
+    container = new LocalStorageContainer()
+    await container.init(TEST_UID)
+  })
+
+  afterEach(async () => {
+    await container.dispose()
+    await deleteDb(TEST_UID)
+  })
+
+  it('patchTodoNextOccurrence 응답값이 LocalStorage 의 동일 uuid 를 덮어쓴다', async () => {
+    await container.todo().saveTodos([
+      todoOf('a', { repeating_turn: 1, event_time: { time_type: 'at', timestamp: 1000 } }),
+    ])
+    const advanced = todoOf('a', { repeating_turn: 2, event_time: { time_type: 'at', timestamp: 86400 } })
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.patchTodo.mockResolvedValue(advanced)
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+    await repo.patchTodoNextOccurrence('a', { time_type: 'at', timestamp: 86400 } as any, 2)
+
+    expect((await container.todo().loadTodo('a'))?.repeating_turn).toBe(2)
+  })
+
+  it('replaceTodoThisScope: 원본 todo 제거 + new_todo / next_repeating 저장', async () => {
+    await container.todo().saveTodos([todoOf('a')])
+    const newTodo = todoOf('new-todo', { event_time: { time_type: 'at', timestamp: 2000 } })
+    const nextRepeating = todoOf('next-rep', { event_time: { time_type: 'at', timestamp: 3000 } })
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.replaceTodo.mockResolvedValue({ new_todo: newTodo, next_repeating: nextRepeating })
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+    await repo.replaceTodoThisScope('a', { new: { name: 'replaced' } } as any)
+
+    expect(await container.todo().loadTodo('a')).toBeNull()
+    expect(await container.todo().loadTodo('new-todo')).not.toBeNull()
+    expect(await container.todo().loadTodo('next-rep')).not.toBeNull()
+  })
+
+  it('replaceTodoThisScope: next_repeating 이 없을 때도 정상 동작', async () => {
+    await container.todo().saveTodos([todoOf('a')])
+    const newTodo = todoOf('new-todo')
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.replaceTodo.mockResolvedValue({ new_todo: newTodo, next_repeating: undefined })
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+    await repo.replaceTodoThisScope('a', { new: { name: 'replaced' } } as any)
+
+    expect(await container.todo().loadTodo('a')).toBeNull()
+    expect(await container.todo().loadTodo('new-todo')).not.toBeNull()
+  })
+})

--- a/tests/repositories/ForemostEventRepository.writeSync.test.ts
+++ b/tests/repositories/ForemostEventRepository.writeSync.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { ForemostEventRepository } from '../../src/repositories/ForemostEventRepository'
+import { LocalStorageContainer } from '../../src/repositories/local-storage/LocalStorageContainer'
+import type { ForemostEvent } from '../../src/models'
+
+const TEST_UID = 'fm-write'
+async function deleteDb(uid: string) {
+  await new Promise<void>((r) => {
+    const req = indexedDB.deleteDatabase(`todocal-cache:${uid}`)
+    req.onsuccess = req.onerror = req.onblocked = () => r()
+  })
+}
+
+describe('ForemostEventRepository — mutation LocalStorage write sync', () => {
+  let container: LocalStorageContainer
+  let foremostApi: { setForemostEvent: ReturnType<typeof vi.fn>; removeForemostEvent: ReturnType<typeof vi.fn>; getForemostEvent: ReturnType<typeof vi.fn> }
+
+  beforeEach(async () => {
+    container = new LocalStorageContainer()
+    await container.init(TEST_UID)
+    foremostApi = { setForemostEvent: vi.fn(), removeForemostEvent: vi.fn(), getForemostEvent: vi.fn() }
+  })
+
+  afterEach(async () => {
+    await container.dispose()
+    await deleteDb(TEST_UID)
+  })
+
+  it('set 응답값이 LocalStorage 에 저장된다', async () => {
+    const event: ForemostEvent = { event_id: 'e-1', is_todo: true } as ForemostEvent
+    foremostApi.setForemostEvent.mockResolvedValue(event)
+
+    const repo = new ForemostEventRepository({ api: foremostApi as any, localStorageContainer: container })
+    await repo.set('e-1', true)
+
+    expect(await container.foremost().load()).toEqual(event)
+  })
+
+  it('clear 응답 후 LocalStorage 에서도 제거된다', async () => {
+    await container.foremost().save({ event_id: 'pre', is_todo: true } as ForemostEvent)
+    foremostApi.removeForemostEvent.mockResolvedValue({ status: 'ok' })
+
+    const repo = new ForemostEventRepository({ api: foremostApi as any, localStorageContainer: container })
+    await repo.clear()
+
+    expect(await container.foremost().load()).toBeNull()
+  })
+
+  it('localStorageContainer 미주입 호환성', async () => {
+    const event: ForemostEvent = { event_id: 'r', is_todo: true } as ForemostEvent
+    foremostApi.setForemostEvent.mockResolvedValue(event)
+
+    const repo = new ForemostEventRepository({ api: foremostApi as any })
+    await expect(repo.set('r', true)).resolves.toBeUndefined()
+  })
+})

--- a/tests/repositories/TagRepository.writeSync.test.ts
+++ b/tests/repositories/TagRepository.writeSync.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { TagRepository } from '../../src/repositories/TagRepository'
+import { LocalStorageContainer } from '../../src/repositories/local-storage/LocalStorageContainer'
+import { useEventTagListCache } from '../../src/repositories/caches/eventTagListCache'
+import type { EventTag } from '../../src/models/EventTag'
+
+const TEST_UID = 'tag-write-sync'
+const tagOf = (uuid: string, name: string): EventTag => ({ uuid, name, color_hex: '#fff' } as EventTag)
+async function deleteDb(uid: string) {
+  await new Promise<void>((r) => {
+    const req = indexedDB.deleteDatabase(`todocal-cache:${uid}`)
+    req.onsuccess = req.onerror = req.onblocked = () => r()
+  })
+}
+
+function makeFakeApis() {
+  return {
+    eventTagApi: {
+      getAllTags: vi.fn().mockResolvedValue([]),
+      createTag: vi.fn(), updateTag: vi.fn(),
+      deleteTag: vi.fn(), deleteTagAndEvents: vi.fn(),
+    },
+    settingApi: {
+      getDefaultTagColors: vi.fn().mockResolvedValue(null),
+      updateDefaultTagColors: vi.fn(),
+    },
+  }
+}
+
+describe('TagRepository — mutation LocalStorage write sync', () => {
+  let container: LocalStorageContainer
+
+  beforeEach(async () => {
+    container = new LocalStorageContainer()
+    await container.init(TEST_UID)
+    useEventTagListCache.getState().reset()
+  })
+
+  afterEach(async () => {
+    await container.dispose()
+    await deleteDb(TEST_UID)
+    useEventTagListCache.getState().reset()
+  })
+
+  it('createTag 응답값이 LocalStorage 에 저장된다', async () => {
+    const created = tagOf('t-1', 'NEW')
+    const { eventTagApi, settingApi } = makeFakeApis()
+    eventTagApi.createTag.mockResolvedValue(created)
+
+    const repo = new TagRepository({
+      eventTagApi: eventTagApi as any,
+      settingApi: settingApi as any,
+      localStorageContainer: container,
+    })
+    await repo.createTag('NEW', '#fff')
+
+    expect(await container.eventTag().loadTag('t-1')).toEqual(created)
+  })
+
+  it('updateTag 응답값이 LocalStorage 의 동일 uuid 를 덮어쓴다', async () => {
+    const existing = tagOf('a', 'OLD')
+    await container.eventTag().saveTags([existing])
+    useEventTagListCache.getState().replaceAll([existing], null)
+
+    const updated = tagOf('a', 'NEW')
+    const { eventTagApi, settingApi } = makeFakeApis()
+    eventTagApi.updateTag.mockResolvedValue(updated)
+
+    const repo = new TagRepository({
+      eventTagApi: eventTagApi as any,
+      settingApi: settingApi as any,
+      localStorageContainer: container,
+    })
+    await repo.updateTag('a', { name: 'NEW' })
+
+    expect((await container.eventTag().loadTag('a'))?.name).toBe('NEW')
+  })
+
+  it('deleteTag 응답 후 LocalStorage 에서도 제거된다', async () => {
+    await container.eventTag().saveTags([tagOf('a', 'A')])
+    const { eventTagApi, settingApi } = makeFakeApis()
+    eventTagApi.deleteTag.mockResolvedValue({ status: 'ok' })
+
+    const repo = new TagRepository({
+      eventTagApi: eventTagApi as any,
+      settingApi: settingApi as any,
+      localStorageContainer: container,
+    })
+    await repo.deleteTag('a')
+
+    expect(await container.eventTag().loadTag('a')).toBeNull()
+  })
+
+  it('localStorageContainer 미주입 호환성', async () => {
+    const created = tagOf('a', 'A')
+    const { eventTagApi, settingApi } = makeFakeApis()
+    eventTagApi.createTag.mockResolvedValue(created)
+
+    const repo = new TagRepository({
+      eventTagApi: eventTagApi as any,
+      settingApi: settingApi as any,
+    })
+    await expect(repo.createTag('A', '#fff')).resolves.toEqual(created)
+  })
+})

--- a/tests/repositories/caches/doneTodosCache.test.ts
+++ b/tests/repositories/caches/doneTodosCache.test.ts
@@ -1,16 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { useDoneTodosCache } from '../../../src/repositories/caches/doneTodosCache'
-import { useCurrentTodosCache } from '../../../src/repositories/caches/currentTodosCache'
-import { doneTodoApi } from '../../../src/api/doneTodoApi'
-import type { Todo } from '../../../src/models'
-
-vi.mock('../../../src/api/doneTodoApi', () => ({
-  doneTodoApi: {
-    getDoneTodos: vi.fn(),
-    deleteDoneTodo: vi.fn(),
-    revertDoneTodo: vi.fn(),
-  },
-}))
 
 const makeDone = (id: string, done_at: number | null = 1000) => ({
   uuid: id,
@@ -21,119 +10,12 @@ const makeDone = (id: string, done_at: number | null = 1000) => ({
   event_tag_id: null,
 })
 
-describe('useDoneTodosCache', () => {
+describe('useDoneTodosCache — primitive operations', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
     useDoneTodosCache.getState().reset()
-    useCurrentTodosCache.getState().reset()
   })
 
-  it('fetchNext 호출 시 items에 결과가 추가된다', async () => {
-    // given
-    vi.mocked(doneTodoApi.getDoneTodos).mockResolvedValue([makeDone('d1', 2000), makeDone('d2', 1000)])
-
-    // when
-    await useDoneTodosCache.getState().fetchNext()
-
-    // then
-    expect(useDoneTodosCache.getState().items).toHaveLength(2)
-  })
-
-  it('fetchNext 연속 호출 시 items가 누적된다', async () => {
-    // given: 첫 번째 응답 20개, 두 번째 응답 5개
-    const page1 = Array.from({ length: 20 }, (_, i) => makeDone(`d${i}`, 2000 - i))
-    const page2 = [makeDone('d20', 100)]
-    vi.mocked(doneTodoApi.getDoneTodos)
-      .mockResolvedValueOnce(page1)
-      .mockResolvedValueOnce(page2)
-
-    // when
-    await useDoneTodosCache.getState().fetchNext()
-    await useDoneTodosCache.getState().fetchNext()
-
-    // then
-    expect(useDoneTodosCache.getState().items).toHaveLength(21)
-    expect(useDoneTodosCache.getState().hasMore).toBe(false)
-  })
-
-  it('반환 개수가 PAGE_SIZE 미만이면 hasMore가 false가 된다', async () => {
-    // given
-    vi.mocked(doneTodoApi.getDoneTodos).mockResolvedValue([makeDone('d1')])
-
-    // when
-    await useDoneTodosCache.getState().fetchNext()
-
-    // then
-    expect(useDoneTodosCache.getState().hasMore).toBe(false)
-  })
-
-  it('remove 호출 시 items에서 해당 항목이 제거된다', async () => {
-    // given
-    useDoneTodosCache.setState({ items: [makeDone('d1'), makeDone('d2')] })
-    vi.mocked(doneTodoApi.deleteDoneTodo).mockResolvedValue({ status: 'ok' })
-
-    // when
-    await useDoneTodosCache.getState().remove('d1')
-
-    // then
-    expect(useDoneTodosCache.getState().items.map(i => i.uuid)).toEqual(['d2'])
-  })
-
-  it('revert 호출 시 plain revert 를 호출하고 items 에서 해당 항목이 제거된다', async () => {
-    // given — iOS RevertTodoResultMapper 와 동일한 { todo, detail } 응답
-    useDoneTodosCache.setState({ items: [makeDone('d1'), makeDone('d2')] })
-    const restored: Todo = { uuid: 'todo-1', name: 'done-d1', is_current: true }
-    vi.mocked(doneTodoApi.revertDoneTodo).mockResolvedValue({ todo: restored, detail: null })
-
-    // when
-    await useDoneTodosCache.getState().revert('d1')
-
-    // then
-    expect(useDoneTodosCache.getState().items.map(i => i.uuid)).toEqual(['d2'])
-  })
-
-  it('revert 응답의 todo 가 is_current 면 currentTodosCache 에 추가된다 (iOS 와 동일 시맨틱)', async () => {
-    useDoneTodosCache.setState({ items: [makeDone('d1')] })
-    useCurrentTodosCache.getState().reset()
-    const restored: Todo = { uuid: 'todo-1', name: '복구된 current', is_current: true }
-    vi.mocked(doneTodoApi.revertDoneTodo).mockResolvedValue({ todo: restored, detail: null })
-
-    await useDoneTodosCache.getState().revert('d1')
-
-    expect(useCurrentTodosCache.getState().todos.find(t => t.uuid === 'todo-1')).toEqual(restored)
-  })
-
-  it('revert 응답의 todo 가 event_time 을 가지면 calendarEventsCache 에도 추가된다', async () => {
-    useDoneTodosCache.setState({ items: [makeDone('d1')] })
-    useCurrentTodosCache.getState().reset()
-    const restored: Todo = {
-      uuid: 'todo-1',
-      name: 'scheduled',
-      is_current: false,
-      event_time: { time_type: 'at', timestamp: 1700 },
-    }
-    vi.mocked(doneTodoApi.revertDoneTodo).mockResolvedValue({ todo: restored, detail: null })
-
-    await useDoneTodosCache.getState().revert('d1')
-
-    // current 가 아니면 currentTodos 에 추가되지 않는다 — BFF 응답을 그대로 신뢰
-    expect(useCurrentTodosCache.getState().todos.find(t => t.uuid === 'todo-1')).toBeUndefined()
-  })
-
-  it('마지막 항목의 done_at이 null이면 hasMore가 false가 된다', async () => {
-    // given: PAGE_SIZE(20)개를 반환하지만 마지막 항목의 done_at이 null
-    const items = Array.from({ length: 20 }, (_, i) => makeDone(`d${i}`, i < 19 ? 2000 - i : null))
-    vi.mocked(doneTodoApi.getDoneTodos).mockResolvedValue(items)
-
-    // when
-    await useDoneTodosCache.getState().fetchNext()
-
-    // then: cursor가 null이므로 다음 페이지 없음
-    expect(useDoneTodosCache.getState().hasMore).toBe(false)
-    expect(useDoneTodosCache.getState().cursor).toBeNull()
-  })
-
-  it('reset 호출 시 상태가 초기화된다', async () => {
+  it('reset 호출 시 상태가 초기화된다', () => {
     // given
     useDoneTodosCache.setState({ items: [makeDone('d1')], hasMore: false, cursor: 999 })
 
@@ -147,46 +29,62 @@ describe('useDoneTodosCache', () => {
     expect(state.cursor).toBeNull()
   })
 
-  it('fetchNext 응답 도착 전에 reset 이 일어났다면 stale 응답은 cache 를 다시 채우지 않는다', async () => {
-    // given — fetchNext 응답을 deferred 로 잡아둔다 (race 시나리오 시뮬레이션)
-    let resolveGet!: (items: ReturnType<typeof makeDone>[]) => void
-    vi.mocked(doneTodoApi.getDoneTodos).mockReturnValue(
-      new Promise(resolve => { resolveGet = resolve as never }),
-    )
+  it('appendPage 호출 시 items 에 결과가 누적되고 cursor/hasMore 가 갱신된다', () => {
+    // given
+    const page1 = [makeDone('d1', 2000), makeDone('d2', 1000)]
 
-    // when — fetchNext 시작 후 응답 도착 전에 reset → stale 한 응답이 도착
-    const inflight = useDoneTodosCache.getState().fetchNext()
-    useDoneTodosCache.getState().reset()
-    resolveGet([makeDone('d-stale', 1000)])
-    await inflight
+    // when
+    useDoneTodosCache.getState().appendPage(page1 as any, 1000, true)
 
-    // then — reset 으로 비워진 cache 는 stale 응답으로 다시 채워지지 않는다
-    expect(useDoneTodosCache.getState().items).toHaveLength(0)
+    // then
+    expect(useDoneTodosCache.getState().items).toHaveLength(2)
+    expect(useDoneTodosCache.getState().cursor).toBe(1000)
+    expect(useDoneTodosCache.getState().hasMore).toBe(true)
   })
 
-  it('fetchNext 응답 도착 전에 revert/remove 가 일어나면 stale 응답이 cache 를 다시 채우지 않는다', async () => {
-    // given — 초기 상태: 한 항목이 있고 fetchNext 가 in-flight
-    useDoneTodosCache.setState({
-      items: [{ ...makeDone('d1', 1500), origin_event_id: 'todo-1' }],
-      cursor: 1500,
-      hasMore: true,
-    })
-    let resolveGet!: (items: ReturnType<typeof makeDone>[]) => void
-    vi.mocked(doneTodoApi.getDoneTodos).mockReturnValue(
-      new Promise(resolve => { resolveGet = resolve as never }),
-    )
-    vi.mocked(doneTodoApi.revertDoneTodo).mockResolvedValue({
-      todo: { uuid: 'todo-1', name: 'done-d1', is_current: true },
-      detail: null,
-    })
+  it('appendPage 를 두 번 호출하면 누적된다', () => {
+    const page1 = Array.from({ length: 20 }, (_, i) => makeDone(`d${i}`, 2000 - i))
+    const page2 = [makeDone('d20', 100)]
 
-    // when — 사용자가 빠르게 revert 클릭 → cache 에서 d1 제거 → fetchNext 응답 뒤늦게 도착
-    const inflight = useDoneTodosCache.getState().fetchNext()
-    await useDoneTodosCache.getState().revert('d1')
-    resolveGet([makeDone('d1', 1500)]) // 백엔드가 다음 페이지 응답으로 d1 을 다시 보내는 케이스
-    await inflight
+    useDoneTodosCache.getState().appendPage(page1 as any, 2000 - 19, true)
+    useDoneTodosCache.getState().appendPage(page2 as any, null, false)
 
-    // then — 사용자가 막 지운 d1 이 stale 응답에 의해 되살아나지 않는다
-    expect(useDoneTodosCache.getState().items.find(i => i.uuid === 'd1')).toBeUndefined()
+    expect(useDoneTodosCache.getState().items).toHaveLength(21)
+    expect(useDoneTodosCache.getState().hasMore).toBe(false)
+  })
+
+  it('removeItem 호출 시 items 에서 해당 항목이 제거된다', () => {
+    // given
+    useDoneTodosCache.setState({ items: [makeDone('d1'), makeDone('d2')] })
+
+    // when
+    useDoneTodosCache.getState().removeItem('d1')
+
+    // then
+    expect(useDoneTodosCache.getState().items.map(i => i.uuid)).toEqual(['d2'])
+  })
+
+  it('removeItem 호출 시 generation 이 증가한다 (stale 응답 차단 메커니즘)', () => {
+    // given
+    useDoneTodosCache.setState({ items: [makeDone('d1')], generation: 0 })
+
+    // when
+    useDoneTodosCache.getState().removeItem('d1')
+
+    // then
+    expect(useDoneTodosCache.getState().generation).toBeGreaterThan(0)
+  })
+
+  it('replaceAll 호출 시 items 전체가 교체된다', () => {
+    // given: 기존 items
+    useDoneTodosCache.setState({ items: [makeDone('old', 9999)] })
+    const newItems = [makeDone('n1', 2000), makeDone('n2', 1000)]
+
+    // when
+    useDoneTodosCache.getState().replaceAll(newItems as any)
+
+    // then
+    const state = useDoneTodosCache.getState()
+    expect(state.items.map(i => i.uuid)).toEqual(['n1', 'n2'])
   })
 })


### PR DESCRIPTION
## 문제
이슈 #129 — PR1 (LocalStorage 인프라) + PR2 (Read cache-first) 후속. mutation 메서드들이 Remote 응답만 메모리 cache 에 반영하고 LocalStorage 는 안 건드려서, 다음 세션 cache-first read 시점에 stale 한 상태로 시작.

## 접근
6 Repository 의 모든 mutation 메서드가 Remote 응답 후 LocalStorage 에도 반영하도록 추가. 패턴 균일 (Remote → LocalStorage → 메모리 store), silent fail (try/catch), `localStorageContainer?.isInitialized()` 가드.

### EventRepository
- Todo: `createTodo` / `updateTodo` / `deleteTodo` / `patchTodoNextOccurrence` / `replaceTodoThisScope`
- Schedule: `createSchedule` / `updateSchedule` / `deleteSchedule` / `excludeScheduleRepeating`
- `completeTodo` 4 분기:
  - `'this'` + repeating + next: todo update + doneTodo save
  - `'this'` + repeating, no next: todo remove + doneTodo save
  - `'future'`: todo remove + doneTodo save
  - 단일 / `'all'`: 동일

### TagRepository
- `createTag` / `updateTag` / `deleteTag` (deleteTagAndEvents 의 cascade 는 PR2 에서 처리됨)

### ForemostEventRepository (PR2 review I2 후속)
- `set` / `clear` 가 LocalStorage 갱신

### DoneTodoRepository
- `revert` 가 doneTodo 제거 + 복원된 todo 를 LocalStorage·메모리 캐시에 추가
- `remove` 가 LocalStorage 도 정리
- 호출처(ArchivePanel / useDoneTodoDetailPopoverViewModel / TestDataSeederButton) 를 cache 직접 호출에서 Repository 호출로 마이그
- doneTodosCache 의 legacy `fetchNext`/`revert`/`remove` biz op 제거 — primitive only
- `fetchNextPage` 가 generation 캡처해 stale 응답 무시 (Strict Mode 더블 마운트, 진행 중 mutation 시 데이터 부활/중복 방지)

### EventDetailRepository
- 신규: `localStorageContainer` DI + `get` cache-first read + `save` LocalStorage 동기화
- `invalidate` 가 LocalStorage 도 정리하도록 async 승격 (PR2 review C2 후속)
- per-eventId `generations` 카운터로 bg refresh 가 fresh save 를 stale Remote 로 덮어쓰는 race 차단 (PR2 review I1 후속)
- save 의 `bumpGeneration` 이 API await 전에 실행되어 save 도중 시작된 bg refresh 도 stale 처리

## 검증
- 6 Repository 별 writeSync 단위 테스트 (mutation 후 LocalStorage 반영)
- DoneTodoRepository race 테스트 (fetchNextPage 도중 removeItem/reset 시 stale 응답 무시)
- EventDetailRepository race 테스트 (cache-hit 후 save → bg refresh 가 stale Remote 로 덮어쓰지 않음)
- ArchivePanel / useDoneTodoDetailPopoverViewModel 등의 caller 테스트가 Repository mock 으로 마이그
- 풀 테스트 1056/1056 PASS, 빌드 성공

## 후속
- 본 PR 시리즈 종료 — 이슈 #129 cache-first read 완료
- 후속 검토 사항 (별도 이슈로):
  - `EventDetail` orphaning: Todo/Schedule 삭제 시 LocalStorage 의 event_details 정리 (현재 미연결 — storage bloat 우려, 정확성 영향 없음)
  - `revert` 가 `useUncompletedTodosCache` 에는 추가 안 함 (cache 가 addTodo 미노출)
  - `EventDetailRepository` 의 in-memory cache / generations Map 무한 증가 (장기 세션)

본 PR plan: `docs/superpowers/plans/2026-05-07-issue-129-pr3-write-local-storage-sync.md`. 설계 spec: `docs/superpowers/specs/2026-05-05-issue-129-cache-first-read-design.md`.

Closes #129