### PR TITLE
#189 fix: 이벤트 목록 반복 할일 완료 시 불필요한 회차 선택 팝업 제거

### DIFF
--- a/src/components/DayEventList.tsx
+++ b/src/components/DayEventList.tsx
@@ -1,12 +1,10 @@
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useResolvedEventTag } from '../hooks/useResolvedEventTag'
 import { tagDisplayName } from '../domain/functions/tagDisplay'
 import { TimeDescription } from './TimeDescription'
-import { RepeatingScopeDialog, type RepeatScope } from './RepeatingScopeDialog'
 import { formatDateKey } from '../domain/functions/eventTime'
 import { useSettingsCache } from '../repositories/caches/settingsCache'
-import { useRepositories } from '../composition/RepositoriesProvider'
+import { useTodoCompleting } from '../hooks/useTodoCompleting'
 import type { CalendarEvent } from '../domain/functions/eventTime'
 import type { Todo } from '../models'
 
@@ -87,31 +85,7 @@ export interface DayEventListProps {
 
 export function DayEventList({ selectedDate, eventsByDate, isTagHidden, onEventClick }: DayEventListProps) {
   const { t } = useTranslation()
-  const { eventRepo } = useRepositories()
-  const [scopeTarget, setScopeTarget] = useState<Todo | null>(null)
-
-  async function handleComplete(todo: Todo) {
-    if (todo.repeating && todo.event_time) {
-      setScopeTarget(todo)
-      return
-    }
-    await doComplete(todo)
-  }
-
-  async function doComplete(todo: Todo, scope?: RepeatScope) {
-    try {
-      await eventRepo.completeTodo(todo, scope)
-    } catch (e) {
-      console.warn('완료 처리 실패:', e)
-    }
-  }
-
-  async function handleCompleteWithScope(scope: RepeatScope) {
-    if (!scopeTarget) return
-    const todo = scopeTarget
-    setScopeTarget(null)
-    await doComplete(todo, scope)
-  }
+  const { toggle } = useTodoCompleting()
 
   if (!selectedDate) return null
 
@@ -128,33 +102,22 @@ export function DayEventList({ selectedDate, eventsByDate, isTagHidden, onEventC
   const sorted = [...allEvents].sort((a, b) => getTimestamp(a) - getTimestamp(b))
 
   return (
-    <>
-      <div className="flex flex-col">
-        {sorted.length === 0 ? (
-          <div className="flex items-center justify-center py-8 text-sm text-fg-tertiary">
-            {t('event.no_events')}
-          </div>
-        ) : (
-          sorted.map((calEvent, i) => (
-            <EventItem
-              key={`${calEvent.event.uuid}-${i}`}
-              calEvent={calEvent}
-              onEventClick={onEventClick}
-              onComplete={handleComplete}
-              isLast={i === sorted.length - 1}
-            />
-          ))
-        )}
-      </div>
-
-      {scopeTarget && (
-        <RepeatingScopeDialog
-          mode="complete"
-          eventType="todo"
-          onSelect={handleCompleteWithScope}
-          onCancel={() => setScopeTarget(null)}
-        />
+    <div className="flex flex-col">
+      {sorted.length === 0 ? (
+        <div className="flex items-center justify-center py-8 text-sm text-fg-tertiary">
+          {t('event.no_events')}
+        </div>
+      ) : (
+        sorted.map((calEvent, i) => (
+          <EventItem
+            key={`${calEvent.event.uuid}-${i}`}
+            calEvent={calEvent}
+            onEventClick={onEventClick}
+            onComplete={toggle}
+            isLast={i === sorted.length - 1}
+          />
+        ))
       )}
-    </>
+    </div>
   )
 }

--- a/tests/components/DayEventList.test.tsx
+++ b/tests/components/DayEventList.test.tsx
@@ -162,4 +162,26 @@ describe('DayEventList', () => {
     expect(calEvent.event.uuid).toBe('todo-abc')
     expect(typeof anchorRect).toBe('object')
   })
+
+  it('반복 할일의 완료 버튼을 눌러도 회차 선택 팝업을 띄우지 않는다', async () => {
+    // given: 반복(repeating) + 시간이 있는 할일
+    const repeatingTodo = {
+      uuid: 'rt1',
+      name: '반복 할 일',
+      is_current: false,
+      event_time: { time_type: 'at' as const, timestamp: 1710480600 },
+      repeating: { start: { timestamp: 1710480600, timeZone: 'UTC' }, option: { optionType: 'everyDay' as const, interval: 1 } },
+      repeating_turn: 1,
+    }
+    const eventsByDate = new Map([
+      ['2024-03-15', [{ type: 'todo' as const, event: repeatingTodo }]],
+    ])
+
+    // when: 완료 버튼(aria-label = 할일 이름) 클릭
+    renderComponent({ selectedDate: new Date(2024, 2, 15), eventsByDate })
+    await userEvent.click(screen.getByRole('button', { name: '반복 할 일' }))
+
+    // then: 회차 선택 팝업이 노출되지 않는다 (우측 패널과 동일하게 바로 완료)
+    expect(screen.queryByTestId('repeating-scope-dialog')).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
Closes #189

## 문제

메인화면 **이벤트 목록(DayEventList)**에서 반복 할일의 완료 버튼을 누르면 `이번만 / 앞으로 모두 / 모두` 선택 팝업이 떴다. todo 완료는 회차 선택이 필요 없는 동작이라 불필요한 스펙이다. 반면 우측 이벤트 패널에서는 팝업 없이 바로 완료돼서 두 경로의 UX가 어긋났다.

## 원인

같은 "todo 완료" 동작인데 두 진입점이 서로 다른 패턴을 썼다.

- 우측 패널 (`useTodoCompleting.toggle`): 반복 todo여도 자동 `scope='this'` → 팝업 없이 즉시 완료
- 이벤트 목록 (`DayEventList.handleComplete`): 반복 todo면 `RepeatingScopeDialog` 강제 노출

## 수정

`DayEventList`의 완료 처리를 `useTodoCompleting` 훅 재사용으로 통일. 팝업 분기(`scopeTarget` state + `RepeatingScopeDialog`)를 제거해 두 경로를 단일 소스로 맞췄다. 이제 이벤트 목록에서도 우측 패널과 동일하게 반복 할일이 팝업 없이 바로 완료된다.

## 검증

- 회귀 테스트 추가 (TDD): 반복 할일 완료 버튼 클릭 시 `repeating-scope-dialog`가 노출되지 않음을 검증 (RED → GREEN)
- 전체 유닛/컴포넌트 테스트 1171개 통과, `tsc --noEmit` 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)