### PR TITLE
[#155] fix(DoneTodoRepository): revert 시 uncompletedTodosCache 동기화

### DIFF
--- a/src/repositories/DoneTodoRepository.ts
+++ b/src/repositories/DoneTodoRepository.ts
@@ -5,6 +5,7 @@ import type { LocalStorageContainer } from './local-storage/LocalStorageContaine
 import { useDoneTodosCache } from './caches/doneTodosCache'
 import { useCalendarEventsCache } from './caches/calendarEventsCache'
 import { useCurrentTodosCache } from './caches/currentTodosCache'
+import { useUncompletedTodosCache } from './caches/uncompletedTodosCache'
 
 const PAGE_SIZE = 20
 
@@ -104,7 +105,19 @@ export class DoneTodoRepository {
     if (response.todo.is_current) {
       useCurrentTodosCache.getState().addTodo(response.todo)
     }
+    if (!response.todo.is_current && this.isUncompletedTodo(response.todo)) {
+      useUncompletedTodosCache.getState().addTodo(response.todo)
+    }
     return response.todo
+  }
+
+  // todo 의 event_time 시작 시점이 현재 이전인지 판별 (미완료 영역 여부)
+  private isUncompletedTodo(todo: import('../models').Todo): boolean {
+    const et = todo.event_time
+    if (!et) return false
+    const nowSec = Math.floor(Date.now() / 1000)
+    const startTs = et.time_type === 'at' ? et.timestamp : et.period_start
+    return startTs <= nowSec
   }
 
   async remove(id: string): Promise<void> {

--- a/src/repositories/caches/uncompletedTodosCache.ts
+++ b/src/repositories/caches/uncompletedTodosCache.ts
@@ -7,6 +7,7 @@ import type { Todo } from '../../models'
 
 interface UncompletedTodosState {
   todos: Todo[]
+  addTodo: (todo: Todo) => void
   removeTodo: (id: string) => void
   replaceAll: (todos: Todo[]) => void
   reset: () => void
@@ -14,6 +15,8 @@ interface UncompletedTodosState {
 
 export const useUncompletedTodosCache = create<UncompletedTodosState>((set, get) => ({
   todos: [],
+
+  addTodo: (todo: Todo) => set({ todos: [...get().todos, todo] }),
 
   removeTodo: (id: string) => {
     set({ todos: get().todos.filter(t => t.uuid !== id) })

--- a/src/repositories/caches/uncompletedTodosCache.ts
+++ b/src/repositories/caches/uncompletedTodosCache.ts
@@ -16,7 +16,7 @@ interface UncompletedTodosState {
 export const useUncompletedTodosCache = create<UncompletedTodosState>((set, get) => ({
   todos: [],
 
-  addTodo: (todo: Todo) => set({ todos: [...get().todos, todo] }),
+  addTodo: (todo: Todo) => set(s => ({ todos: [...s.todos, todo] })),
 
   removeTodo: (id: string) => {
     set({ todos: get().todos.filter(t => t.uuid !== id) })

--- a/tests/repositories/DoneTodoRepository.test.ts
+++ b/tests/repositories/DoneTodoRepository.test.ts
@@ -7,6 +7,7 @@ vi.mock('../../src/api/doneTodoApi', () => ({ doneTodoApi: {} }))
 import { DoneTodoRepository } from '../../src/repositories/DoneTodoRepository'
 import { useDoneTodosCache } from '../../src/repositories/caches/doneTodosCache'
 import { useCurrentTodosCache } from '../../src/repositories/caches/currentTodosCache'
+import { useUncompletedTodosCache } from '../../src/repositories/caches/uncompletedTodosCache'
 import type { DoneTodoApi } from '../../src/repositories/DoneTodoRepository'
 import type { DoneTodo } from '../../src/models'
 import type { Todo } from '../../src/models'
@@ -32,6 +33,7 @@ function makeFakeApi(overrides: Partial<DoneTodoApi> = {}): DoneTodoApi {
 function resetCache() {
   useDoneTodosCache.getState().reset()
   useCurrentTodosCache.getState().reset()
+  useUncompletedTodosCache.getState().reset()
 }
 
 // ──────────────────────── fetchNextPage ────────────────────────
@@ -117,6 +119,62 @@ describe('DoneTodoRepository — revert', () => {
 
     // then: currentTodosCache 에 추가됨
     expect(useCurrentTodosCache.getState().todos.find(t => t.uuid === restored.uuid)).toBeDefined()
+  })
+
+  it('revert 된 todo 가 과거 시점(event_time.timestamp <= now, is_current=false)이면 uncompletedTodosCache 에 추가된다', async () => {
+    // given: 과거 시점의 todo — timestamp 를 1(과거)로 설정
+    useDoneTodosCache.setState({ items: [makeDone('d4')] })
+    const restored: Todo = {
+      uuid: 'd4', name: 'past-todo', is_current: false,
+      event_time: { time_type: 'at', timestamp: 1 },
+    }
+    const repo = new DoneTodoRepository({
+      api: makeFakeApi({ revertDoneTodo: vi.fn(async () => ({ todo: restored, detail: null })) }),
+    })
+
+    // when
+    await repo.revert('d4')
+
+    // then: uncompletedTodosCache 에 추가됨
+    expect(useUncompletedTodosCache.getState().todos.find(t => t.uuid === 'd4')).toBeDefined()
+  })
+
+  it('revert 된 todo 가 is_current=true 이면 uncompletedTodosCache 에 추가되지 않는다', async () => {
+    // given: is_current=true 인 todo
+    useDoneTodosCache.setState({ items: [makeDone('d5')] })
+    const restored: Todo = {
+      uuid: 'd5', name: 'current-todo', is_current: true,
+      event_time: { time_type: 'at', timestamp: 1 },
+    }
+    const repo = new DoneTodoRepository({
+      api: makeFakeApi({ revertDoneTodo: vi.fn(async () => ({ todo: restored, detail: null })) }),
+    })
+
+    // when
+    await repo.revert('d5')
+
+    // then: uncompletedTodosCache 에 없음 (currentTodosCache 만)
+    expect(useUncompletedTodosCache.getState().todos.find(t => t.uuid === 'd5')).toBeUndefined()
+    expect(useCurrentTodosCache.getState().todos.find(t => t.uuid === 'd5')).toBeDefined()
+  })
+
+  it('revert 된 todo 가 미래 시점이면 uncompletedTodosCache 에 추가되지 않는다', async () => {
+    // given: 미래 timestamp
+    const futureTs = Date.now() / 1000 + 86400 * 365 // 1년 후
+    useDoneTodosCache.setState({ items: [makeDone('d6')] })
+    const restored: Todo = {
+      uuid: 'd6', name: 'future-todo', is_current: false,
+      event_time: { time_type: 'at', timestamp: futureTs },
+    }
+    const repo = new DoneTodoRepository({
+      api: makeFakeApi({ revertDoneTodo: vi.fn(async () => ({ todo: restored, detail: null })) }),
+    })
+
+    // when
+    await repo.revert('d6')
+
+    // then: uncompletedTodosCache 에 없음
+    expect(useUncompletedTodosCache.getState().todos.find(t => t.uuid === 'd6')).toBeUndefined()
   })
 })
 

--- a/tests/repositories/DoneTodoRepository.test.ts
+++ b/tests/repositories/DoneTodoRepository.test.ts
@@ -176,6 +176,80 @@ describe('DoneTodoRepository — revert', () => {
     // then: uncompletedTodosCache 에 없음
     expect(useUncompletedTodosCache.getState().todos.find(t => t.uuid === 'd6')).toBeUndefined()
   })
+
+  it('revert 된 todo 가 period 타입이고 period_start <= now 이면 uncompletedTodosCache 에 추가된다', async () => {
+    // given: period, period_start 가 과거
+    useDoneTodosCache.setState({ items: [makeDone('d7')] })
+    const restored: Todo = {
+      uuid: 'd7', name: 'period-past-todo', is_current: false,
+      event_time: { time_type: 'period', period_start: 1, period_end: 2 },
+    }
+    const repo = new DoneTodoRepository({
+      api: makeFakeApi({ revertDoneTodo: vi.fn(async () => ({ todo: restored, detail: null })) }),
+    })
+
+    // when
+    await repo.revert('d7')
+
+    // then: uncompletedTodosCache 에 추가됨
+    expect(useUncompletedTodosCache.getState().todos.find(t => t.uuid === 'd7')).toBeDefined()
+  })
+
+  it('revert 된 todo 가 period 타입이고 period_start > now 이면 uncompletedTodosCache 에 추가되지 않는다', async () => {
+    // given: period, period_start 가 미래
+    const futureTs = Math.floor(Date.now() / 1000) + 86400 * 365
+    useDoneTodosCache.setState({ items: [makeDone('d8')] })
+    const restored: Todo = {
+      uuid: 'd8', name: 'period-future-todo', is_current: false,
+      event_time: { time_type: 'period', period_start: futureTs, period_end: futureTs + 3600 },
+    }
+    const repo = new DoneTodoRepository({
+      api: makeFakeApi({ revertDoneTodo: vi.fn(async () => ({ todo: restored, detail: null })) }),
+    })
+
+    // when
+    await repo.revert('d8')
+
+    // then: uncompletedTodosCache 에 없음
+    expect(useUncompletedTodosCache.getState().todos.find(t => t.uuid === 'd8')).toBeUndefined()
+  })
+
+  it('revert 된 todo 가 allday 타입이고 period_start <= now 이면 uncompletedTodosCache 에 추가된다', async () => {
+    // given: allday, period_start 가 과거
+    useDoneTodosCache.setState({ items: [makeDone('d9')] })
+    const restored: Todo = {
+      uuid: 'd9', name: 'allday-past-todo', is_current: false,
+      event_time: { time_type: 'allday', period_start: 1, seconds_from_gmt: 0 },
+    }
+    const repo = new DoneTodoRepository({
+      api: makeFakeApi({ revertDoneTodo: vi.fn(async () => ({ todo: restored, detail: null })) }),
+    })
+
+    // when
+    await repo.revert('d9')
+
+    // then: uncompletedTodosCache 에 추가됨
+    expect(useUncompletedTodosCache.getState().todos.find(t => t.uuid === 'd9')).toBeDefined()
+  })
+
+  it('revert 된 todo 가 allday 타입이고 period_start > now 이면 uncompletedTodosCache 에 추가되지 않는다', async () => {
+    // given: allday, period_start 가 미래
+    const futureTs = Math.floor(Date.now() / 1000) + 86400 * 365
+    useDoneTodosCache.setState({ items: [makeDone('d10')] })
+    const restored: Todo = {
+      uuid: 'd10', name: 'allday-future-todo', is_current: false,
+      event_time: { time_type: 'allday', period_start: futureTs, seconds_from_gmt: 0 },
+    }
+    const repo = new DoneTodoRepository({
+      api: makeFakeApi({ revertDoneTodo: vi.fn(async () => ({ todo: restored, detail: null })) }),
+    })
+
+    // when
+    await repo.revert('d10')
+
+    // then: uncompletedTodosCache 에 없음
+    expect(useUncompletedTodosCache.getState().todos.find(t => t.uuid === 'd10')).toBeUndefined()
+  })
 })
 
 // ──────────────────────── remove ────────────────────────

--- a/tests/repositories/caches/uncompletedTodosCache.test.ts
+++ b/tests/repositories/caches/uncompletedTodosCache.test.ts
@@ -59,4 +59,17 @@ describe('useUncompletedTodosCache', () => {
     // then: 빈 목록
     expect(useUncompletedTodosCache.getState().todos).toEqual([])
   })
+
+  it('addTodo를 호출하면 todos 목록에서 해당 todo를 찾을 수 있다', () => {
+    // given: 기존 todo가 하나 있는 상태
+    useUncompletedTodosCache.setState({ todos: [makeTodo('u1', '미완료1')] })
+
+    // when: 새 todo 추가
+    useUncompletedTodosCache.getState().addTodo(makeTodo('u2', '미완료2'))
+
+    // then: 기존 항목과 새 항목 모두 목록에 있어야 한다
+    const todos = useUncompletedTodosCache.getState().todos
+    expect(todos.some(t => t.uuid === 'u1')).toBe(true)
+    expect(todos.some(t => t.uuid === 'u2')).toBe(true)
+  })
 })


### PR DESCRIPTION
## 배경
이슈 #129 PR3 후속. revert 가 useUncompletedTodosCache 에 복원 todo 를 반영 안 해 미완료 패널에 다음 fetch 전까지 안 보임.

## 변경
- `useUncompletedTodosCache.addTodo` — currentTodosCache 와 대칭으로 primitive 추가
- `DoneTodoRepository.revert` — is_current=false 이고 event_time 시작 ts <= 현재(초)인 todo 복원 시 즉시 `uncompletedTodosCache.addTodo` 호출
- `DoneTodoRepository.isUncompletedTodo` — 미완료 영역 판별 private 헬퍼 (at.timestamp / period·allday.period_start <= nowSec)

## Test plan
- [x] `useUncompletedTodosCache.addTodo` — 기존 항목 유지하며 새 항목 추가 검증
- [x] revert 호출 시 과거 시점 todo → uncompletedTodosCache.todos 에 즉시 반영
- [x] is_current=true 항목 → uncompletedTodosCache 에 추가되지 않음
- [x] 미래 시점 항목 → uncompletedTodosCache 에 추가되지 않음
- [x] npm test 137 files / 1060 tests 전체 통과
- [x] npm run build 성공

Closes #155