### PR TITLE
#191 fix(api): weekday codec 누락 일괄 보강 (todoApi + foremostApi)

### DIFF
--- a/src/api/foremostApi.ts
+++ b/src/api/foremostApi.ts
@@ -1,13 +1,23 @@
 import { apiClient } from './apiClient'
 import type { ForemostEvent } from '../models'
+import { repeatingFromServer } from './repeatingCodec'
+
+// foremost 의 embedded event(Todo|Schedule)도 repeating 을 가질 수 있다. scheduleApi/todoApi 와
+// 동일하게 네트워크 경계에서 weekday 를 web 인코딩(getDay 0=일)으로 변환한다. 미변환 시 server
+// 인코딩(일=1)이 메모리/로컬캐시에 그대로 올라가, 배너 클릭 시 EventDetailPopover 의
+// describeRepeating 이 요일을 한 칸 밀어 표기한다 (예: 매주 일요일 → "매주 월요일").
+function foremostFromServer(f: ForemostEvent): ForemostEvent {
+  if (!f.event?.repeating) return f
+  return { ...f, event: { ...f.event, repeating: repeatingFromServer(f.event.repeating) } }
+}
 
 export const foremostApi = {
-  getForemostEvent(): Promise<ForemostEvent> {
-    return apiClient.get('/v2/foremost/event')
+  async getForemostEvent(): Promise<ForemostEvent> {
+    return foremostFromServer(await apiClient.get<ForemostEvent>('/v2/foremost/event'))
   },
 
-  setForemostEvent(body: { event_id: string; is_todo: boolean }): Promise<ForemostEvent> {
-    return apiClient.put('/v2/foremost/event', body)
+  async setForemostEvent(body: { event_id: string; is_todo: boolean }): Promise<ForemostEvent> {
+    return foremostFromServer(await apiClient.put<ForemostEvent>('/v2/foremost/event', body))
   },
 
   removeForemostEvent(): Promise<{ status: string }> {

--- a/src/api/todoApi.ts
+++ b/src/api/todoApi.ts
@@ -1,5 +1,27 @@
 import { apiClient } from './apiClient'
 import type { Todo, DoneTodo, EventTime, Repeating, NotificationOption } from '../models'
+import { repeatingFromServer, repeatingToServer } from './repeatingCodec'
+
+// 서버는 weekday 를 1=일..7=토 로 인코딩한다. web 은 Date.getDay()(0=일..6=토)로 통일돼 있어
+// scheduleApi 와 동일하게 이 모듈(네트워크 경계)에서만 변환한다. 위 레이어·로컬캐시는 전부 web 인코딩을 본다.
+// (issue #191: todo 경로엔 이 변환이 빠져 있어, 매주 일요일(서버 1) 반복 todo 가 web 에서 월요일(1)로
+//  해석돼 완료 시 다음 차수가 다음주 일요일이 아니라 내일(월요일)로 계산됐음)
+
+function todoFromServer(t: Todo): Todo {
+  return t.repeating != null ? { ...t, repeating: repeatingFromServer(t.repeating) } : t
+}
+
+// 명시적 `repeating: null`(시리즈 제거 요청)은 변환 없이 그대로 통과시켜 서버에 전달한다.
+function bodyToServer<T extends { repeating?: Repeating | null }>(body: T): T {
+  return body.repeating != null ? { ...body, repeating: repeatingToServer(body.repeating) } : body
+}
+
+// patchTodo / replaceTodo 처럼 타입이 느슨한 Record body 안의 repeating 만 서버 인코딩으로 변환.
+function recordRepeatingToServer<T extends Record<string, unknown>>(body: T): T {
+  return body.repeating != null
+    ? { ...body, repeating: repeatingToServer(body.repeating as Repeating) }
+    : body
+}
 
 /**
  * iOS `TodoMakeParams.asJson()` 와 동일한 5개 필드만 추려낸다.
@@ -11,49 +33,60 @@ function buildCompleteOrigin(origin: Todo): Record<string, unknown> {
   const sanitized: Record<string, unknown> = { name: origin.name }
   if (origin.event_tag_id != null) sanitized.event_tag_id = origin.event_tag_id
   if (origin.event_time != null) sanitized.event_time = origin.event_time
-  if (origin.repeating != null) sanitized.repeating = origin.repeating
+  if (origin.repeating != null) sanitized.repeating = repeatingToServer(origin.repeating)
   if (origin.notification_options != null) sanitized.notification_options = origin.notification_options
   return sanitized
 }
 
 export const todoApi = {
-  getTodos(lower: number, upper: number): Promise<Todo[]> {
-    return apiClient.get(`/v2/todos?lower=${lower}&upper=${upper}`)
+  async getTodos(lower: number, upper: number): Promise<Todo[]> {
+    const todos = await apiClient.get<Todo[]>(`/v2/todos?lower=${lower}&upper=${upper}`)
+    return todos.map(todoFromServer)
   },
 
-  getCurrentTodos(): Promise<Todo[]> {
-    return apiClient.get('/v2/todos')
+  async getCurrentTodos(): Promise<Todo[]> {
+    const todos = await apiClient.get<Todo[]>('/v2/todos')
+    return todos.map(todoFromServer)
   },
 
-  getUncompletedTodos(refTime: number): Promise<Todo[]> {
-    return apiClient.get(`/v2/todos/uncompleted?refTime=${refTime}`)
+  async getUncompletedTodos(refTime: number): Promise<Todo[]> {
+    const todos = await apiClient.get<Todo[]>(`/v2/todos/uncompleted?refTime=${refTime}`)
+    return todos.map(todoFromServer)
   },
 
-  getTodo(id: string): Promise<Todo> {
-    return apiClient.get(`/v2/todos/todo/${id}`)
+  async getTodo(id: string): Promise<Todo> {
+    return todoFromServer(await apiClient.get<Todo>(`/v2/todos/todo/${id}`))
   },
 
-  createTodo(body: { name: string; event_tag_id?: string; event_time?: EventTime; repeating?: Repeating; notification_options?: NotificationOption[]; is_current?: boolean }): Promise<Todo> {
-    return apiClient.post('/v2/todos/todo', body)
+  async createTodo(body: { name: string; event_tag_id?: string; event_time?: EventTime; repeating?: Repeating; notification_options?: NotificationOption[]; is_current?: boolean }): Promise<Todo> {
+    return todoFromServer(await apiClient.post<Todo>('/v2/todos/todo', bodyToServer(body)))
   },
 
-  updateTodo(id: string, body: Partial<Pick<Todo, 'name' | 'event_tag_id' | 'event_time' | 'repeating' | 'notification_options'>>): Promise<Todo> {
-    return apiClient.put(`/v2/todos/todo/${id}`, body)
+  async updateTodo(id: string, body: Partial<Pick<Todo, 'name' | 'event_tag_id' | 'event_time' | 'repeating' | 'notification_options'>>): Promise<Todo> {
+    return todoFromServer(await apiClient.put<Todo>(`/v2/todos/todo/${id}`, bodyToServer(body)))
   },
 
   completeTodo(id: string, body: { origin: Todo; next_event_time?: EventTime; next_repeating_turn?: number }, options?: { signal?: AbortSignal }): Promise<DoneTodo> {
     const sanitized: Record<string, unknown> = { origin: buildCompleteOrigin(body.origin) }
     if (body.next_event_time != null) sanitized.next_event_time = body.next_event_time
     if (body.next_repeating_turn != null) sanitized.next_repeating_turn = body.next_repeating_turn
+    // DoneTodo 는 repeating 필드가 없어 응답 변환 불필요.
     return apiClient.post(`/v2/todos/todo/${id}/complete`, sanitized, options)
   },
 
-  replaceTodo(id: string, body: { new: Record<string, unknown>; origin_next_event_time?: EventTime; next_repeating_turn?: number }): Promise<{ new_todo: Todo; next_repeating?: Todo }> {
-    return apiClient.post(`/v2/todos/todo/${id}/replace`, body)
+  async replaceTodo(id: string, body: { new: Record<string, unknown>; origin_next_event_time?: EventTime; next_repeating_turn?: number }): Promise<{ new_todo: Todo; next_repeating?: Todo }> {
+    const result = await apiClient.post<{ new_todo: Todo; next_repeating?: Todo }>(
+      `/v2/todos/todo/${id}/replace`,
+      { ...body, new: recordRepeatingToServer(body.new) },
+    )
+    return {
+      new_todo: todoFromServer(result.new_todo),
+      next_repeating: result.next_repeating != null ? todoFromServer(result.next_repeating) : undefined,
+    }
   },
 
-  patchTodo(id: string, body: Record<string, unknown>): Promise<Todo> {
-    return apiClient.patch(`/v2/todos/todo/${id}`, body)
+  async patchTodo(id: string, body: Record<string, unknown>): Promise<Todo> {
+    return todoFromServer(await apiClient.patch<Todo>(`/v2/todos/todo/${id}`, recordRepeatingToServer(body)))
   },
 
   deleteTodo(id: string): Promise<{ status: string }> {

--- a/tests/api/foremostApi.test.ts
+++ b/tests/api/foremostApi.test.ts
@@ -34,6 +34,43 @@ describe('foremostApi', () => {
     expect(JSON.parse((options as RequestInit).body as string)).toEqual(body)
   })
 
+  // #191 후속: foremost 의 embedded event(Todo|Schedule)도 repeating 을 가질 수 있으므로
+  // scheduleApi/todoApi 와 동일하게 weekday 를 web 인코딩(getDay 0=일)으로 변환해야 한다.
+  // 미변환 시 배너 클릭 → EventDetailPopover 의 describeRepeating 이 요일을 한 칸 밀어 표기한다.
+  describe('weekday 인코딩 변환 (서버 1=일 ↔ web getDay 0=일)', () => {
+    const serverForemost = {
+      event_id: 'sch-rep',
+      is_todo: false,
+      event: {
+        uuid: 'sch-rep',
+        name: '매주 일요일',
+        event_time: { time_type: 'at', timestamp: 1770267600 },
+        repeating: {
+          start: 1770267600,
+          option: { optionType: 'every_week', interval: 1, dayOfWeek: [1], timeZone: 'Asia/Seoul' },
+        },
+      },
+    }
+
+    it('getForemostEvent 응답의 서버 요일(일=1)을 web getDay(일=0)로 변환한다', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify(serverForemost), { status: 200, headers: { 'content-type': 'application/json' } })
+      )
+      const { foremostApi } = await import('../../src/api/foremostApi')
+      const result = await foremostApi.getForemostEvent()
+      expect((result.event as any).repeating.option.dayOfWeek).toEqual([0])
+    })
+
+    it('setForemostEvent 응답도 web getDay 로 변환한다', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify(serverForemost), { status: 200, headers: { 'content-type': 'application/json' } })
+      )
+      const { foremostApi } = await import('../../src/api/foremostApi')
+      const result = await foremostApi.setForemostEvent({ event_id: 'sch-rep', is_todo: false })
+      expect((result.event as any).repeating.option.dayOfWeek).toEqual([0])
+    })
+  })
+
   it('removeForemostEvent()가 /v2/foremost/event로 DELETE 호출한다', async () => {
     fetchSpy.mockResolvedValue(
       new Response(JSON.stringify({ status: 'ok' }), { status: 200, headers: { 'content-type': 'application/json' } })

--- a/tests/api/todoApi.test.ts
+++ b/tests/api/todoApi.test.ts
@@ -178,4 +178,142 @@ describe('todoApi', () => {
     expect(String(url)).toContain('/v2/todos/todo/todo-1')
     expect((options as RequestInit).method).toBe('DELETE')
   })
+
+  // schedule 과 동일하게 todo 도 weekday 인코딩을 네트워크 경계에서 변환해야 한다.
+  // (issue #191) 이 변환이 빠지면 매주 일요일(서버 1) 반복 todo 가 web 도메인에서 월요일(1)로
+  // 해석돼, 완료 시 다음 차수가 다음주 일요일이 아니라 내일(월요일)로 계산된다.
+  describe('weekday 인코딩 변환 (서버 1=일..7=토 ↔ web getDay 0=일..6=토)', () => {
+    const sundayWeb = 0
+    const sundayServer = 1
+    const serverTodo = {
+      uuid: 'todo-rep',
+      name: '매주 일요일 할일',
+      is_current: true,
+      event_time: { time_type: 'at', timestamp: 1770267600 },
+      repeating: {
+        start: 1770267600,
+        option: { optionType: 'every_week', interval: 1, dayOfWeek: [sundayServer], timeZone: 'Asia/Seoul' },
+      },
+    }
+
+    const expectWebSunday = (todo: Todo) =>
+      expect((todo.repeating!.option as any).dayOfWeek).toEqual([sundayWeb])
+
+    it('getTodos 응답의 서버 요일(일=1)을 web getDay(일=0)로 변환해 돌려준다', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify([serverTodo]), { status: 200, headers: { 'content-type': 'application/json' } })
+      )
+      const { todoApi } = await import('../../src/api/todoApi')
+      const [todo] = await todoApi.getTodos(0, 2_000_000_000)
+      expectWebSunday(todo)
+    })
+
+    it('getCurrentTodos 응답도 web getDay 로 변환한다', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify([serverTodo]), { status: 200, headers: { 'content-type': 'application/json' } })
+      )
+      const { todoApi } = await import('../../src/api/todoApi')
+      const [todo] = await todoApi.getCurrentTodos()
+      expectWebSunday(todo)
+    })
+
+    it('getUncompletedTodos 응답도 web getDay 로 변환한다', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify([serverTodo]), { status: 200, headers: { 'content-type': 'application/json' } })
+      )
+      const { todoApi } = await import('../../src/api/todoApi')
+      const [todo] = await todoApi.getUncompletedTodos(1770000000)
+      expectWebSunday(todo)
+    })
+
+    it('getTodo 응답도 web getDay 로 변환한다', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify(serverTodo), { status: 200, headers: { 'content-type': 'application/json' } })
+      )
+      const { todoApi } = await import('../../src/api/todoApi')
+      const todo = await todoApi.getTodo('todo-rep')
+      expectWebSunday(todo)
+    })
+
+    it('createTodo 는 web getDay(일=0)를 서버 요일(일=1)로 변환해 전송하고, 응답은 다시 web 으로 변환한다', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify(serverTodo), { status: 200, headers: { 'content-type': 'application/json' } })
+      )
+      const { todoApi } = await import('../../src/api/todoApi')
+      const created = await todoApi.createTodo({
+        name: '매주 일요일 할일',
+        event_time: { time_type: 'at', timestamp: 1770267600 },
+        repeating: {
+          start: 1770267600,
+          option: { optionType: 'every_week', interval: 1, dayOfWeek: [sundayWeb], timeZone: 'Asia/Seoul' },
+        },
+      })
+      const sentBody = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string)
+      expect(sentBody.repeating.option.dayOfWeek).toEqual([sundayServer])
+      expectWebSunday(created)
+    })
+
+    it('updateTodo 도 요청 body 의 요일을 서버 인코딩으로 변환해 전송한다', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify(serverTodo), { status: 200, headers: { 'content-type': 'application/json' } })
+      )
+      const { todoApi } = await import('../../src/api/todoApi')
+      await todoApi.updateTodo('todo-rep', {
+        repeating: {
+          start: 1770267600,
+          option: { optionType: 'every_week', interval: 1, dayOfWeek: [sundayWeb], timeZone: 'Asia/Seoul' },
+        },
+      })
+      const sentBody = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string)
+      expect(sentBody.repeating.option.dayOfWeek).toEqual([sundayServer])
+    })
+
+    it('patchTodo 의 body.repeating 도 서버 인코딩으로 변환하고 응답은 web 으로 변환한다', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify(serverTodo), { status: 200, headers: { 'content-type': 'application/json' } })
+      )
+      const { todoApi } = await import('../../src/api/todoApi')
+      const updated = await todoApi.patchTodo('todo-rep', {
+        repeating: {
+          start: 1770267600,
+          option: { optionType: 'every_week', interval: 1, dayOfWeek: [sundayWeb], timeZone: 'Asia/Seoul' },
+        },
+      })
+      const sentBody = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string)
+      expect(sentBody.repeating.option.dayOfWeek).toEqual([sundayServer])
+      expectWebSunday(updated)
+    })
+
+    it('completeTodo 의 origin.repeating 도 서버 인코딩으로 변환해 전송한다', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ uuid: 'done-1' }), { status: 200, headers: { 'content-type': 'application/json' } })
+      )
+      const { todoApi } = await import('../../src/api/todoApi')
+      const origin: Todo = {
+        uuid: 'todo-rep',
+        name: '매주 일요일 할일',
+        is_current: true,
+        event_time: { time_type: 'at', timestamp: 1770267600 },
+        repeating: {
+          start: 1770267600,
+          option: { optionType: 'every_week', interval: 1, dayOfWeek: [sundayWeb], timeZone: 'Asia/Seoul' },
+        },
+      }
+      await todoApi.completeTodo('todo-rep', { origin })
+      const sentBody = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string)
+      expect(sentBody.origin.repeating.option.dayOfWeek).toEqual([sundayServer])
+    })
+
+    it('replaceTodo 의 next_repeating 응답도 web getDay 로 변환한다', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ new_todo: { uuid: 'new-1', name: 'x', is_current: true }, next_repeating: serverTodo }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      )
+      const { todoApi } = await import('../../src/api/todoApi')
+      const result = await todoApi.replaceTodo('todo-rep', { new: { name: 'x' } })
+      expectWebSunday(result.next_repeating!)
+    })
+  })
 })


### PR DESCRIPTION
closes #191

**문제**: 매주 일요일 반복 할일 완료 시 다음 차수가 다음주 일요일이 아니라 월요일로 계산됨.

**원인**: `scheduleApi` 에만 있는 weekday codec(서버 1=일 ↔ web 0=일)이 `todoApi` 와 `foremostApi` 엔 누락. 서버의 일요일(1)이 web 에서 월요일(1)로 해석됨.

**수정**: 두 API 경계에 `repeatingFromServer`/`repeatingToServer` 적용.
- foremost 누락은 리뷰 중 발견 — 미수정 시 배너 클릭 팝오버가 요일을 한 칸 밀어 표기

테스트: todoApi/foremostApi 전 경로 변환 검증, 유닛 1182 + E2E 통과.