### PR TITLE
[#145] fix(EventRepository): completeTodo 응답으로 doneTodosCache prepend

### DIFF
--- a/src/repositories/EventRepository.ts
+++ b/src/repositories/EventRepository.ts
@@ -6,6 +6,7 @@ import type { LocalStorageContainer } from './local-storage/LocalStorageContaine
 import { useCalendarEventsCache } from './caches/calendarEventsCache'
 import { useCurrentTodosCache } from './caches/currentTodosCache'
 import { useUncompletedTodosCache } from './caches/uncompletedTodosCache'
+import { useDoneTodosCache } from './caches/doneTodosCache'
 import { monthRange, yearRange, groupEventsByDate } from '../domain/functions/eventTime'
 import type { CalendarEvent } from '../domain/functions/eventTime'
 import { nextRepeatingTime, getStartTimestamp } from '../domain/functions/repeating'
@@ -416,6 +417,7 @@ export class EventRepository {
         useCurrentTodosCache.getState().removeTodo(todo.uuid)
         useUncompletedTodosCache.getState().removeTodo(todo.uuid)
       }
+      useDoneTodosCache.getState().prependItem(done)
       return done
     }
 
@@ -432,6 +434,7 @@ export class EventRepository {
       useCalendarEventsCache.getState().removeEvent(todo.uuid)
       useCurrentTodosCache.getState().removeTodo(todo.uuid)
       useUncompletedTodosCache.getState().removeTodo(todo.uuid)
+      useDoneTodosCache.getState().prependItem(done)
       return done
     }
 
@@ -445,6 +448,7 @@ export class EventRepository {
     useCalendarEventsCache.getState().removeEvent(todo.uuid)
     useCurrentTodosCache.getState().removeTodo(todo.uuid)
     useUncompletedTodosCache.getState().removeTodo(todo.uuid)
+    useDoneTodosCache.getState().prependItem(done)
     return done
   }
 

--- a/src/repositories/caches/doneTodosCache.ts
+++ b/src/repositories/caches/doneTodosCache.ts
@@ -25,6 +25,7 @@ interface DoneTodosCacheState {
   // ── cache primitive operations (used by DoneTodoRepository) ───────
   replaceAll: (items: DoneTodo[]) => void
   appendPage: (items: DoneTodo[], nextCursor: number | null, hasMore: boolean) => void
+  prependItem: (doneTodo: DoneTodo) => void
   removeItem: (id: string) => void
   reset: () => void
 }
