### PR TITLE
#192 fix(tag): iOS 8자리 태그 color_hex 로 멀티데이 일정 배경이 투명해지던 버그

### DIFF
--- a/e2e/specs/repro-192-multiday.spec.ts
+++ b/e2e/specs/repro-192-multiday.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test'
+import { setupAuthContext } from '../helpers/auth'
+
+// #192 재현: iOS 가 만든 태그 color_hex 는 8자리(#RRGGBBAA, alpha 포함)로 온다.
+// 멀티데이 allday 일정(7/31~8/14, KST)이 8자리 태그 색을 쓰면 EventBar 의 `${color}88` 가
+// 무효 hex 가 돼 배경이 투명해진다 — span 영역은 차지하나 색이 안 칠해지는 증상.
+const KST = 32400
+const ps = Math.floor(new Date('2026-07-31T00:00:00+09:00').getTime() / 1000)
+const pe = Math.floor(new Date('2026-08-14T23:59:59+09:00').getTime() / 1000)
+const INVEST_TAG = { uuid: 'tag-invest', name: '투자', color_hex: '#1976D2FF' } // 8자리(iOS)
+const MULTI_DAY = {
+  uuid: 'dummy-multiday-allday',
+  name: '멀티데이 테스트 일정',
+  event_tag_id: INVEST_TAG.uuid,
+  event_time: { time_type: 'allday', period_start: ps, period_end: pe, seconds_from_gmt: KST },
+  notification_options: [],
+  exclude_repeatings: [],
+}
+
+test.beforeEach(async ({ page, context }) => {
+  await page.clock.install({ time: new Date('2026-08-10T09:00:00+09:00') })
+  await setupAuthContext(context)
+  await page.route('**/v2/tags/all', r => r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([INVEST_TAG]) }))
+  await page.route('**/v2/tags/**', r => r.fulfill({ status: 200, contentType: 'application/json', body: '[]' }))
+  await page.route('**/v2/foremost**', r => r.fulfill({ status: 404, body: '{}' }))
+  await page.route('**/v2/holidays**', r => r.fulfill({ status: 200, contentType: 'application/json', body: '[]' }))
+  await page.route('**/v2/todos**', async r => {
+    if (r.request().method() === 'GET') await r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+    else await r.continue()
+  })
+  await page.route('**/v2/schedules**', async r => {
+    if (r.request().method() === 'GET') await r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([MULTI_DAY]) })
+    else await r.continue()
+  })
+})
+
+test('8자리 hex 태그 멀티데이 allday 가 연속 span + 채워진 배경으로 표시된다', async ({ page }) => {
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  const bars = page.locator('[data-testid="event-bar"]').filter({ hasText: '멀티데이 테스트' })
+  const count = await bars.count()
+  expect(count).toBeGreaterThan(0)
+
+  const cellWidth = (await page.locator('[data-testid="day-cell"]').first().boundingBox())!.width
+  let hasSpan = false
+  let allFilled = true
+  for (let i = 0; i < count; i++) {
+    const bar = bars.nth(i)
+    const box = await bar.boundingBox()
+    if (box && box.width > cellWidth * 1.5) hasSpan = true
+    const bg = await bar.evaluate(el => getComputedStyle(el).backgroundColor)
+    // 투명/미지정이면 'rgba(0, 0, 0, 0)' 또는 빈 값 → 버그
+    if (!bg || bg === 'rgba(0, 0, 0, 0)' || bg === 'transparent') allFilled = false
+  }
+
+  expect(hasSpan).toBe(true)      // 영역(span) 차지
+  expect(allFilled).toBe(true)    // 배경 채워짐 (투명 회귀 차단)
+})

--- a/src/calendar/MainCalendarGrid.tsx
+++ b/src/calendar/MainCalendarGrid.tsx
@@ -10,6 +10,7 @@ import { useHolidayCache } from '../repositories/caches/holidayCache'
 import { useTagFilterStore } from '../stores/tagFilterStore'
 import { useSettingsCache } from '../repositories/caches/settingsCache'
 import { useResolvedEventTag } from '../hooks/useResolvedEventTag'
