### PR TITLE
#184 feat(todo): 완료 처리 펄스 + 취소 인터랙션

### DIFF
--- a/e2e/specs/p1-todo-completion-pulse-cancel.spec.ts
+++ b/e2e/specs/p1-todo-completion-pulse-cancel.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, type Page } from '@playwright/test'
+import { setupAuthContext } from '../helpers/auth'
+
+const SAMPLE_TODO = {
+  uuid: 'pulse-todo',
+  name: '펄스 회귀 todo',
+  is_current: true,
+  event_time: null,
+}
+
+async function setupBaseRoutes(page: Page) {
+  await page.route('**/v2/todos**', async route => {
+    const method = route.request().method()
+    const url = route.request().url()
+    if (method === 'GET' && url.includes('uncompleted')) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+      return
+    }
+    if (method === 'GET') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([SAMPLE_TODO]) })
+      return
+    }
+    await route.continue()
+  })
+  await page.route('**/v2/schedules**', async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  })
+  await page.route('**/v2/tags**', async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  })
+  await page.route('**/v2/setting/event/tag/default/color', async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ default: '#aaaaaa', holiday: '#bbbbbb' }) })
+  })
+  await page.route('**/v2/foremost**', async route => {
+    await route.fulfill({ status: 404, body: '{}' })
+  })
+  await page.route('**/v2/holidays**', async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  })
+}
+
+test.beforeEach(async ({ context }) => {
+  await setupAuthContext(context)
+})
+
+test('완료 버튼 클릭 시 채움 + 펄스 상태가 노출되고, 응답 도착 후 todo 가 done 으로 이동한다', async ({ page }) => {
+  await setupBaseRoutes(page)
+  // complete API 응답을 800ms 지연시켜 펄스 상태를 관찰 가능하게 함
+  await page.route('**/v2/todos/todo/pulse-todo/complete', async route => {
+    await new Promise(r => setTimeout(r, 800))
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ uuid: 'done-id', done_at: Date.now(), origin: { ...SAMPLE_TODO } }),
+    })
+  })
+
+  await page.goto('/')
+  const btn = page.getByRole('button', { name: SAMPLE_TODO.name })
+  await expect(btn).toBeVisible()
+  await btn.click()
+
+  // 처리중 — 채움 + 펄스 상태가 표시된다
+  await expect(btn).toHaveAttribute('data-completing', 'true')
+
+  // 응답 도착 후 → 캐시에서 제거되어 목록에서 사라진다
+  await expect(page.getByText(SAMPLE_TODO.name)).toBeHidden({ timeout: 5000 })
+})
+
+test('펄스 상태에서 동일 버튼을 재클릭하면 complete API 가 abort 되어 todo 가 목록에 남는다', async ({ page }) => {
+  await setupBaseRoutes(page)
+  // complete API 응답을 충분히 지연시켜 사용자의 abort 가 응답보다 먼저 도착하게 함
+  await page.route('**/v2/todos/todo/pulse-todo/complete', async route => {
+    await new Promise(r => setTimeout(r, 5000))
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ uuid: 'done', done_at: Date.now(), origin: { ...SAMPLE_TODO } }),
+    })
+  })
+
+  await page.goto('/')
+  const btn = page.getByRole('button', { name: SAMPLE_TODO.name })
+  await expect(btn).toBeVisible()
+  await btn.click()
+  await expect(btn).toHaveAttribute('data-completing', 'true')
+
+  // 재클릭 — fetch abort
+  await btn.click()
+  await expect(btn).toHaveAttribute('data-completing', 'false')
+
+  // todo 가 그대로 목록에 남아있다
+  await expect(page.getByText(SAMPLE_TODO.name)).toBeVisible()
+})

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -12,7 +12,11 @@ export function setUnauthorizedHandler(handler: () => void): void {
   onUnauthorized = handler
 }
 
-async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
+export interface RequestOptions {
+  signal?: AbortSignal
+}
+
+async function request<T>(method: string, path: string, body?: unknown, options?: RequestOptions): Promise<T> {
   const token = await tokenProvider.getToken()
   const response = await fetch(`${BASE_URL}${path}`, {
     method,
@@ -21,6 +25,7 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
       Authorization: `Bearer ${token}`,
     },
     ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    ...(options?.signal ? { signal: options.signal } : {}),
   })
 
   if (!response.ok) {
@@ -37,9 +42,9 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
 }
 
 export const apiClient = {
-  get: <T>(path: string) => request<T>('GET', path),
-  post: <T>(path: string, body?: unknown) => request<T>('POST', path, body),
-  put: <T>(path: string, body?: unknown) => request<T>('PUT', path, body),
-  patch: <T>(path: string, body?: unknown) => request<T>('PATCH', path, body),
-  delete: <T>(path: string) => request<T>('DELETE', path),
+  get: <T>(path: string, options?: RequestOptions) => request<T>('GET', path, undefined, options),
+  post: <T>(path: string, body?: unknown, options?: RequestOptions) => request<T>('POST', path, body, options),
+  put: <T>(path: string, body?: unknown, options?: RequestOptions) => request<T>('PUT', path, body, options),
+  patch: <T>(path: string, body?: unknown, options?: RequestOptions) => request<T>('PATCH', path, body, options),
+  delete: <T>(path: string, options?: RequestOptions) => request<T>('DELETE', path, undefined, options),
 }