@@ -51,6 +52,10 @@ export const useDoneTodosCache = create<DoneTodosCacheState>((set, _get) => ({
 
   appendPage: (items: DoneTodo[], nextCursor: number | null, hasMore: boolean) => {
     set(s => ({ items: [...s.items, ...items], cursor: nextCursor, hasMore }))
+  },
+
+  prependItem: (doneTodo: DoneTodo) => {
+    set(s => ({ items: [doneTodo, ...s.items] }))
   },
 
   removeItem: (id: string) => {

--- a/src/repositories/caches/doneTodosCache.ts
+++ b/src/repositories/caches/doneTodosCache.ts
@@ -55,7 +55,10 @@ export const useDoneTodosCache = create<DoneTodosCacheState>((set, _get) => ({
   },
 
   prependItem: (doneTodo: DoneTodo) => {
-    set(s => ({ items: [doneTodo, ...s.items] }))
+    set(s => ({
+      items: [doneTodo, ...s.items.filter(i => i.uuid !== doneTodo.uuid)],
+      generation: s.generation + 1,
+    }))
   },
 
   removeItem: (id: string) => {

--- a/tests/repositories/EventRepository.test.ts
+++ b/tests/repositories/EventRepository.test.ts
@@ -10,6 +10,7 @@ import { EventRepository } from '../../src/repositories/EventRepository'
 import { useCalendarEventsCache } from '../../src/repositories/caches/calendarEventsCache'
 import { useCurrentTodosCache } from '../../src/repositories/caches/currentTodosCache'
 import { useUncompletedTodosCache } from '../../src/repositories/caches/uncompletedTodosCache'
+import { useDoneTodosCache } from '../../src/repositories/caches/doneTodosCache'
 import type { Todo } from '../../src/models/Todo'
 import type { Schedule } from '../../src/models/Schedule'
 
@@ -71,6 +72,7 @@ function resetCaches() {
   useCalendarEventsCache.getState().reset()
   useCurrentTodosCache.getState().reset()
   useUncompletedTodosCache.getState().reset()
+  useDoneTodosCache.getState().reset()
 }
 
 // ───────────────────────────── 테스트 ──────────────────────────────
@@ -541,5 +543,106 @@ describe('EventRepository — completeTodo', () => {
     expect(calSnapshot.some(e => e.event.uuid === 'rep-todo-future')).toBe(false)
     expect(useCurrentTodosCache.getState().todos.some(t => t.uuid === 'rep-todo-future')).toBe(false)
     expect(useUncompletedTodosCache.getState().todos.some(t => t.uuid === 'rep-todo-future')).toBe(false)
+  })
+
+  it('비반복 todo 완료(default 분기) 시 doneTodosCache 최상단에 완료 항목이 추가된다', async () => {
+    // given: 기존 done 항목이 있는 상태
+    const existingDone = { uuid: 'existing-done', name: '기존완료', done_at: MAR_01_TS } as any
+    useDoneTodosCache.setState({ items: [existingDone] })
+    const todo = makeTodo({ uuid: 'simple-todo2', event_time: { time_type: 'at', timestamp: MAR_15_TS } })
+    const doneTodo = { uuid: 'done-simple2', name: '완료됨', done_at: MAR_15_TS } as any
+    const repo = new EventRepository({
+      todoApi: makeFakeTodoApi({ completeTodo: async () => doneTodo }),
+      scheduleApi: makeFakeScheduleApi(),
+    })
+
+    // when
+    await repo.completeTodo(todo)
+
+    // then: doneTodosCache 최상단에 새 완료 항목이 추가된다
+    const items = useDoneTodosCache.getState().items
+    expect(items[0].uuid).toBe('done-simple2')
+    expect(items[1].uuid).toBe('existing-done')
+  })
+
+  it("반복 todo 'this' 스코프 + 다음 차수 있음: doneTodosCache 최상단에 완료 항목이 추가된다", async () => {
+    // given
+    const repeating = { start: MAR_01_TS, option: { optionType: 'every_day' as const, interval: 1 } }
+    const todo = makeTodo({
+      uuid: 'rep-done-this',
+      event_time: { time_type: 'at', timestamp: MAR_01_TS },
+      repeating,
+      repeating_turn: 1,
+    })
+    useCalendarEventsCache.getState().addEvent({ type: 'todo', event: todo })
+    const existingDone = { uuid: 'older-done', name: '이전완료', done_at: MAR_01_TS - 1000 } as any
+    useDoneTodosCache.setState({ items: [existingDone] })
+    const doneTodo = { uuid: 'done-rep-this', name: '완료됨', done_at: MAR_01_TS } as any
+    const repo = new EventRepository({
+      todoApi: makeFakeTodoApi({ completeTodo: async () => doneTodo }),
+      scheduleApi: makeFakeScheduleApi(),
+    })
+
+    // when
+    await repo.completeTodo(todo, 'this')
+
+    // then: doneTodosCache 최상단에 새 완료 항목이 추가된다
+    const items = useDoneTodosCache.getState().items
+    expect(items[0].uuid).toBe('done-rep-this')
+  })
+
+  it("반복 todo 'this' 스코프 + 다음 차수 없음(반복 종료): doneTodosCache 최상단에 완료 항목이 추가된다", async () => {
+    // given
+    const repeating = { start: MAR_01_TS, end: MAR_01_TS, option: { optionType: 'every_day' as const, interval: 1 } }
+    const todo = makeTodo({
+      uuid: 'rep-done-end',
+      event_time: { time_type: 'at', timestamp: MAR_01_TS },
+      repeating,
+      repeating_turn: 1,
+    })
+    useCalendarEventsCache.getState().addEvent({ type: 'todo', event: todo })
+    const existingDone = { uuid: 'older-done2', name: '이전완료', done_at: MAR_01_TS - 1000 } as any
+    useDoneTodosCache.setState({ items: [existingDone] })
+    const doneTodo = { uuid: 'done-rep-end', name: '완료됨', done_at: MAR_01_TS } as any
+    const repo = new EventRepository({
+      todoApi: makeFakeTodoApi({ completeTodo: async () => doneTodo }),
+      scheduleApi: makeFakeScheduleApi(),
+    })
+
+    // when
+    await repo.completeTodo(todo, 'this')
+
+    // then: doneTodosCache 최상단에 새 완료 항목이 추가된다
+    const items = useDoneTodosCache.getState().items
+    expect(items[0].uuid).toBe('done-rep-end')
+  })
+
+  it("반복 todo 'future' 스코프: doneTodosCache 최상단에 완료 항목이 추가된다", async () => {
+    // given
+    const repeating = { start: MAR_01_TS, option: { optionType: 'every_day' as const, interval: 1 } }
+    const todo = makeTodo({
+      uuid: 'rep-done-future',
+      event_time: { time_type: 'at', timestamp: MAR_15_TS },
+      repeating,
+      repeating_turn: 15,
+    })
+    useCalendarEventsCache.getState().addEvent({ type: 'todo', event: todo })
+    const existingDone = { uuid: 'older-done3', name: '이전완료', done_at: MAR_01_TS } as any
+    useDoneTodosCache.setState({ items: [existingDone] })
+    const doneTodo = { uuid: 'done-rep-future', name: '완료됨', done_at: MAR_15_TS } as any
+    const repo = new EventRepository({
+      todoApi: makeFakeTodoApi({
+        patchTodo: async () => todo,
+        completeTodo: async () => doneTodo,
+      }),
+      scheduleApi: makeFakeScheduleApi(),
+    })
+
+    // when
+    await repo.completeTodo(todo, 'future')
+
+    // then: doneTodosCache 최상단에 새 완료 항목이 추가된다
+    const items = useDoneTodosCache.getState().items
+    expect(items[0].uuid).toBe('done-rep-future')
   })
 })

--- a/tests/repositories/caches/doneTodosCache.test.ts
+++ b/tests/repositories/caches/doneTodosCache.test.ts
@@ -87,4 +87,32 @@ describe('useDoneTodosCache — primitive operations', () => {
     const state = useDoneTodosCache.getState()
     expect(state.items.map(i => i.uuid)).toEqual(['n1', 'n2'])
   })
+
+  it('prependItem 호출 시 새 항목이 목록 최상단(인덱스 0)에 추가된다', () => {
+    // given: 기존 items
+    useDoneTodosCache.setState({ items: [makeDone('old1', 2000), makeDone('old2', 1000)] })
+    const newDone = makeDone('new-done', 3000)
+
+    // when
+    useDoneTodosCache.getState().prependItem(newDone as any)
+
+    // then: 새 항목이 최상단에 위치해야 한다
+    const state = useDoneTodosCache.getState()
+    expect(state.items[0].uuid).toBe('new-done')
+    expect(state.items.map(i => i.uuid)).toEqual(['new-done', 'old1', 'old2'])
+  })
+
+  it('prependItem 호출 시 기존 목록이 비어있어도 단일 항목으로 채워진다', () => {
+    // given: 빈 목록
+    useDoneTodosCache.getState().reset()
+    const newDone = makeDone('first-done', 5000)
+
+    // when
+    useDoneTodosCache.getState().prependItem(newDone as any)
+
+    // then
+    const state = useDoneTodosCache.getState()
+    expect(state.items).toHaveLength(1)
+    expect(state.items[0].uuid).toBe('first-done')
+  })
 })

--- a/tests/repositories/caches/doneTodosCache.test.ts
+++ b/tests/repositories/caches/doneTodosCache.test.ts
@@ -115,4 +115,32 @@ describe('useDoneTodosCache — primitive operations', () => {
     expect(state.items).toHaveLength(1)
     expect(state.items[0].uuid).toBe('first-done')
   })
+
+  it('prependItem 호출 시 generation 이 증가한다 (stale in-flight fetchNextPage 차단 메커니즘)', () => {
+    // given
+    useDoneTodosCache.setState({ items: [], generation: 3 })
+    const newDone = makeDone('gen-test', 9000)
+
+    // when
+    useDoneTodosCache.getState().prependItem(newDone as any)
+
+    // then
+    expect(useDoneTodosCache.getState().generation).toBeGreaterThan(3)
+  })
+
+  it('같은 uuid 의 항목을 두 번 prependItem 하면 1개만 남고 최신 데이터로 교체된다', () => {
+    // given: 기존 목록에 'd1' 이 이미 있는 상황 (이전 fetchNextPage 응답이 먼저 도착한 경우)
+    useDoneTodosCache.setState({ items: [makeDone('d1', 1000), makeDone('d2', 500)] })
+    const updatedDone = { ...makeDone('d1', 1000), name: 'done-d1-updated' }
+
+    // when: 같은 uuid 로 prependItem (completeTodo 응답이 뒤늦게 도착)
+    useDoneTodosCache.getState().prependItem(updatedDone as any)
+
+    // then: uuid 'd1' 은 최상단 1개만 존재, 최신 데이터로 교체
+    const state = useDoneTodosCache.getState()
+    expect(state.items.filter(i => i.uuid === 'd1')).toHaveLength(1)
+    expect(state.items[0].uuid).toBe('d1')
+    expect(state.items[0].name).toBe('done-d1-updated')
+    expect(state.items.map(i => i.uuid)).toEqual(['d1', 'd2'])
+  })
 })


### PR DESCRIPTION
## 배경
PR #141 후속. completeTodo 가 calendarEvents/currentTodos/uncompletedTodos 셋은 응답값으로 갱신하면서 doneTodosCache 만 누락 — ArchivePanel 즉시 반영 안 됨.

## 변경
- doneTodosCache.prependItem primitive 추가
- EventRepository.completeTodo — 'this'/'future'/default 모든 분기에서 응답 DoneTodo 를 prepend

## Test plan
- [ ] todo 완료 시 ArchivePanel 최상단 즉시 등장
- [ ] 분기 3개 모두 동일 동작
- [ ] npm test 통과

Closes #145