### PR TITLE
#195 fix: 메인 캘린더가 다른 디바이스의 할일 완료를 반영하도록 fetchUncompletedTodos reconcile

### DIFF
--- a/src/repositories/EventRepository.ts
+++ b/src/repositories/EventRepository.ts
@@ -195,6 +195,9 @@ export class EventRepository {
     const refTime = Math.floor(Date.now() / 1000)
     const local = this.deps.localStorageContainer
 
+    // reconcile 기준점: remote 동기화 직전 미완료 스냅샷
+    const prevUncompleted = useUncompletedTodosCache.getState().todos
+
     // 1. Cache-first
     if (local?.isInitialized()) {
       try {
@@ -219,6 +222,20 @@ export class EventRepository {
       }
     }
     useUncompletedTodosCache.getState().replaceAll(todos)
+
+    // 3. 캘린더 캐시 reconcile — 우측 미완료 목록만 갱신하면 좌측 월간 캘린더가
+    // 다른 디바이스의 완료/전진을 반영 못 하므로(#195) 서버 응답을 캘린더에도 동기화한다.
+    const nextIds = new Set(todos.map(t => t.uuid))
+    // 미완료 목록에서 빠진 = 다른 곳에서 완료/삭제됨 → 캘린더에서도 제거
+    prevUncompleted
+      .filter(t => !nextIds.has(t.uuid))
+      .forEach(t => useCalendarEventsCache.getState().removeEvent(t.uuid))
+    // 남아있는 todo는 event_time 이 전진됐을 수 있으므로 교체
+    todos.forEach(t => {
+      if (t.event_time) {
+        useCalendarEventsCache.getState().replaceEvent(t.uuid, { type: 'todo', event: t })
+      }
+    })
   }
 
   // ── observe: snapshot ────────────────────────────────────────────

--- a/tests/repositories/EventRepository.test.ts
+++ b/tests/repositories/EventRepository.test.ts
@@ -402,6 +402,50 @@ describe('EventRepository — fetchUncompletedTodos', () => {
     expect(snapshot.some(t => t.uuid === 'unc-1')).toBe(true)
     expect(snapshot.some(t => t.uuid === 'unc-2')).toBe(true)
   })
+
+  it('다른 디바이스에서 완료되어 미완료 목록에서 빠진 todo는 캘린더 캐시에서도 제거된다', async () => {
+    // given: 미완료 todo A·B 가 우측 캐시와 캘린더 캐시 양쪽에 존재
+    const todoA = makeTodo({ uuid: 'unc-A', event_time: { time_type: 'at', timestamp: MAR_01_TS } })
+    const todoB = makeTodo({ uuid: 'unc-B', event_time: { time_type: 'at', timestamp: MAR_15_TS } })
+    useUncompletedTodosCache.setState({ todos: [todoA, todoB] })
+    useCalendarEventsCache.getState().addEvent({ type: 'todo', event: todoA })
+    useCalendarEventsCache.getState().addEvent({ type: 'todo', event: todoB })
+    // 서버는 B 가 완료되어 A 만 미완료로 반환
+    const repo = new EventRepository({
+      todoApi: makeFakeTodoApi({ getUncompletedTodos: async () => [todoA] }),
+      scheduleApi: makeFakeScheduleApi(),
+    })
+
+    // when
+    await repo.fetchUncompletedTodos()
+
+    // then: 캘린더 캐시에서도 B 가 사라지고 A 는 남는다
+    const calSnapshot = repo.getMonthEventsSnapshot(2025, 2)
+    expect(calSnapshot.some(e => e.event.uuid === 'unc-B')).toBe(false)
+    expect(calSnapshot.some(e => e.event.uuid === 'unc-A')).toBe(true)
+  })
+
+  it('미완료 목록에 남아있되 event_time 이 전진된 todo는 캘린더 캐시도 갱신된다', async () => {
+    // given: 캘린더·우측 캐시에 MAR_01 의 todo. 서버는 같은 uuid 를 MAR_15 로 전진해 반환
+    const before = makeTodo({ uuid: 'unc-rep', event_time: { time_type: 'at', timestamp: MAR_01_TS } })
+    const advanced = makeTodo({ uuid: 'unc-rep', event_time: { time_type: 'at', timestamp: MAR_15_TS } })
+    useUncompletedTodosCache.setState({ todos: [before] })
+    useCalendarEventsCache.getState().addEvent({ type: 'todo', event: before })
+    const repo = new EventRepository({
+      todoApi: makeFakeTodoApi({ getUncompletedTodos: async () => [advanced] }),
+      scheduleApi: makeFakeScheduleApi(),
+    })
+
+    // when
+    await repo.fetchUncompletedTodos()
+
+    // then: 캘린더 캐시의 해당 uuid event_time 이 MAR_15 로 갱신된다
+    const calSnapshot = repo.getMonthEventsSnapshot(2025, 2)
+    const found = calSnapshot.filter(e => e.event.uuid === 'unc-rep')
+    expect(found.length).toBeGreaterThan(0)
+    expect(found.every(e => e.event.event_time?.time_type === 'at'
+      && (e.event.event_time as any).timestamp === MAR_15_TS)).toBe(true)
+  })
 })
 
 describe('EventRepository — completeTodo', () => {


### PR DESCRIPTION
closes #195

## 문제
다른 디바이스에서 할일을 완료하면, 이 디바이스에서 우측 "미완료 할일" 섹션을 새로고침했을 때 우측 목록에선 사라지지만 좌측 월간 캘린더 셀엔 그 할일이 그대로 남았다.

## 원인
우측 미완료 목록과 좌측 캘린더는 서로 다른 캐시(`uncompletedTodosCache` / `calendarEventsCache`)를 본다. `EventRepository.fetchUncompletedTodos` 가 서버 응답을 `uncompletedTodosCache` 에만 반영하고 `calendarEventsCache` 는 건드리지 않아, 캘린더가 stale 상태로 남았다. (로컬 완료 경로인 `completeTodo` 는 양쪽 캐시를 모두 갱신하므로 정상)

## 수정
`fetchUncompletedTodos` 가 서버 응답을 캘린더 캐시에도 reconcile:
- remote 동기화 직전 미완료 스냅샷을 기준점으로 캡처
- 목록에서 빠진 todo(완료/삭제) → `removeEvent`
- 남은 todo(event_time 전진 가능) → `replaceEvent`

## 테스트
- 유닛: `fetchUncompletedTodos` reconcile 케이스 2개 추가 (사라진 todo 제거 / event_time 전진 갱신). 전체 1189 passed
- E2E: 144 passed