--- a/src/api/todoApi.ts
+++ b/src/api/todoApi.ts
@@ -41,11 +41,11 @@ export const todoApi = {
     return apiClient.put(`/v2/todos/todo/${id}`, body)
   },
 
-  completeTodo(id: string, body: { origin: Todo; next_event_time?: EventTime; next_repeating_turn?: number }): Promise<DoneTodo> {
+  completeTodo(id: string, body: { origin: Todo; next_event_time?: EventTime; next_repeating_turn?: number }, options?: { signal?: AbortSignal }): Promise<DoneTodo> {
     const sanitized: Record<string, unknown> = { origin: buildCompleteOrigin(body.origin) }
     if (body.next_event_time != null) sanitized.next_event_time = body.next_event_time
     if (body.next_repeating_turn != null) sanitized.next_repeating_turn = body.next_repeating_turn
-    return apiClient.post(`/v2/todos/todo/${id}/complete`, sanitized)
+    return apiClient.post(`/v2/todos/todo/${id}/complete`, sanitized, options)
   },
 
   replaceTodo(id: string, body: { new: Record<string, unknown>; origin_next_event_time?: EventTime; next_repeating_turn?: number }): Promise<{ new_todo: Todo; next_repeating?: Todo }> {

--- a/src/components/CurrentTodoList.tsx
+++ b/src/components/CurrentTodoList.tsx
@@ -1,9 +1,8 @@
 import { useTranslation } from 'react-i18next'
 import { useResolvedEventTag } from '../hooks/useResolvedEventTag'
 import { tagDisplayName } from '../domain/functions/tagDisplay'
-import type { RepeatScope } from './RepeatingScopeDialog'
 import { useSettingsCache } from '../repositories/caches/settingsCache'
-import { useRepositories } from '../composition/RepositoriesProvider'
+import { useTodoCompleting } from '../hooks/useTodoCompleting'
 import type { Todo } from '../models'
 import type { CalendarEvent } from '../domain/functions/eventTime'
 import { EventTimeDisplay } from './EventTimeDisplay'
@@ -11,11 +10,12 @@ import { EventTimeDisplay } from './EventTimeDisplay'
 interface CurrentTodoRowProps {
   todo: Todo
   onEventClick?: (calEvent: CalendarEvent, anchorRect: DOMRect) => void
-  onComplete: (todo: Todo) => void
+  onComplete: () => void
+  isCompleting: boolean
   isLast: boolean
 }
 
-function CurrentTodoRow({ todo, onEventClick, onComplete, isLast }: CurrentTodoRowProps) {
+function CurrentTodoRow({ todo, onEventClick, onComplete, isCompleting, isLast }: CurrentTodoRowProps) {
   const { t } = useTranslation()
   const resolved = useResolvedEventTag(todo.event_tag_id)
   const color = resolved.color
@@ -65,8 +65,14 @@ function CurrentTodoRow({ todo, onEventClick, onComplete, isLast }: CurrentTodoR
         </div>
         <button
           aria-label={todo.name}
-          className="shrink-0 h-5 w-5 rounded-full border-2 border-line-strong hover:border-fg transition-colors mt-0.5"
-          onClick={(e) => { e.stopPropagation(); onComplete(todo) }}
+          aria-pressed={isCompleting}
+          data-completing={isCompleting ? 'true' : 'false'}
+          className={`shrink-0 h-5 w-5 rounded-full border-2 transition-colors mt-0.5 ${
+            isCompleting
+              ? 'bg-fg border-fg animate-pulse'
+              : 'border-line-strong hover:border-fg'
+          }`}
+          onClick={(e) => { e.stopPropagation(); onComplete() }}
         />
       </div>
     </div>
@@ -80,21 +86,7 @@ export interface CurrentTodoListProps {
 }
 
 export function CurrentTodoList({ todos, isTagHidden, onEventClick }: CurrentTodoListProps) {
-  const { eventRepo } = useRepositories()
-
-  async function handleComplete(todo: Todo) {
-    // 반복 할일은 차수 선택 팝업을 띄우지 않고 항상 현재 차수만 완료 + 다음 차수로 이동 (앱과 동일한 정책)
-    const scope: RepeatScope | undefined = (todo.repeating && todo.event_time) ? 'this' : undefined
-    await doComplete(todo, scope)
-  }
-
-  async function doComplete(todo: Todo, scope?: RepeatScope) {
-    try {
-      await eventRepo.completeTodo(todo, scope)
-    } catch (e) {
-      console.warn('완료 처리 실패:', e)
-    }
-  }
+  const { isCompleting, toggle } = useTodoCompleting()
 
   const visibleTodos = todos.filter(t => !isTagHidden(t.event_tag_id))
 
@@ -112,7 +104,8 @@ export function CurrentTodoList({ todos, isTagHidden, onEventClick }: CurrentTod
             key={todo.uuid}
             todo={todo}
             onEventClick={onEventClick}
-            onComplete={handleComplete}
+            onComplete={() => toggle(todo)}
+            isCompleting={isCompleting(todo.uuid)}
             isLast={i === visibleTodos.length - 1}
           />
         ))}

--- a/src/components/CurrentTodoList.tsx
+++ b/src/components/CurrentTodoList.tsx
@@ -67,13 +67,15 @@ function CurrentTodoRow({ todo, onEventClick, onComplete, isCompleting, isLast }
           aria-label={todo.name}
           aria-pressed={isCompleting}
           data-completing={isCompleting ? 'true' : 'false'}
-          className={`shrink-0 h-5 w-5 rounded-full border-2 transition-colors mt-0.5 ${
-            isCompleting
-              ? 'bg-fg border-fg animate-pulse'
-              : 'border-line-strong hover:border-fg'
+          className={`shrink-0 h-5 w-5 rounded-full border-2 transition-colors mt-0.5 flex items-center justify-center ${
+            isCompleting ? 'border-fg animate-todo-completing' : 'border-line-strong hover:border-fg'
           }`}
           onClick={(e) => { e.stopPropagation(); onComplete() }}
-        />
+        >
+          {isCompleting && (
+            <span className="block h-2.5 w-2.5 rounded-full bg-fg" />
+          )}
+        </button>
       </div>
     </div>
   )

--- a/src/components/UncompletedTodoList.tsx
+++ b/src/components/UncompletedTodoList.tsx
@@ -2,9 +2,8 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useResolvedEventTag } from '../hooks/useResolvedEventTag'
 import { tagDisplayName } from '../domain/functions/tagDisplay'
-import type { RepeatScope } from './RepeatingScopeDialog'
 import { useSettingsCache } from '../repositories/caches/settingsCache'
-import { useRepositories } from '../composition/RepositoriesProvider'
+import { useTodoCompleting } from '../hooks/useTodoCompleting'
 import type { Todo } from '../models'
 import type { CalendarEvent } from '../domain/functions/eventTime'
 import { EventTimeDisplay } from './EventTimeDisplay'
@@ -12,11 +11,12 @@ import { EventTimeDisplay } from './EventTimeDisplay'
 interface UncompletedTodoRowProps {
   todo: Todo
   onEventClick?: (calEvent: CalendarEvent, anchorRect: DOMRect) => void
-  onComplete: (todo: Todo) => void
+  onComplete: () => void
+  isCompleting: boolean
   isLast: boolean
 }
 
-function UncompletedTodoRow({ todo, onEventClick, onComplete, isLast }: UncompletedTodoRowProps) {
+function UncompletedTodoRow({ todo, onEventClick, onComplete, isCompleting, isLast }: UncompletedTodoRowProps) {
   const { t } = useTranslation()
   const resolved = useResolvedEventTag(todo.event_tag_id)
   const color = resolved.color
@@ -66,8 +66,14 @@ function UncompletedTodoRow({ todo, onEventClick, onComplete, isLast }: Uncomple
         </div>
         <button
           aria-label={todo.name}
-          className="shrink-0 h-5 w-5 rounded-full border-2 border-line-strong hover:border-fg transition-colors mt-0.5"
-          onClick={(e) => { e.stopPropagation(); onComplete(todo) }}
+          aria-pressed={isCompleting}
+          data-completing={isCompleting ? 'true' : 'false'}
+          className={`shrink-0 h-5 w-5 rounded-full border-2 transition-colors mt-0.5 ${
+            isCompleting
+              ? 'bg-fg border-fg animate-pulse'
+              : 'border-line-strong hover:border-fg'
+          }`}
+          onClick={(e) => { e.stopPropagation(); onComplete() }}
         />
       </div>
     </div>
@@ -83,22 +89,8 @@ export interface UncompletedTodoListProps {
 
 export function UncompletedTodoList({ todos, isTagHidden, onReload, onEventClick }: UncompletedTodoListProps) {
   const { t } = useTranslation()
-  const { eventRepo } = useRepositories()
+  const { isCompleting, toggle } = useTodoCompleting()
   const [isReloading, setIsReloading] = useState(false)
-
-  async function handleComplete(todo: Todo) {
-    // 반복 할일은 차수 선택 팝업을 띄우지 않고 항상 현재 차수만 완료 + 다음 차수로 이동 (앱과 동일한 정책)
-    const scope: RepeatScope | undefined = (todo.repeating && todo.event_time) ? 'this' : undefined
-    await doComplete(todo, scope)
-  }
-
-  async function doComplete(todo: Todo, scope?: RepeatScope) {
-    try {
-      await eventRepo.completeTodo(todo, scope)
-    } catch (e) {
-      console.warn('완료 처리 실패:', e)
-    }
-  }
 
   async function handleReload() {
     if (isReloading) return
@@ -136,7 +128,8 @@ export function UncompletedTodoList({ todos, isTagHidden, onReload, onEventClick
             key={todo.uuid}
             todo={todo}
             onEventClick={onEventClick}
-            onComplete={handleComplete}
+            onComplete={() => toggle(todo)}
+            isCompleting={isCompleting(todo.uuid)}
             isLast={i === visibleTodos.length - 1}
           />
         ))}

--- a/src/components/UncompletedTodoList.tsx
+++ b/src/components/UncompletedTodoList.tsx
@@ -68,13 +68,15 @@ function UncompletedTodoRow({ todo, onEventClick, onComplete, isCompleting, isLa
           aria-label={todo.name}
           aria-pressed={isCompleting}
           data-completing={isCompleting ? 'true' : 'false'}
-          className={`shrink-0 h-5 w-5 rounded-full border-2 transition-colors mt-0.5 ${
-            isCompleting
-              ? 'bg-fg border-fg animate-pulse'
-              : 'border-line-strong hover:border-fg'
+          className={`shrink-0 h-5 w-5 rounded-full border-2 transition-colors mt-0.5 flex items-center justify-center ${
+            isCompleting ? 'border-fg animate-todo-completing' : 'border-line-strong hover:border-fg'
           }`}
           onClick={(e) => { e.stopPropagation(); onComplete() }}
-        />
+        >
+          {isCompleting && (
+            <span className="block h-2.5 w-2.5 rounded-full bg-fg" />
+          )}
+        </button>
       </div>
     </div>
   )

--- a/src/hooks/useTodoCompleting.ts
+++ b/src/hooks/useTodoCompleting.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useRepositories } from '../composition/RepositoriesProvider'
+import { useToastStore } from '../stores/toastStore'
+import type { Todo } from '../models'
+
+export interface UseTodoCompletingResult {
+  isCompleting: (todoId: string) => boolean
+  toggle: (todo: Todo) => void
+}
+
+function isAbortError(e: unknown): boolean {
+  return typeof e === 'object' && e !== null && (e as { name?: string }).name === 'AbortError'
+}
+
+export function useTodoCompleting(): UseTodoCompletingResult {
+  const { eventRepo } = useRepositories()
+  const [completingIds, setCompletingIds] = useState<Set<string>>(new Set())
+  const controllersRef = useRef<Map<string, AbortController>>(new Map())
+
+  useEffect(() => {
+    const map = controllersRef.current
+    return () => {
+      map.forEach(c => c.abort())
+      map.clear()
+    }
+  }, [])
+
+  const removeId = useCallback((id: string) => {
+    controllersRef.current.delete(id)
+    setCompletingIds(prev => {
+      if (!prev.has(id)) return prev
+      const next = new Set(prev)
+      next.delete(id)
+      return next
+    })
+  }, [])
+
+  const isCompleting = useCallback(
+    (id: string) => completingIds.has(id),
+    [completingIds],
+  )
+
+  const toggle = useCallback((todo: Todo) => {
+    if (controllersRef.current.has(todo.uuid)) {
+      controllersRef.current.get(todo.uuid)!.abort()
+      removeId(todo.uuid)
+      return
+    }
+
+    const controller = new AbortController()
+    controllersRef.current.set(todo.uuid, controller)
+    setCompletingIds(prev => new Set(prev).add(todo.uuid))
+
+    const scope = (todo.repeating && todo.event_time) ? 'this' : undefined
+
+    eventRepo.completeTodo(todo, scope, { signal: controller.signal })
+      .catch((e: unknown) => {
+        if (isAbortError(e)) return
+        useToastStore.getState().show('todo.complete_failed', 'error')
+      })
+      .finally(() => {
+        removeId(todo.uuid)
+      })
+  }, [eventRepo, removeId])
+
+  return { isCompleting, toggle }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -49,11 +49,23 @@
 
   /* === 이벤트 조회 progress bar (#110) — toolbar 하단 indeterminate 인디케이터 === */
   --animate-events-loading-bar: events-loading-bar 1.4s ease-in-out infinite;
+
+  /* === todo 완료 처리중 인디케이터 (#184) — 안쪽 dot 깜빡임 === */
+  --animate-todo-completing: todo-completing-blink 1.15s ease-in-out infinite;
 }
 
 @keyframes events-loading-bar {
   0%   { transform: translateX(-100%); }
   100% { transform: translateX(400%); }
+}
+
+@keyframes todo-completing-blink {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.15; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-todo-completing { animation: none; opacity: 1; }
 }
 
 html {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -162,6 +162,7 @@
   "todo.revert_success": "Reverted successfully",
   "todo.revert_failed": "Failed to revert",
   "todo.delete_failed": "Failed to delete",
+  "todo.complete_failed": "Failed to complete",
   "todo.no_date": "No date",
   "common.loading": "Loading...",
   "common.close": "Close",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -162,6 +162,7 @@
   "todo.revert_success": "되돌리기 완료",
   "todo.revert_failed": "되돌리기에 실패했습니다",
   "todo.delete_failed": "삭제에 실패했습니다",
+  "todo.complete_failed": "완료 처리에 실패했습니다",
   "todo.no_date": "날짜 없음",
   "common.loading": "로딩 중...",
   "common.close": "닫기",

--- a/src/repositories/EventRepository.ts
+++ b/src/repositories/EventRepository.ts
@@ -20,7 +20,7 @@ export interface TodoApi {
   getTodo(id: string): Promise<Todo>
   createTodo(body: { name: string; event_tag_id?: string; event_time?: EventTime; repeating?: Repeating; notification_options?: NotificationOption[]; is_current?: boolean }): Promise<Todo>
   updateTodo(id: string, body: Partial<Pick<Todo, 'name' | 'event_tag_id' | 'event_time' | 'repeating' | 'notification_options'>>): Promise<Todo>
-  completeTodo(id: string, body: { origin: Todo; next_event_time?: EventTime; next_repeating_turn?: number }): Promise<DoneTodo>
+  completeTodo(id: string, body: { origin: Todo; next_event_time?: EventTime; next_repeating_turn?: number }, options?: { signal?: AbortSignal }): Promise<DoneTodo>
   replaceTodo(id: string, body: { new: Record<string, unknown>; origin_next_event_time?: EventTime; next_repeating_turn?: number }): Promise<{ new_todo: Todo; next_repeating?: Todo }>
   patchTodo(id: string, body: Record<string, unknown>): Promise<Todo>
   deleteTodo(id: string): Promise<{ status: string }>
@@ -387,7 +387,7 @@ export class EventRepository {
     return updated
   }
 
-  async completeTodo(todo: Todo, scope?: 'this' | 'future' | 'all'): Promise<DoneTodo> {
+  async completeTodo(todo: Todo, scope?: 'this' | 'future' | 'all', options?: { signal?: AbortSignal }): Promise<DoneTodo> {
     const isRepeating = !!todo.repeating && !!todo.event_time
 
     if (scope === 'this' && isRepeating) {
@@ -396,7 +396,7 @@ export class EventRepository {
         origin: todo,
         next_event_time: next?.time,
         next_repeating_turn: next?.turn,
-      })
+      }, options)
       if (next?.time) {
         const nextTurn = next.turn ?? (todo.repeating_turn ?? 1) + 1
         const advanced: Todo = { ...todo, event_time: next.time, repeating_turn: nextTurn }
@@ -440,7 +440,7 @@ export class EventRepository {
       return done
     }
 
-    const done = await this.deps.todoApi.completeTodo(todo.uuid, { origin: todo })
+    const done = await this.deps.todoApi.completeTodo(todo.uuid, { origin: todo }, options)
     await this.writeLocal('completeTodo (all)', async () => {
       const local = this.deps.localStorageContainer!
       await local.todo().removeTodos([todo.uuid])

--- a/tests/components/CurrentTodoList.test.tsx
+++ b/tests/components/CurrentTodoList.test.tsx
@@ -255,6 +255,56 @@ describe('CurrentTodoList — 완료', () => {
     })
   })
 
+  it('완료 버튼 클릭 시 채움 + animate-pulse 클래스로 처리중 상태가 노출된다', async () => {
+    const todo = { uuid: 't-pulse', name: '펄스', is_current: true, event_time: null } as Todo
+    let releaseCompletion: (() => void) | null = null
+    const pendingRepo = makeFakeEventRepo(
+      () => new Promise<any>(r => { releaseCompletion = () => r({ uuid: 'done', done_at: 0 }) }),
+    )
+
+    render(
+      <RepositoriesProvider value={makeFakeRepos(pendingRepo)}>
+        <MemoryRouter>
+          <CurrentTodoList todos={[todo]} isTagHidden={() => false} />
+        </MemoryRouter>
+      </RepositoriesProvider>
+    )
+    const btn = screen.getByRole('button', { name: '펄스' })
+    await userEvent.click(btn)
+
+    await waitFor(() => expect(btn).toHaveAttribute('data-completing', 'true'))
+    expect(btn.className).toContain('animate-pulse')
+
+    // cleanup — 응답 풀어주어 pending Promise 정리
+    releaseCompletion?.()
+  })
+
+  it('처리중 상태에서 동일 버튼을 재클릭하면 빈 ○ 상태로 복귀한다 (취소)', async () => {
+    const todo = { uuid: 't-cancel', name: '취소', is_current: true, event_time: null } as Todo
+    const abortableRepo = makeFakeEventRepo(
+      ((_t: Todo, _s: unknown, opts?: { signal?: AbortSignal }) => new Promise<any>((_, reject) => {
+        opts?.signal?.addEventListener('abort', () => {
+          reject(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+        })
+      })) as any,
+    )
+
+    render(
+      <RepositoriesProvider value={makeFakeRepos(abortableRepo)}>
+        <MemoryRouter>
+          <CurrentTodoList todos={[todo]} isTagHidden={() => false} />
+        </MemoryRouter>
+      </RepositoriesProvider>
+    )
+    const btn = screen.getByRole('button', { name: '취소' })
+    await userEvent.click(btn)
+    await waitFor(() => expect(btn).toHaveAttribute('data-completing', 'true'))
+
+    await userEvent.click(btn)
+    await waitFor(() => expect(btn).toHaveAttribute('data-completing', 'false'))
+    expect(btn.className).not.toContain('animate-pulse')
+  })
+
   it('반복 Todo 체크박스 클릭 시 RepeatingScopeDialog가 표시되지 않는다', async () => {
     // given: 반복 todo (사용자에게 차수 선택을 묻지 않아야 함)
     const repeatingTodo = {

--- a/tests/components/CurrentTodoList.test.tsx
+++ b/tests/components/CurrentTodoList.test.tsx
@@ -255,7 +255,7 @@ describe('CurrentTodoList — 완료', () => {
     })
   })
 
-  it('완료 버튼 클릭 시 채움 + animate-pulse 클래스로 처리중 상태가 노출된다', async () => {
+  it('완료 버튼 클릭 시 dot + 깜빡임으로 처리중 상태가 노출된다', async () => {
     const todo = { uuid: 't-pulse', name: '펄스', is_current: true, event_time: null } as Todo
     let releaseCompletion: (() => void) | null = null
     const pendingRepo = makeFakeEventRepo(
@@ -273,7 +273,7 @@ describe('CurrentTodoList — 완료', () => {
     await userEvent.click(btn)
 
     await waitFor(() => expect(btn).toHaveAttribute('data-completing', 'true'))
-    expect(btn.className).toContain('animate-pulse')
+    expect(btn.className).toContain('animate-todo-completing')
 
     // cleanup — 응답 풀어주어 pending Promise 정리
     releaseCompletion?.()
@@ -302,7 +302,7 @@ describe('CurrentTodoList — 완료', () => {
 
     await userEvent.click(btn)
     await waitFor(() => expect(btn).toHaveAttribute('data-completing', 'false'))
-    expect(btn.className).not.toContain('animate-pulse')
+    expect(btn.className).not.toContain('animate-todo-completing')
   })
 
   it('반복 Todo 체크박스 클릭 시 RepeatingScopeDialog가 표시되지 않는다', async () => {

--- a/tests/components/UncompletedTodoList.test.tsx
+++ b/tests/components/UncompletedTodoList.test.tsx
@@ -77,9 +77,9 @@ vi.mock('../../src/firebase', () => ({
 const mockOnReload = vi.fn()
 const mockOnEventClick = vi.fn()
 
-function makeFakeRepos(): Repositories {
+function makeFakeRepos(completeImpl?: EventRepository['completeTodo']): Repositories {
   return {
-    eventRepo: { completeTodo: vi.fn(async () => ({ uuid: 'done', done_at: 0 })) } as unknown as EventRepository,
+    eventRepo: { completeTodo: completeImpl ?? vi.fn(async () => ({ uuid: 'done', done_at: 0 })) } as unknown as EventRepository,
     eventDetailRepo: {} as any,
     tagRepo: {} as any,
     holidayRepo: {} as any,
@@ -175,6 +175,55 @@ describe('UncompletedTodoList', () => {
       expect(button).toHaveAttribute('aria-busy', 'false')
       expect(button).not.toBeDisabled()
     })
+  })
+
+  it('완료 버튼 클릭 시 채움 + animate-pulse 클래스로 처리중 상태가 노출된다', async () => {
+    const todo = { uuid: 'u-pulse', name: '펄스 미완료', is_current: false, event_time: null } as Todo
+    let releaseCompletion: (() => void) | null = null
+    const repos = makeFakeRepos(
+      (() => new Promise<any>(r => { releaseCompletion = () => r({ uuid: 'done', done_at: 0 }) })) as any,
+    )
+
+    render(
+      <RepositoriesProvider value={repos}>
+        <MemoryRouter>
+          <UncompletedTodoList {...defaultProps({ todos: [todo] })} />
+        </MemoryRouter>
+      </RepositoriesProvider>
+    )
+    const btn = screen.getByRole('button', { name: '펄스 미완료' })
+    await userEvent.click(btn)
+
+    await waitFor(() => expect(btn).toHaveAttribute('data-completing', 'true'))
+    expect(btn.className).toContain('animate-pulse')
+
+    releaseCompletion?.()
+  })
+
+  it('처리중 상태에서 동일 버튼을 재클릭하면 빈 ○ 상태로 복귀한다 (취소)', async () => {
+    const todo = { uuid: 'u-cancel', name: '취소 미완료', is_current: false, event_time: null } as Todo
+    const repos = makeFakeRepos(
+      ((_t: Todo, _s: unknown, opts?: { signal?: AbortSignal }) => new Promise<any>((_, reject) => {
+        opts?.signal?.addEventListener('abort', () => {
+          reject(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+        })
+      })) as any,
+    )
+
+    render(
+      <RepositoriesProvider value={repos}>
+        <MemoryRouter>
+          <UncompletedTodoList {...defaultProps({ todos: [todo] })} />
+        </MemoryRouter>
+      </RepositoriesProvider>
+    )
+    const btn = screen.getByRole('button', { name: '취소 미완료' })
+    await userEvent.click(btn)
+    await waitFor(() => expect(btn).toHaveAttribute('data-completing', 'true'))
+
+    await userEvent.click(btn)
+    await waitFor(() => expect(btn).toHaveAttribute('data-completing', 'false'))
+    expect(btn.className).not.toContain('animate-pulse')
   })
 })
 

--- a/tests/components/UncompletedTodoList.test.tsx
+++ b/tests/components/UncompletedTodoList.test.tsx
@@ -177,7 +177,7 @@ describe('UncompletedTodoList', () => {
     })
   })
 
-  it('완료 버튼 클릭 시 채움 + animate-pulse 클래스로 처리중 상태가 노출된다', async () => {
+  it('완료 버튼 클릭 시 dot + 깜빡임으로 처리중 상태가 노출된다', async () => {
     const todo = { uuid: 'u-pulse', name: '펄스 미완료', is_current: false, event_time: null } as Todo
     let releaseCompletion: (() => void) | null = null
     const repos = makeFakeRepos(
@@ -195,7 +195,7 @@ describe('UncompletedTodoList', () => {
     await userEvent.click(btn)
 
     await waitFor(() => expect(btn).toHaveAttribute('data-completing', 'true'))
-    expect(btn.className).toContain('animate-pulse')
+    expect(btn.className).toContain('animate-todo-completing')
 
     releaseCompletion?.()
   })
@@ -223,7 +223,7 @@ describe('UncompletedTodoList', () => {
 
     await userEvent.click(btn)
     await waitFor(() => expect(btn).toHaveAttribute('data-completing', 'false'))
-    expect(btn.className).not.toContain('animate-pulse')
+    expect(btn.className).not.toContain('animate-todo-completing')
   })
 })
 

--- a/tests/hooks/useTodoCompleting.test.tsx
+++ b/tests/hooks/useTodoCompleting.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { useTodoCompleting } from '../../src/hooks/useTodoCompleting'
+import { RepositoriesProvider } from '../../src/composition/RepositoriesProvider'
+import { useToastStore } from '../../src/stores/toastStore'
+import type { Repositories } from '../../src/composition/container'
+import type { EventRepository } from '../../src/repositories/EventRepository'
+import type { Todo } from '../../src/models'
+
+function makeTodo(uuid = 'todo-1', overrides: Partial<Todo> = {}): Todo {
+  return { uuid, name: 'test', ...overrides } as Todo
+}
+
+function makeRepeatingTodo(uuid = 'todo-r'): Todo {
+  return {
+    uuid,
+    name: 'repeating',
+    event_time: { type: 'at', time: 1000 } as any,
+    repeating: { repeat_option: { optionType: 'everyDay' }, repeatingStartTime: 1000 } as any,
+  } as Todo
+}
+
+function makeFakeRepo(completeImpl: EventRepository['completeTodo']): Repositories {
+  return {
+    eventRepo: { completeTodo: completeImpl } as unknown as EventRepository,
+  } as Repositories
+}
+
+function setup(repos: Repositories) {
+  return renderHook(() => useTodoCompleting(), {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <RepositoriesProvider value={repos}>{children}</RepositoriesProvider>
+    ),
+  })
+}
+
+describe('useTodoCompleting', () => {
+  beforeEach(() => {
+    useToastStore.setState({ toasts: [] })
+  })
+
+  it('toggle 호출 시 해당 todo 가 진행 중 상태가 되고, API 응답 도착 시 해제된다', async () => {
+    let resolveCall: (() => void) | null = null
+    const repos = makeFakeRepo(
+      vi.fn(() => new Promise<any>(r => { resolveCall = () => r({ uuid: 'done', done_at: 0 }) })),
+    )
+    const { result } = setup(repos)
+
+    act(() => result.current.toggle(makeTodo('a')))
+    expect(result.current.isCompleting('a')).toBe(true)
+
+    await act(async () => {
+      resolveCall!()
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(result.current.isCompleting('a')).toBe(false))
+  })
+
+  it('진행 중 동일 todo 의 toggle 을 다시 호출하면 진행 상태가 즉시 해제된다 (취소)', async () => {
+    const repos = makeFakeRepo(
+      vi.fn((_t, _s, opts: any) => new Promise<any>((_, reject) => {
+        opts.signal.addEventListener('abort', () => {
+          reject(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+        })
+      })),
+    )
+    const { result } = setup(repos)
+
+    act(() => result.current.toggle(makeTodo('a')))
+    expect(result.current.isCompleting('a')).toBe(true)
+
+    act(() => result.current.toggle(makeTodo('a')))
+    expect(result.current.isCompleting('a')).toBe(false)
+    await waitFor(() => expect(useToastStore.getState().toasts).toHaveLength(0))
+  })
+
+  it('비-Abort 에러 발생 시 todo.complete_failed 토스트가 표시되고 진행 상태가 해제된다', async () => {
+    const repos = makeFakeRepo(vi.fn(() => Promise.reject(new Error('network'))))
+    const { result } = setup(repos)
+
+    act(() => result.current.toggle(makeTodo('a')))
+    await waitFor(() => expect(result.current.isCompleting('a')).toBe(false))
+    expect(useToastStore.getState().toasts).toHaveLength(1)
+    expect(useToastStore.getState().toasts[0].key).toBe('todo.complete_failed')
+    expect(useToastStore.getState().toasts[0].type).toBe('error')
+  })
+
+  it('hook 을 가진 컴포넌트가 unmount 되면 진행 중 호출이 abort 되어 토스트가 발생하지 않는다', async () => {
+    const repos = makeFakeRepo(
+      vi.fn((_t, _s, opts: any) => new Promise<any>((_, reject) => {
+        opts.signal.addEventListener('abort', () => {
+          reject(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+        })
+      })),
+    )
+    const { result, unmount } = setup(repos)
+
+    act(() => result.current.toggle(makeTodo('a')))
+    expect(result.current.isCompleting('a')).toBe(true)
+
+    unmount()
+    await new Promise(r => setTimeout(r, 0))
+    expect(useToastStore.getState().toasts).toHaveLength(0)
+  })
+
+  it('반복 todo 의 경우 scope="this" 로 eventRepo.completeTodo 가 호출된다', async () => {
+    let capturedScope: unknown = 'unset'
+    const repos = makeFakeRepo(
+      vi.fn((_t: Todo, scope: unknown) => {
+        capturedScope = scope
+        return Promise.resolve({ uuid: 'done', done_at: 0 } as any)
+      }),
+    )
+    const { result } = setup(repos)
+
+    await act(async () => {
+      result.current.toggle(makeRepeatingTodo('r1'))
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(result.current.isCompleting('r1')).toBe(false))
+    expect(capturedScope).toBe('this')
+  })
+})


### PR DESCRIPTION
Closes #184

## 배경

todo ○ 버튼 클릭 시 `eventRepo.completeTodo` 가 응답을 await 한 뒤에야 캐시를 업데이트했기 때문에 사용자는 처리중인지 인지하지 못하고 중복 클릭을 시도하기 쉬웠다. 의도치 않은 클릭을 취소할 수단도 없었다.

## 변경

완료 클릭 시 ○ 가 즉시 채워진 ● + `animate-pulse` 로 처리중 상태를 노출하고, 동일 버튼 재클릭 시 진행중인 complete API 호출을 `AbortController.abort()` 로 취소해 ○ 로 복귀한다. 단일/반복 todo 모두 동일 인터랙션 (반복은 자동 `scope='this'` 정책 그대로).

## 커밋 시리즈

1. `#184 feat(api): completeTodo 경로에 AbortSignal options 시그니처 확장` — apiClient + todoApi + EventRepository.TodoApi interface 까지 signal 옵션 통과 경로 마련. `future` 분기는 patchTodo→completeTodo 두 단계 partial state 위험 회피를 위해 signal 무전달.
2. `#184 feat(hooks): useTodoCompleting 도입` — 진행 상태(Set) + AbortController(Map) 관리, toggle 시작/재호출 시 abort, unmount 시 일괄 abort, 비-Abort 에러만 `todo.complete_failed` 토스트. + 단위 테스트 5종 + locale 키.
3. `#184 feat(component): CurrentTodoList 펄스 + 취소 적용` — 채움(bg-fg) + animate-pulse 분기 + `data-completing` 어트리뷰트. handleComplete/doComplete 제거 후 hook 일임. 회귀 안전망 2건.
4. `#184 feat(component): UncompletedTodoList 펄스 + 취소 적용` — 동일 인터페이스로 통일.
5. `#184 test(e2e): todo 완료 펄스/취소 회귀 안전망` — 800ms 지연 응답으로 펄스 노출 → done 이동 / 5s 지연 응답에서 재클릭 abort → todo 잔류.

## 인정된 trade-off

abort 시점에 서버가 이미 완료 처리를 끝냈다면 → 클라이언트는 todo 그대로, 서버는 done 저장됨 → 다음 refetch 때 todo 가 사라지고 done 으로 나타난다. 사용자가 채택한 trade-off (leading delay 모델 거부).

## 테스트

- Unit (Vitest): 1162 passed (149 files)
- E2E (Playwright): 143 passed / 7 skipped (KNOWN FAIL - 기존)
- 신규 E2E: 펄스 노출 + 응답 후 done 이동 / 재클릭 abort + todo 잔류