+import { withAlpha } from '../utils/color'
 
 const ALL_WEEKDAY_KEYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const
 
@@ -65,7 +66,7 @@ function EventBar({ ev, timeType, showEventNames, fontSizeWeight, onEventClick }
         gridRow: 1,
         // #106: 옛 alpha 22(12%) → 44(27%) 도 다크/라이트 모두 너무 옅어 chip 영역이 식별 안 됨.
         // 88(53%) 로 키워 텍스트 가독성을 유지하면서 chip span 이 명확히 보이도록.
-        backgroundColor: isAtTime ? 'transparent' : `${color}88`,
+        backgroundColor: isAtTime ? 'transparent' : withAlpha(color, '88'),
         fontSize,
       }}
       onClick={(e) => {

--- a/src/components/CurrentTodoList.tsx
+++ b/src/components/CurrentTodoList.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { useResolvedEventTag } from '../hooks/useResolvedEventTag'
+import { withAlpha } from '../utils/color'
 import { tagDisplayName } from '../domain/functions/tagDisplay'
 import { useSettingsCache } from '../repositories/caches/settingsCache'
 import { useTodoCompleting } from '../hooks/useTodoCompleting'
@@ -56,7 +57,7 @@ function CurrentTodoRow({ todo, onEventClick, onComplete, isCompleting, isLast }
             {tagName && (
               <span
                 className="shrink-0 text-meta font-semibold px-1.5 py-0.5 rounded-full leading-none"
-                style={{ color, backgroundColor: `${color}22` }}
+                style={{ color, backgroundColor: withAlpha(color, '22') }}
               >
                 {tagName}
               </span>

--- a/src/components/DayEventList.tsx
+++ b/src/components/DayEventList.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { useResolvedEventTag } from '../hooks/useResolvedEventTag'
+import { withAlpha } from '../utils/color'
 import { tagDisplayName } from '../domain/functions/tagDisplay'
 import { TimeDescription } from './TimeDescription'
 import { formatDateKey } from '../domain/functions/eventTime'
@@ -56,7 +57,7 @@ function EventItem({ calEvent, onEventClick, onComplete, isLast }: {
             {tagName && (
               <span
                 className="shrink-0 text-meta font-semibold px-1.5 py-0.5 rounded-full leading-none"
-                style={{ color, backgroundColor: `${color}22` }}
+                style={{ color, backgroundColor: withAlpha(color, '22') }}
               >
                 {tagName}
               </span>

--- a/src/components/EventDetail/EventDetailPopover.tsx
+++ b/src/components/EventDetail/EventDetailPopover.tsx
@@ -5,6 +5,7 @@ import { Pencil, Trash2, X, Clock, Repeat, Bell, MapPin, FileText, Link2 } from 
 import type { CalendarEvent } from '../../domain/functions/eventTime'
 import { displayPlace } from '../../models/EventDetail'
 import { useResolvedEventTag } from '../../hooks/useResolvedEventTag'
+import { withAlpha } from '../../utils/color'
 import { tagDisplayName } from '../../domain/functions/tagDisplay'
 import { EventTimeDisplay } from '../EventTimeDisplay'
 import { useEventDetailPopoverViewModel } from './useEventDetailPopoverViewModel'
@@ -104,7 +105,7 @@ export function EventDetailPopover({
           <div data-testid="popover-tag-name">
             <span
               className="inline-block text-meta font-semibold px-1.5 py-0.5 rounded-full leading-none"
-              style={{ color: tagColor, backgroundColor: `${tagColor}22` }}
+              style={{ color: tagColor, backgroundColor: withAlpha(tagColor, '22') }}
             >
               {tagName}
             </span>

--- a/src/components/ForemostEventBanner.tsx
+++ b/src/components/ForemostEventBanner.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { useResolvedEventTag } from '../hooks/useResolvedEventTag'
+import { withAlpha } from '../utils/color'
 import { useSettingsCache } from '../repositories/caches/settingsCache'
 import { tagDisplayName } from '../domain/functions/tagDisplay'
 import { TimeDescription } from './TimeDescription'
@@ -56,7 +57,7 @@ export function ForemostEventBanner({ foremostEvent, onEventClick }: ForemostEve
             {tagName && (
               <span
                 className="shrink-0 text-meta font-semibold px-1.5 py-0.5 rounded-full leading-none"
-                style={{ color: resolved.color, backgroundColor: `${resolved.color}22` }}
+                style={{ color: resolved.color, backgroundColor: withAlpha(resolved.color, '22') }}
               >
                 {tagName}
               </span>

--- a/src/components/UncompletedTodoList.tsx
+++ b/src/components/UncompletedTodoList.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useResolvedEventTag } from '../hooks/useResolvedEventTag'
+import { withAlpha } from '../utils/color'
 import { tagDisplayName } from '../domain/functions/tagDisplay'
 import { useSettingsCache } from '../repositories/caches/settingsCache'
 import { useTodoCompleting } from '../hooks/useTodoCompleting'
@@ -57,7 +58,7 @@ function UncompletedTodoRow({ todo, onEventClick, onComplete, isCompleting, isLa
             {tagName && (
               <span
                 className="shrink-0 text-meta font-semibold px-1.5 py-0.5 rounded-full leading-none"
-                style={{ color, backgroundColor: `${color}22` }}
+                style={{ color, backgroundColor: withAlpha(color, '22') }}
               >
                 {tagName}
               </span>

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,9 @@
+// 태그 색에 2자리 hex alpha 를 덧붙인다.
+// base 가 6자리(#RRGGBB)면 그대로 덧붙이고, iOS 가 만든 태그처럼 8자리(#RRGGBBAA, alpha 포함)면
+// 기존 alpha 를 떼고 6자리에 덧붙여 유효한 hex 를 만든다. 그냥 문자열로 이으면 8자리는
+// #RRGGBBAA88(10자리) 가 돼 무효 CSS → 배경이 통째로 투명해진다 (#192).
+// 6/8자리 hex 가 아니면(named/rgb 등) 원본을 그대로 반환한다 (덧붙이면 깨지므로).
+export function withAlpha(color: string, alphaHex: string): string {
+  const m = /^#([0-9a-fA-F]{6})(?:[0-9a-fA-F]{2})?$/.exec(color)
+  return m ? `#${m[1]}${alphaHex}` : color
+}

--- a/tests/calendar/eventBarTagColor.test.tsx
+++ b/tests/calendar/eventBarTagColor.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import MainCalendarGrid from '../../src/calendar/MainCalendarGrid'
+import { buildCalendarGrid } from '../../src/calendar/calendarUtils'
+import { useCalendarEventsCache } from '../../src/repositories/caches/calendarEventsCache'
+import { useHolidayCache } from '../../src/repositories/caches/holidayCache'
+import { useEventTagListCache } from '../../src/repositories/caches/eventTagListCache'
+import { groupEventsByDate, monthRange } from '../../src/domain/functions/eventTime'
+import type { Schedule } from '../../src/models/Schedule'
+
+vi.mock('../../src/firebase', () => ({ getAuthInstance: vi.fn(() => ({})) }))
+
+const augDays = buildCalendarGrid(2026, 7, new Date(2026, 7, 1), 0)
+
+// #192: iOS 가 만든 태그 color_hex 는 8자리(#RRGGBBAA). EventBar 가 `${color}88` 로 alpha 를
+// 덧붙일 때 base 가 6자리로 정규화돼 있지 않으면 무효 hex 가 되어 배경이 통째로 투명해진다
+// (멀티데이 일정이 span 영역은 차지하나 색이 안 칠해지는 증상).
+describe('#192 EventBar 태그 색상 — 8자리 hex 도 배경이 채워진다', () => {
+  beforeEach(() => {
+    useHolidayCache.setState({ holidays: new Map(), loadedYears: new Set() })
+  })
+
+  function renderMultiDayWithTagColor(colorHex: string): HTMLElement {
+    useEventTagListCache.setState({
+      tags: new Map([['t-invest', { uuid: 't-invest', name: '투자', color_hex: colorHex }]]),
+    } as never)
+    const ps = Math.floor(new Date('2026-07-31T00:00:00+09:00').getTime() / 1000)
+    const pe = Math.floor(new Date('2026-08-14T23:59:59+09:00').getTime() / 1000)
+    const sch = {
+      uuid: 'sp',
+      name: '멀티데이',
+      event_tag_id: 't-invest',
+      event_time: { time_type: 'allday', period_start: ps, period_end: pe, seconds_from_gmt: 32400 },
+    } as Schedule
+    const range = monthRange(2026, 7)
+    useCalendarEventsCache.setState({ eventsByDate: groupEventsByDate([], [sch], range.lower, range.upper), loading: false })
+    render(<MainCalendarGrid days={augDays} />)
+    return screen.getAllByTestId('event-bar')[0] as HTMLElement
+  }
+
+  it('6자리 hex 태그 → 배경 채워짐', () => {
+    const bar = renderMultiDayWithTagColor('#1976D2')
+    expect(bar.style.backgroundColor).not.toBe('')
+  })
+
+  it('8자리 hex(iOS) 태그 → 배경 채워짐 (투명 회귀 차단)', () => {
+    const bar = renderMultiDayWithTagColor('#1976D2FF')
+    expect(bar.style.backgroundColor).not.toBe('')
+  })
+})

--- a/tests/utils/color.test.ts
+++ b/tests/utils/color.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { withAlpha } from '../../src/utils/color'
+
+describe('withAlpha', () => {
+  it('6자리 hex 에 alpha 를 덧붙인다', () => {
+    expect(withAlpha('#1976D2', '88')).toBe('#1976D288')
+  })
+
+  // #192: iOS 태그는 8자리(#RRGGBBAA). 그냥 이으면 10자리 무효 hex → 배경 투명.
+  it('8자리 hex 는 기존 alpha 를 떼고 6자리에 덧붙인다', () => {
+    expect(withAlpha('#1976D2FF', '88')).toBe('#1976D288')
+    expect(withAlpha('#1976D2FF', '22')).toBe('#1976D222')
+  })
+
+  it('hex 가 아니면 원본을 그대로 반환한다', () => {
+    expect(withAlpha('rgb(25,118,210)', '88')).toBe('rgb(25,118,210)')
+    expect(withAlpha('rebeccapurple', '88')).toBe('rebeccapurple')
+  })
+})


### PR DESCRIPTION
closes #192

**문제**: 하루 이상 걸친 일정이 캘린더에서 영역(span)은 차지하나 배경색이 안 칠해짐.

**원인**: iOS 가 만든 태그 `color_hex` 는 8자리(`#RRGGBBAA`). `` `${color}88` `` 로 alpha 를 이으면 10자리 무효 hex → 배경 투명 (점은 `color` 그대로라 칠해짐).

**수정**: `withAlpha(color, alpha)` 헬퍼 추가 — 8자리면 alpha 떼고 6자리에 덧붙임. alpha 를 덧붙이던 6곳(EventBar·DayEventList·ForemostBanner·Current/UncompletedTodoList·EventDetailPopover)에 적용. 공통 색 출처(useResolvedEventTag)는 안 건드려 다른 소비처 무영향.

테스트: withAlpha 단위 + EventBar 8자리 배경 채움(유닛/e2e), 유닛 1176 + E2E 144 통과.