### PR TITLE
[#146] refactor(eventTagListCache): 태그 삭제 시 todos 캐시 in-memory transform

### DIFF
--- a/src/repositories/TagRepository.ts
+++ b/src/repositories/TagRepository.ts
@@ -3,6 +3,8 @@ import type { DefaultTagColors } from '../models/DefaultTagColors'
 import type { LocalStorageContainer } from './local-storage/LocalStorageContainer'
 import { useEventTagListCache } from './caches/eventTagListCache'
 import { useCalendarEventsCache } from './caches/calendarEventsCache'
+import { useCurrentTodosCache } from './caches/currentTodosCache'
+import { useUncompletedTodosCache } from './caches/uncompletedTodosCache'
 import type { EventRepository } from './EventRepository'
 
 // ── API 인터페이스 명시적 정의 ────────────────────────────────────────
@@ -133,8 +135,14 @@ export class TagRepository {
     await this.deps.eventTagApi.deleteTagAndEvents(id)
     useEventTagListCache.getState().remove(id)
 
-    // Cascade: 서버측에서 그 태그가 붙은 이벤트도 모두 삭제하므로
-    // 클라이언트의 calendar events / current todos / uncompleted todos 를 모두 재fetch.
+    // 서버 응답에 영향받은 UUID 목록 없음 — 보유 캐시를 event_tag_id 기준으로 in-memory 필터
+    const filteredCurrent = useCurrentTodosCache.getState().todos.filter(t => t.event_tag_id !== id)
+    useCurrentTodosCache.getState().replaceAll(filteredCurrent)
+
+    const filteredUncompleted = useUncompletedTodosCache.getState().todos.filter(t => t.event_tag_id !== id)
+    useUncompletedTodosCache.getState().replaceAll(filteredUncompleted)
+
+    // Cascade: 캘린더 이벤트(schedule 등)는 태그+관련 이벤트 삭제 의도에 맞게 재fetch.
     // eventRepo 미주입이면 cascade 생략 (호환성 — 테스트 등에서 의존성 안 넣어도 동작).
     const eventRepo = this.deps.eventRepo
     if (!eventRepo) return
@@ -145,9 +153,5 @@ export class TagRepository {
       useCalendarEventsCache.getState().invalidateYears(loadedYears)
       await Promise.allSettled(loadedYears.map((y) => eventRepo.fetchEventsForYear(y)))
     }
-    await Promise.allSettled([
-      eventRepo.fetchCurrentTodos(),
-      eventRepo.fetchUncompletedTodos(),
-    ])
   }
 }

--- a/src/repositories/TagRepository.ts
+++ b/src/repositories/TagRepository.ts
@@ -136,10 +136,10 @@ export class TagRepository {
     useEventTagListCache.getState().remove(id)
 
     // 서버 응답에 영향받은 UUID 목록 없음 — 보유 캐시를 event_tag_id 기준으로 in-memory 필터
-    const filteredCurrent = useCurrentTodosCache.getState().todos.filter(t => t.event_tag_id !== id)
+    const filteredCurrent = useCurrentTodosCache.getState().todos.filter(t => !t.event_tag_id || t.event_tag_id !== id)
     useCurrentTodosCache.getState().replaceAll(filteredCurrent)
 
-    const filteredUncompleted = useUncompletedTodosCache.getState().todos.filter(t => t.event_tag_id !== id)
+    const filteredUncompleted = useUncompletedTodosCache.getState().todos.filter(t => !t.event_tag_id || t.event_tag_id !== id)
     useUncompletedTodosCache.getState().replaceAll(filteredUncompleted)
 
     // Cascade: 캘린더 이벤트(schedule 등)는 태그+관련 이벤트 삭제 의도에 맞게 재fetch.

--- a/tests/repositories/TagRepository.cacheFirst.test.ts
+++ b/tests/repositories/TagRepository.cacheFirst.test.ts
@@ -3,7 +3,10 @@ import { TagRepository } from '../../src/repositories/TagRepository'
 import { LocalStorageContainer } from '../../src/repositories/local-storage/LocalStorageContainer'
 import { useEventTagListCache } from '../../src/repositories/caches/eventTagListCache'
 import { useCalendarEventsCache } from '../../src/repositories/caches/calendarEventsCache'
+import { useCurrentTodosCache } from '../../src/repositories/caches/currentTodosCache'
+import { useUncompletedTodosCache } from '../../src/repositories/caches/uncompletedTodosCache'
 import type { EventTag } from '../../src/models/EventTag'
+import type { Todo } from '../../src/models/Todo'
 import type { EventRepository } from '../../src/repositories/EventRepository'
 
 const TEST_UID = 'tag-cf'
@@ -85,6 +88,10 @@ describe('TagRepository.fetchAll — cache-first', () => {
   })
 })
 
