### PR TITLE
[#156] Google 로그인에 계정 선택 단계 추가

### DIFF
--- a/src/api/firebaseAuthApi.ts
+++ b/src/api/firebaseAuthApi.ts
@@ -13,6 +13,7 @@ import type { AuthFirebaseApi } from '../repositories/AuthRepository'
 export const firebaseAuthApi: AuthFirebaseApi = {
   async signInWithGoogle(): Promise<void> {
     const provider = new GoogleAuthProvider()
+    provider.setCustomParameters({ prompt: 'select_account' })
     await signInWithPopup(getAuthInstance(), provider)
   },
 


### PR DESCRIPTION
Closes #156

## Summary
- Chrome 등 브라우저에 이미 로그인된 Google 계정으로의 silent 자동 로그인을 차단하고, 매번 계정 선택 팝업이 뜨도록 변경
- `GoogleAuthProvider` 에 `setCustomParameters({ prompt: 'select_account' })` 추가

## Test plan
- [ ] Chrome 에서 Google 계정 로그인된 상태로 앱의 Google 로그인 버튼 클릭 → 계정 선택 팝업 표시
- [ ] 다른 계정 선택 시 정상 로그인 / 메인 진입
- [ ] 로그아웃 후 재로그인 시도해도 매번 계정 선택 팝업 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)