### PR TITLE
[#159] chore(ci): Firebase Hosting 자동 배포 워크플로 (self-hosted runner)

### DIFF
--- a/.github/workflows/firebase-deploy-production.yml
+++ b/.github/workflows/firebase-deploy-production.yml
@@ -1,0 +1,26 @@
+name: Deploy to Firebase Hosting (production)
+
+on:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: firebase-production
+  cancel-in-progress: false
+
+jobs:
+  build_and_deploy:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Copy local .env.local
+        run: cp ~/.config/todocalendar/.env.local .env.local
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Deploy to Firebase Hosting (live channel)
+        run: firebase deploy --only hosting --project todocalendar-1707723626269 --non-interactive

--- a/.github/workflows/firebase-deploy-staging.yml
+++ b/.github/workflows/firebase-deploy-staging.yml
@@ -1,0 +1,26 @@
+name: Deploy to Firebase Hosting (staging preview)
+
+on:
+  push:
+    branches:
+      - develop
+
+concurrency:
+  group: firebase-staging
+  cancel-in-progress: true
+
+jobs:
+  build_and_deploy:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Copy local .env.local
+        run: cp ~/.config/todocalendar/.env.local .env.local
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Deploy to Firebase Hosting (staging channel)
+        run: firebase hosting:channel:deploy staging --expires 30d --project todocalendar-1707723626269 --non-interactive


### PR DESCRIPTION
Closes #159

## Summary

GitHub Actions로 Firebase Hosting 자동 배포 셋업.
- \`develop\` push → staging preview channel (\`--expires 30d\`)
- \`master\` push → live(production) 채널

**self-hosted runner (로컬 macOS)** 사용. GitHub Secrets / Service Account JSON 등록 0개. 로컬 \`.env.local\` + \`firebase login\` 자격증명을 그대로 활용.

## 워크플로 설계

| 항목 | staging | production |
|------|---------|------------|
| 트리거 | \`push\` to \`develop\` | \`push\` to \`master\` |
| 채널 | \`hosting:channel:deploy staging --expires 30d\` | \`deploy --only hosting\` |
| concurrency | \`cancel-in-progress: true\` (최신만 살림) | \`cancel-in-progress: false\` (순차) |
| Node | 로컬 시스템 Node 24 | 동일 |
| 배포 도구 | 로컬 \`firebase\` CLI 직접 호출 | 동일 |

\`firebase deploy --only hosting\` 으로 functions(\`api\`)는 미포함 — functions는 별도 레포(TodoCalendar-Functions)에서 관리.

## 보안 모델 — 머지 전 반드시 읽을 것

repo 가시성이 **PUBLIC**(\`sudopark/TodoCalendar-Web\`)이고, GitHub 공식 권고는 self-hosted runner를 private repo에만 쓰라는 입장. 다음을 근거로 진행:
- 단독 작업자 (collaborator 없음)
- \`push\` 트리거만 사용 → fork PR이 self-hosted runner에서 코드 실행하지 못함
- develop/master 머지가 잦지 않음

**다음 시점에 즉시 재검토 필요:**
- collaborator 추가
- \`pull_request_target\` 트리거 도입
- 워크플로 yaml 수정 PR을 부주의하게 머지하는 순간

## 머지 직전 사용자 체크리스트

- [ ] **.env.local 심링크 생성** — 메인 워크트리의 \`.env.local\`을 single source of truth로 사용
  \`\`\`bash
  mkdir -p ~/.config/todocalendar
  ln -s /Users/sudo.park/Documents/codebase/TodoCalendar-Web/.env.local ~/.config/todocalendar/.env.local
  ls -la ~/.config/todocalendar/.env.local  # 심링크 확인
  \`\`\`
- [ ] **firebase login 상태 확인** — \`firebase projects:list\`로 \`todocalendar-1707723626269\` 보이면 OK
- [x] **self-hosted runner 등록** — https://github.com/sudopark/TodoCalendar-Web/settings/actions/runners/new
  - macOS arm64 선택, \`~/actions-runner/\`에 설치
  - **반드시 LaunchAgent로** (\`./svc.sh install && ./svc.sh start\`) — LaunchDaemon은 root로 돌아 \`~\` / firebase 토큰 모두 어긋남
  - 등록 후: \`Settings > Actions > Runners\`에서 Idle 상태 확인
- [ ] **PATH 점검 (LaunchAgent 컨텍스트)** — \`node\`, \`npm\`, \`firebase\`가 GUI 로그인 PATH에 있는지. nvm 설치는 LaunchAgent에서 안 보일 수 있어 brew/공식 인스톨러 권장.

## 머지 후 동작 확인

1. PR 머지 → develop push → staging 워크플로 실행
2. 액션 로그에서 \`firebase hosting:channel:deploy staging\` 출력 URL 클릭 → preview 페이지 동작 확인
3. develop을 master로 수동 머지 → production 워크플로 실행 → live 페이지 동작 확인

## 운영 시 알 것

- macOS 머신이 sleep되면 runner도 멈춤 (배포가 큐잉됐다가 깨어나면 실행)
- \`.env.local\`에 새 \`VITE_*\` 추가 시 메인 워크트리에서만 수정하면 심링크로 자동 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)