### PR TITLE
[#161] ci/build: checkout v5 + commit SHA / version 빌드타임 주입

### DIFF
--- a/.github/workflows/firebase-deploy-production.yml
+++ b/.github/workflows/firebase-deploy-production.yml
@@ -13,7 +13,7 @@ jobs:
   build_and_deploy:
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Copy local .env.local
         run: cp ~/.config/todocalendar/.env.local .env.local
@@ -21,6 +21,8 @@ jobs:
       - run: npm ci
 
       - run: npm run build
+        env:
+          VITE_DEPLOY_ENV: production
 
       - name: Deploy to Firebase Hosting (live channel)
         run: firebase deploy --only hosting --project todocalendar-1707723626269 --non-interactive

--- a/.github/workflows/firebase-deploy-staging.yml
+++ b/.github/workflows/firebase-deploy-staging.yml
@@ -13,7 +13,7 @@ jobs:
   build_and_deploy:
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Copy local .env.local
         run: cp ~/.config/todocalendar/.env.local .env.local
@@ -21,6 +21,8 @@ jobs:
       - run: npm ci
 
       - run: npm run build
+        env:
+          VITE_DEPLOY_ENV: staging
 
       - name: Deploy to Firebase Hosting (staging channel)
         run: firebase hosting:channel:deploy staging --expires 30d --project todocalendar-1707723626269 --non-interactive

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,12 @@ import './index.css'
 import './firebase'
 import App from './App.tsx'
 
+console.info(
+  `%cTodoCalendar-Web%c ${__APP_VERSION__} (${__APP_COMMIT__}) [${__DEPLOY_ENV__}] ${__APP_BUILD_TIME__}`,
+  'color:#4f46e5;font-weight:bold',
+  'color:gray',
+)
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string
+declare const __APP_COMMIT__: string
+declare const __APP_BUILD_TIME__: string
+declare const __DEPLOY_ENV__: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,53 @@
 /// <reference types="vitest/config" />
 import path from 'path'
+import { execSync } from 'node:child_process'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
+const commitSha =
+  process.env.GITHUB_SHA?.substring(0, 7) ??
+  (() => {
+    try {
+      return execSync('git rev-parse --short HEAD').toString().trim()
+    } catch {
+      return 'dev'
+    }
+  })()
+const buildTime = new Date().toISOString()
+const deployEnv = process.env.VITE_DEPLOY_ENV ?? 'local'
+const appVersion =
+  deployEnv === 'production' ? pkg.version : `${pkg.version}+${commitSha}`
+
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    {
+      name: 'emit-version-json',
+      apply: 'build',
+      writeBundle(options) {
+        const dir = options.dir ?? 'dist'
+        writeFileSync(
+          path.join(dir, 'version.json'),
+          JSON.stringify(
+            { version: appVersion, commit: commitSha, buildTime, deployEnv },
+            null,
+            2,
+          ) + '\n',
+        )
+      },
+    },
+  ],
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+    __APP_COMMIT__: JSON.stringify(commitSha),
+    __APP_BUILD_TIME__: JSON.stringify(buildTime),
+    __DEPLOY_ENV__: JSON.stringify(deployEnv),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,10 +8,10 @@ import tailwindcss from '@tailwindcss/vite'
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 const commitSha =
-  process.env.GITHUB_SHA?.substring(0, 7) ??
+  process.env.GITHUB_SHA?.substring(0, 7) ||
   (() => {
     try {
-      return execSync('git rev-parse --short HEAD').toString().trim()
+      return execSync('git rev-parse --short=7 HEAD').toString().trim()
     } catch {
       return 'dev'
     }


### PR DESCRIPTION
Closes #161

## Summary

PR #160 후속. 워크플로 \`actions/checkout\` 최신화 + 빌드 산출물에 commit SHA / version 표식 주입.

## 동작 변화

- **워크플로**: \`actions/checkout@v4\` → \`@v5\` (Node 20 deprecation 경고 해소, 2026-09-16 차단 대응 선반영). \`npm run build\` 단계에 \`VITE_DEPLOY_ENV\` 환경변수 추가 (staging/production)
- **vite.config.ts**: \`define\`으로 빌드타임 상수 4종 주입 (\`__APP_VERSION__\`, \`__APP_COMMIT__\`, \`__APP_BUILD_TIME__\`, \`__DEPLOY_ENV__\`). commit SHA는 \`process.env.GITHUB_SHA\` 우선 사용, fallback으로 \`git rev-parse --short HEAD\`, 최후 \`'dev'\`
- **emit-version-json 플러그인**: \`dist/version.json\` 정적 파일 산출 → 배포 후 \`<URL>/version.json\` fetch로 빌드 추적 가능
- **src/main.tsx**: 부팅 시 콘솔에 한 줄 출력 (UI 미노출, DevTools에서만 가시)
- **src/vite-env.d.ts**: 글로벌 \`__APP_*__\` 타입 선언

## 표식 형태

| 환경 | \`__APP_VERSION__\` 예시 | 비고 |
|------|---------------------|------|
| staging (\`VITE_DEPLOY_ENV=staging\`) | \`0.0.0+21b0af6\` | commit 7자리 부착 |
| production (\`VITE_DEPLOY_ENV=production\`) | \`0.0.0\` | SemVer 표준, package.json version 그대로 |
| local (env 없음) | \`0.0.0+21b0af6\` | 개발자 빌드 |

## production 버전 운영 (수동 모델)

\`package.json\`의 \`version\` 필드가 single source of truth. release 시점에:

\`\`\`
develop 작업 → version 0.0.0 → 0.1.0 PR
develop 머지 → staging 자동 배포 (표식: 0.1.0+abc1234)
staging /version.json 검증
master 머지 → production 자동 배포 (표식: 0.1.0)
\`\`\`

자동화(semantic-release / git tag)는 release 빈도 늘 때 별도 검토.

## 검증

- 로컬 \`VITE_DEPLOY_ENV=staging npm run build\` → \`dist/version.json\` 정상 ({version:0.0.0+21b0af6, commit:21b0af6, deployEnv:staging})
- 로컬 \`VITE_DEPLOY_ENV=production npm run build\` → \`dist/version.json\` 정상 ({version:0.0.0, commit:21b0af6, deployEnv:production})
- \`npm test\` 137 파일 / 1056 테스트 모두 PASS
- 번들 코드에 \`__APP_VERSION__\` 등 치환 확인됨

## Test plan

- [ ] develop 머지 후 self-hosted runner에서 staging 잡 정상 실행
- [ ] \`curl https://todocalendar-1707723626269--staging-XXXX.web.app/version.json\` 응답 확인
- [ ] 브라우저 DevTools 콘솔에 \`TodoCalendar-Web 0.0.0+<sha> (<sha>) [staging] <ISO>\` 한 줄 확인
- [ ] (선택) 추후 master 머지 시 production 표식이 \`0.0.0\` 만 나오는지 확인