+const makeTodo = (uuid: string, event_tag_id?: string | null): Todo => ({
+  uuid, name: `todo-${uuid}`, is_current: true, event_time: null, event_tag_id: event_tag_id ?? null,
+})
+
 describe('TagRepository.deleteTagAndEvents — cascading invalidate', () => {
   let container: LocalStorageContainer
 
@@ -93,6 +100,8 @@ describe('TagRepository.deleteTagAndEvents — cascading invalidate', () => {
     await container.init(TEST_UID)
     useEventTagListCache.getState().reset()
     useCalendarEventsCache.getState().reset()
+    useCurrentTodosCache.getState().reset()
+    useUncompletedTodosCache.getState().reset()
   })
 
   afterEach(async () => {
@@ -100,22 +109,22 @@ describe('TagRepository.deleteTagAndEvents — cascading invalidate', () => {
     await deleteDb(TEST_UID)
     useEventTagListCache.getState().reset()
     useCalendarEventsCache.getState().reset()
+    useCurrentTodosCache.getState().reset()
+    useUncompletedTodosCache.getState().reset()
   })
 
-  it('deleteTagAndEvents 호출 후 loadedYears 각각에 대해 fetchEventsForYear, fetchCurrentTodos, fetchUncompletedTodos 가 호출된다', async () => {
+  it('deleteTagAndEvents 호출 후 calendarEventsCache 의 loadedYears 가 invalidate 되고 재fetch 된다', async () => {
     // given: calendar events cache 에 2025/2026 두 해가 로드된 상태
     useCalendarEventsCache.setState({ loadedYears: new Set([2025, 2026]) })
 
     const { eventTagApi, settingApi } = makeFakeApis()
     eventTagApi.deleteTagAndEvents.mockResolvedValue({ status: 'ok' })
 
-    const fetchYear = vi.fn().mockResolvedValue(undefined)
-    const fetchCurrent = vi.fn().mockResolvedValue(undefined)
-    const fetchUncompleted = vi.fn().mockResolvedValue(undefined)
+    const fetchedYears: number[] = []
     const eventRepo = {
-      fetchEventsForYear: fetchYear,
-      fetchCurrentTodos: fetchCurrent,
-      fetchUncompletedTodos: fetchUncompleted,
+      fetchEventsForYear: vi.fn((y: number) => { fetchedYears.push(y); return Promise.resolve() }),
+      fetchCurrentTodos: vi.fn().mockResolvedValue(undefined),
+      fetchUncompletedTodos: vi.fn().mockResolvedValue(undefined),
     } as unknown as EventRepository
 
     const repo = new TagRepository({
@@ -128,14 +137,36 @@ describe('TagRepository.deleteTagAndEvents — cascading invalidate', () => {
     // when
     await repo.deleteTagAndEvents('tag-1')
 
-    // then: 두 해 모두에 대해 fetchEventsForYear 호출, current/uncompleted 도 재fetch
-    expect(fetchYear).toHaveBeenCalledWith(2025)
-    expect(fetchYear).toHaveBeenCalledWith(2026)
-    expect(fetchCurrent).toHaveBeenCalled()
-    expect(fetchUncompleted).toHaveBeenCalled()
-    // calendar events cache 의 loadedYears 도 invalidate 됨
+    // then: calendar events cache 의 loadedYears invalidate 됨
     expect(useCalendarEventsCache.getState().loadedYears.has(2025)).toBe(false)
     expect(useCalendarEventsCache.getState().loadedYears.has(2026)).toBe(false)
+    // 두 해 모두에 대해 fetchEventsForYear 재fetch
+    expect(fetchedYears).toContain(2025)
+    expect(fetchedYears).toContain(2026)
+  })
+
+  it('deleteTagAndEvents 호출 시 태그를 가진 todo 가 currentTodosCache/uncompletedTodosCache 에서 즉시 제거된다', async () => {
+    // given
+    useCurrentTodosCache.setState({ todos: [makeTodo('c1', 'tag-del'), makeTodo('c2', 'other')] })
+    useUncompletedTodosCache.setState({ todos: [makeTodo('u1', 'tag-del'), makeTodo('u2', 'other')] })
+
+    const { eventTagApi, settingApi } = makeFakeApis()
+    eventTagApi.deleteTagAndEvents.mockResolvedValue({ status: 'ok' })
+
+    const repo = new TagRepository({
+      eventTagApi: eventTagApi as any,
+      settingApi: settingApi as any,
+      localStorageContainer: container,
+    })
+
+    // when
+    await repo.deleteTagAndEvents('tag-del')
+
+    // then: 삭제된 태그를 가진 todo 만 제거, 나머지는 유지
+    expect(useCurrentTodosCache.getState().todos.some(t => t.uuid === 'c1')).toBe(false)
+    expect(useCurrentTodosCache.getState().todos.some(t => t.uuid === 'c2')).toBe(true)
+    expect(useUncompletedTodosCache.getState().todos.some(t => t.uuid === 'u1')).toBe(false)
+    expect(useUncompletedTodosCache.getState().todos.some(t => t.uuid === 'u2')).toBe(true)
   })
 
   it('eventRepo 미주입 시 cascade 없이 정상 동작 (호환성)', async () => {

--- a/tests/repositories/TagRepository.test.ts
+++ b/tests/repositories/TagRepository.test.ts
@@ -7,10 +7,13 @@ vi.mock('../../src/api/settingApi', () => ({ settingApi: {} }))
 
 import { TagRepository } from '../../src/repositories/TagRepository'
 import { useEventTagListCache } from '../../src/repositories/caches/eventTagListCache'
+import { useCurrentTodosCache } from '../../src/repositories/caches/currentTodosCache'
+import { useUncompletedTodosCache } from '../../src/repositories/caches/uncompletedTodosCache'
 import type { EventTag } from '../../src/models/EventTag'
 import type { DefaultTagColors } from '../../src/models/DefaultTagColors'
 import type { EventTagApi } from '../../src/repositories/TagRepository'
 import type { SettingApi } from '../../src/repositories/TagRepository'
+import type { Todo } from '../../src/models/Todo'
 
 // ──────────────────────── helpers ────────────────────────
 
@@ -40,8 +43,14 @@ function makeFakeSettingApi(overrides: Partial<SettingApi> = {}): SettingApi {
   }
 }
 
+function makeTodo(uuid: string, event_tag_id?: string | null): Todo {
+  return { uuid, name: `todo-${uuid}`, is_current: true, event_time: null, event_tag_id: event_tag_id ?? null }
+}
+
 function resetCache() {
   useEventTagListCache.getState().reset()
+  useCurrentTodosCache.getState().reset()
+  useUncompletedTodosCache.getState().reset()
 }
 
 // ──────────────────────── fetchAll ────────────────────────
@@ -210,5 +219,88 @@ describe('TagRepository — deleteTagAndEvents', () => {
 
     // then
     expect(repo.getTagsSnapshot().find(t => t.uuid === 'tag-x')).toBeUndefined()
+  })
+
+  it('삭제된 태그를 가진 todo가 currentTodosCache에서 즉시 제거된다', async () => {
+    // given
+    useCurrentTodosCache.setState({
+      todos: [
+        makeTodo('todo-1', 'tag-x'),
+        makeTodo('todo-2', 'tag-y'),  // 다른 태그 — 유지돼야 함
+        makeTodo('todo-3', null),     // 태그 없음 — 유지돼야 함
+      ],
+    })
+    useEventTagListCache.getState().add(makeTag({ uuid: 'tag-x' }))
+    const repo = new TagRepository({
+      eventTagApi: makeFakeEventTagApi({ deleteTagAndEvents: vi.fn(async () => ({ status: 'ok' })) }),
+      settingApi: makeFakeSettingApi(),
+    })
+
+    // when
+    await repo.deleteTagAndEvents('tag-x')
+
+    // then: tag-x를 가진 todo-1 만 제거됨
+    const todos = useCurrentTodosCache.getState().todos
+    expect(todos.some(t => t.uuid === 'todo-1')).toBe(false)
+    expect(todos.some(t => t.uuid === 'todo-2')).toBe(true)
+    expect(todos.some(t => t.uuid === 'todo-3')).toBe(true)
+  })
+
+  it('삭제된 태그를 가진 todo가 uncompletedTodosCache에서 즉시 제거된다', async () => {
+    // given
+    useUncompletedTodosCache.setState({
+      todos: [
+        makeTodo('todo-a', 'tag-x'),
+        makeTodo('todo-b', 'tag-z'),  // 다른 태그 — 유지
+      ],
+    })
+    useEventTagListCache.getState().add(makeTag({ uuid: 'tag-x' }))
+    const repo = new TagRepository({
+      eventTagApi: makeFakeEventTagApi({ deleteTagAndEvents: vi.fn(async () => ({ status: 'ok' })) }),
+      settingApi: makeFakeSettingApi(),
+    })
+
+    // when
+    await repo.deleteTagAndEvents('tag-x')
+
+    // then: tag-x를 가진 todo-a 만 제거됨
+    const todos = useUncompletedTodosCache.getState().todos
+    expect(todos.some(t => t.uuid === 'todo-a')).toBe(false)
+    expect(todos.some(t => t.uuid === 'todo-b')).toBe(true)
+  })
+
+  it('todo 캐시에 태그 id와 일치하는 항목이 없으면 캐시가 그대로 유지된다', async () => {
+    // given
+    useCurrentTodosCache.setState({ todos: [makeTodo('todo-1', 'other-tag')] })
+    useUncompletedTodosCache.setState({ todos: [makeTodo('todo-2', 'other-tag')] })
+    useEventTagListCache.getState().add(makeTag({ uuid: 'tag-x' }))
+    const repo = new TagRepository({
+      eventTagApi: makeFakeEventTagApi({ deleteTagAndEvents: vi.fn(async () => ({ status: 'ok' })) }),
+      settingApi: makeFakeSettingApi(),
+    })
+
+    // when
+    await repo.deleteTagAndEvents('tag-x')
+
+    // then: 다른 태그 todo는 그대로 남아 있어야 함
+    expect(useCurrentTodosCache.getState().todos.some(t => t.uuid === 'todo-1')).toBe(true)
+    expect(useUncompletedTodosCache.getState().todos.some(t => t.uuid === 'todo-2')).toBe(true)
+  })
+
+  it('eventRepo 없이도 todo 캐시 in-memory transform이 동작한다', async () => {
+    // given: eventRepo 미주입
+    useCurrentTodosCache.setState({ todos: [makeTodo('todo-1', 'tag-x')] })
+    useEventTagListCache.getState().add(makeTag({ uuid: 'tag-x' }))
+    const repo = new TagRepository({
+      eventTagApi: makeFakeEventTagApi({ deleteTagAndEvents: vi.fn(async () => ({ status: 'ok' })) }),
+      settingApi: makeFakeSettingApi(),
+      // eventRepo 미주입
+    })
+
+    // when
+    await repo.deleteTagAndEvents('tag-x')
+
+    // then: eventRepo 없어도 currentTodos에서 제거됨
+    expect(useCurrentTodosCache.getState().todos.some(t => t.uuid === 'todo-1')).toBe(false)
   })
 })


### PR DESCRIPTION
## 배경
PR #141 후속. eventTagListCache.deleteTagAndEvents 가 태그 삭제 후 currentTodos/uncompletedTodos 의 fetch() 전체 재조회를 호출 — 사용자 원칙(API 응답 활용 필수, 전체 재조회 금지) 위반.

서버 응답 스키마(`{ status: string }`)에 영향받은 UUID 목록 없음 → 클라이언트 보유 캐시를 `event_tag_id` 기준으로 필터하는 in-memory transform으로 전환.

## 변경
- `TagRepository.deleteTagAndEvents` — currentTodosCache/uncompletedTodosCache 의 보유 캐시를 `event_tag_id` 기준으로 filter 후 `replaceAll`. `fetchCurrentTodos`/`fetchUncompletedTodos` 호출 제거
- `calendarEventsCache.invalidateYears` + `fetchEventsForYear` 는 태그+관련 이벤트 삭제 의도에 부합하므로 유지
- `TagRepository.cacheFirst.test` — 구현 호출 검증(`toHaveBeenCalled`) → 캐시 상태 결과 검증으로 교체 (금지 패턴 제거)
- `TagRepository.test` — deleteTagAndEvents 케이스 4개 추가

## Test plan
- [ ] 태그 삭제 시 해당 태그 `event_tag_id` 를 가진 todo 가 currentTodosCache 에서 즉시 제거됨
- [ ] 태그 삭제 시 해당 태그 `event_tag_id` 를 가진 todo 가 uncompletedTodosCache 에서 즉시 제거됨
- [ ] 다른 태그 또는 태그 없는 todo 는 영향받지 않음
- [ ] eventRepo 미주입 시에도 todo 캐시 transform 동작
- [ ] npm test 전체 통과 (1061 tests)
- [ ] npm run build 통과

Closes #146

---

## 동작 근거 (PR review 🔴 해소)

본 PR 의 `deleteTagAndEvents` 는 **2번 시나리오 (태그 + 연관 이벤트 물리 삭제) 전용** 흐름.

- 1번 시나리오 (태그만 삭제 / event_tag_id detach) 는 별도 메서드: `TagRepository.deleteTag` → `DELETE /v1/tags/tag/{id}`
- 사용자 선택 UI: `src/pages/settings/tagManagement/DeleteTagDialog.tsx` 가 1번/2번 선택을 받아 분기 (`onDeleteTagOnly` / `onDeleteTagAndEvents`)
- 따라서 본 PR 의 `event_tag_id === id` filter + replaceAll 동작 (todo 캐시 제거) 은 2번 시나리오의 정확한 캐시 동기화