### PR TITLE
[#154] fix(EventRepository): 이벤트 삭제 시 LocalStorage event_details 정리

### DIFF
--- a/src/repositories/EventRepository.ts
+++ b/src/repositories/EventRepository.ts
@@ -304,9 +304,11 @@ export class EventRepository {
 
   async deleteTodo(id: string): Promise<void> {
     await this.deps.todoApi.deleteTodo(id)
-    await this.writeLocal('deleteTodo', () =>
-      this.deps.localStorageContainer!.todo().removeTodos([id]),
-    )
+    await this.writeLocal('deleteTodo', async () => {
+      const local = this.deps.localStorageContainer!
+      await local.todo().removeTodos([id])
+      await local.eventDetail().removeDetail(id)
+    })
     useCalendarEventsCache.getState().removeEvent(id)
     useCurrentTodosCache.getState().removeTodo(id)
   }
@@ -368,9 +370,11 @@ export class EventRepository {
 
   async deleteSchedule(id: string): Promise<void> {
     await this.deps.scheduleApi.deleteSchedule(id)
-    await this.writeLocal('deleteSchedule', () =>
-      this.deps.localStorageContainer!.schedule().removeSchedules([id]),
-    )
+    await this.writeLocal('deleteSchedule', async () => {
+      const local = this.deps.localStorageContainer!
+      await local.schedule().removeSchedules([id])
+      await local.eventDetail().removeDetail(id)
+    })
     useCalendarEventsCache.getState().removeEvent(id)
   }
 
@@ -408,6 +412,7 @@ export class EventRepository {
         await this.writeLocal('completeTodo (this+end)', async () => {
           const local = this.deps.localStorageContainer!
           await local.todo().removeTodos([todo.uuid])
+          await local.eventDetail().removeDetail(todo.uuid)
           await local.doneTodo().saveDoneTodos([done])
         })
         useCalendarEventsCache.getState().removeEvent(todo.uuid)
@@ -424,6 +429,7 @@ export class EventRepository {
       await this.writeLocal('completeTodo (future)', async () => {
         const local = this.deps.localStorageContainer!
         await local.todo().removeTodos([todo.uuid])
+        await local.eventDetail().removeDetail(todo.uuid)
         await local.doneTodo().saveDoneTodos([done])
       })
       useCalendarEventsCache.getState().removeEvent(todo.uuid)
@@ -436,6 +442,7 @@ export class EventRepository {
     await this.writeLocal('completeTodo (all)', async () => {
       const local = this.deps.localStorageContainer!
       await local.todo().removeTodos([todo.uuid])
+      await local.eventDetail().removeDetail(todo.uuid)
       await local.doneTodo().saveDoneTodos([done])
     })
     useCalendarEventsCache.getState().removeEvent(todo.uuid)

--- a/src/repositories/EventRepository.ts
+++ b/src/repositories/EventRepository.ts
@@ -304,11 +304,8 @@ export class EventRepository {
 
   async deleteTodo(id: string): Promise<void> {
     await this.deps.todoApi.deleteTodo(id)
-    await this.writeLocal('deleteTodo', async () => {
-      const local = this.deps.localStorageContainer!
-      await local.todo().removeTodos([id])
-      await local.eventDetail().removeDetail(id)
-    })
+    await this.writeLocal('deleteTodo', () => this.deps.localStorageContainer!.todo().removeTodos([id]))
+    await this.writeLocal('deleteTodo (detail)', () => this.deps.localStorageContainer!.eventDetail().removeDetail(id))
     useCalendarEventsCache.getState().removeEvent(id)
     useCurrentTodosCache.getState().removeTodo(id)
   }
@@ -373,11 +370,8 @@ export class EventRepository {
 
   async deleteSchedule(id: string): Promise<void> {
     await this.deps.scheduleApi.deleteSchedule(id)
-    await this.writeLocal('deleteSchedule', async () => {
-      const local = this.deps.localStorageContainer!
-      await local.schedule().removeSchedules([id])
-      await local.eventDetail().removeDetail(id)
-    })
+    await this.writeLocal('deleteSchedule', () => this.deps.localStorageContainer!.schedule().removeSchedules([id]))
+    await this.writeLocal('deleteSchedule (detail)', () => this.deps.localStorageContainer!.eventDetail().removeDetail(id))
     useCalendarEventsCache.getState().removeEvent(id)
   }
 

--- a/src/repositories/EventRepository.ts
+++ b/src/repositories/EventRepository.ts
@@ -338,6 +338,9 @@ export class EventRepository {
       if (result.next_repeating) toSave.push(result.next_repeating)
       await local.todo().saveTodos(toSave)
     })
+    await this.writeLocal('replaceTodoThisScope (detail)', () =>
+      this.deps.localStorageContainer!.eventDetail().removeDetail(id),
+    )
     useCalendarEventsCache.getState().removeEvent(id)
     if (result.new_todo.event_time) {
       useCalendarEventsCache.getState().addEvent({ type: 'todo', event: result.new_todo })

--- a/tests/repositories/EventRepository.writeSync.test.ts
+++ b/tests/repositories/EventRepository.writeSync.test.ts
@@ -492,4 +492,42 @@ describe('EventRepository — patch/replaceThisScope LocalStorage write sync', (
     expect(await container.todo().loadTodo('a')).toBeNull()
     expect(await container.todo().loadTodo('new-todo')).not.toBeNull()
   })
+
+  it('replaceTodoThisScope: 원본 id 의 event_details 가 제거된다', async () => {
+    // given: 원본 todo + detail 준비
+    await container.todo().saveTodos([todoOf('a')])
+    await container.eventDetail().saveDetail('a', { memo: 'original detail' })
+    const newTodo = todoOf('new-uuid', { event_time: { time_type: 'at', timestamp: 2000 } })
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.replaceTodo.mockResolvedValue({ new_todo: newTodo, next_repeating: undefined })
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+
+    // when
+    await repo.replaceTodoThisScope('a', { new: { name: 'replaced' } } as any)
+
+    // then: 원본 id 의 detail 은 제거되어야 한다
+    expect(await container.eventDetail().loadDetail('a')).toBeNull()
+  })
+
+  it('replaceTodoThisScope: detail 제거 실패가 todo 교체 흐름을 깨지 않는다 (silent fail 격리)', async () => {
+    // given: container 가 disposed 되어 LocalStorage 작업이 실패하는 상황
+    await container.dispose()
+    const newTodo = todoOf('new-uuid', { event_time: { time_type: 'at', timestamp: 2000 } })
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.replaceTodo.mockResolvedValue({ new_todo: newTodo, next_repeating: undefined })
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+
+    // when / then: LocalStorage 실패에도 불구하고 Promise 가 정상 resolve
+    await expect(
+      repo.replaceTodoThisScope('a', { new: { name: 'replaced' } } as any),
+    ).resolves.toMatchObject({ new_todo: newTodo })
+  })
 })

--- a/tests/repositories/EventRepository.writeSync.test.ts
+++ b/tests/repositories/EventRepository.writeSync.test.ts
@@ -114,6 +114,22 @@ describe('EventRepository — Todo mutation LocalStorage write sync', () => {
     expect(await container.todo().loadTodo('a')).toBeNull()
   })
 
+  it('deleteTodo 후 event_details 의 동일 uuid 레코드도 제거된다', async () => {
+    await container.todo().saveTodos([todoOf('a')])
+    await container.eventDetail().saveDetail('a', { memo: 'some detail' })
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.deleteTodo.mockResolvedValue({ status: 'ok' })
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+
+    await repo.deleteTodo('a')
+
+    expect(await container.eventDetail().loadDetail('a')).toBeNull()
+  })
+
   it('localStorageContainer 미주입이면 LocalStorage 작업 없이 Remote + 메모리만 동작 (호환성)', async () => {
     const created = todoOf('only-remote', { is_current: true })
     const { todoApi, scheduleApi } = makeFakeApis()
@@ -196,6 +212,21 @@ describe('EventRepository — Schedule mutation LocalStorage write sync', () => 
     await repo.deleteSchedule('a')
 
     expect(await container.schedule().loadSchedule('a')).toBeNull()
+  })
+
+  it('deleteSchedule 후 event_details 의 동일 uuid 레코드도 제거된다', async () => {
+    await container.schedule().saveSchedules([scheduleOf('a')])
+    await container.eventDetail().saveDetail('a', { memo: 'schedule detail' })
+    const { todoApi, scheduleApi } = makeFakeApis()
+    scheduleApi.deleteSchedule.mockResolvedValue({ status: 'ok' })
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+    await repo.deleteSchedule('a')
+
+    expect(await container.eventDetail().loadDetail('a')).toBeNull()
   })
 
   it('excludeScheduleRepeating 응답값이 LocalStorage 의 동일 uuid 를 덮어쓴다', async () => {
@@ -297,6 +328,104 @@ describe('EventRepository.completeTodo — LocalStorage write sync', () => {
 
     expect(await container.todo().loadTodo('a')).toBeNull()
     expect(await container.doneTodo().loadDoneTodo('done-a')).toEqual(doneEvent)
+  })
+
+  it("단일(비반복) todo 완료 시 event_details 도 제거된다", async () => {
+    const todo = todoOf('a', { is_current: true })
+    await container.todo().saveTodos([todo])
+    await container.eventDetail().saveDetail('a', { memo: 'detail' })
+
+    const doneEvent = { uuid: 'done-a', origin_event_id: 'a', name: 't-a', done_at: 5000 }
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.completeTodo.mockResolvedValue(doneEvent)
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+
+    await repo.completeTodo(todo)
+
+    expect(await container.eventDetail().loadDetail('a')).toBeNull()
+  })
+
+  it("반복 todo 'this' 스코프 + 시리즈 종료 시 event_details 도 제거된다", async () => {
+    // end 가 start 와 같아서 다음 회차가 없는 반복 todo
+    const repeating = { start: 1000, end: 1000, option: { optionType: 'every_day' as const, interval: 1 } } as any
+    const todo = todoOf('a', {
+      is_current: true,
+      repeating,
+      repeating_turn: 1,
+      event_time: { time_type: 'at', timestamp: 1000 },
+    })
+    await container.todo().saveTodos([todo])
+    await container.eventDetail().saveDetail('a', { memo: 'detail' })
+
+    const doneEvent = { uuid: 'done-a', origin_event_id: 'a', name: 't-a', done_at: 1000 }
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.completeTodo.mockResolvedValue(doneEvent)
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+
+    await repo.completeTodo(todo, 'this')
+
+    expect(await container.eventDetail().loadDetail('a')).toBeNull()
+  })
+
+  it("반복 todo 'this' 스코프 + 다음 회차 있음: event_details 는 유지된다", async () => {
+    // 다음 회차가 있으면 todo 자체가 살아남으므로 detail 은 유지돼야 한다
+    const repeating = { start: 1000, option: { optionType: 'every_day' as const, interval: 1 } } as any
+    const todo = todoOf('a', {
+      is_current: true,
+      repeating,
+      repeating_turn: 1,
+      event_time: { time_type: 'at', timestamp: 1000 },
+    })
+    await container.todo().saveTodos([todo])
+    await container.eventDetail().saveDetail('a', { memo: 'detail' })
+
+    const doneEvent = { uuid: 'done-a', origin_event_id: 'a', name: 't-a', done_at: 1000 }
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.completeTodo.mockResolvedValue(doneEvent)
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+
+    await repo.completeTodo(todo, 'this')
+
+    // todo 가 다음 회차로 advance 되었으므로 detail 은 그대로여야 한다
+    expect(await container.eventDetail().loadDetail('a')).not.toBeNull()
+  })
+
+  it("반복 todo 'future' 완료 시 event_details 도 제거된다", async () => {
+    const repeating = { option: { optionType: 'every_day' as const, interval: 1 } } as any
+    const todo = todoOf('a', {
+      is_current: true,
+      repeating,
+      repeating_turn: 1,
+      event_time: { time_type: 'at', timestamp: 1000 },
+    })
+    await container.todo().saveTodos([todo])
+    await container.eventDetail().saveDetail('a', { memo: 'detail' })
+
+    const doneEvent = { uuid: 'done-a', origin_event_id: 'a', name: 't-a', done_at: 1000 }
+    const { todoApi, scheduleApi } = makeFakeApis()
+    todoApi.completeTodo.mockResolvedValue(doneEvent)
+    todoApi.patchTodo.mockResolvedValue(todo)
+
+    const repo = new EventRepository({
+      todoApi: todoApi as any, scheduleApi: scheduleApi as any,
+      localStorageContainer: container,
+    })
+
+    await repo.completeTodo(todo, 'future')
+
+    expect(await container.eventDetail().loadDetail('a')).toBeNull()
   })
 })
 


### PR DESCRIPTION
## 배경
이슈 #129 PR3 후속. `deleteTodo`/`deleteSchedule` 호출 시 LocalStorage `event_details` 가 orphan 으로 남아 storage bloat 발생. `EventDetailLocalStorage.removeDetail` 인터페이스는 이미 존재하지만 호출되는 자리가 없었음.

## 변경

- `EventRepository.deleteTodo` — `writeLocal` 블록에 `eventDetail.removeDetail(id)` 추가 (silent fail)
- `EventRepository.deleteSchedule` — 동일 패턴 적용
- `EventRepository.completeTodo (this+end)` — 시리즈 종료(다음 회차 없음) 분기에서 todo 제거 시 detail 함께 제거
- `EventRepository.completeTodo (future / all)` — todo 제거 경로 2곳에 동일 적용
- `completeTodo (this+next 있음)` 분기는 todo가 advance될 뿐 제거되지 않으므로 제외

## completeTodo 분기 적용 여부

`this` 스코프 중 다음 회차가 있는 경우(`next?.time` 존재)는 todo 자체가 살아남아 다음 회차로 advance되므로, detail 을 삭제하면 오히려 데이터 손실이다 — 해당 분기만 제외하고 나머지 3 경로 모두 적용.

## Test plan
- [ ] `deleteTodo` 후 LocalStorage `event_details` 의 동일 uuid 레코드 제거 확인
- [ ] `deleteSchedule` 동일
- [ ] `completeTodo` 단일·시리즈종료·future 후 `event_details` 제거 확인
- [ ] `completeTodo (this+next 있음)` 후 `event_details` 유지 확인
- [ ] silent fail — IDB 실패가 mutation 흐름을 깨지 않음 (기존 테스트 커버)
- [ ] `npm test` 전체 통과 (1062 passed)

Closes #154